### PR TITLE
Remove hard-coded `Network`s

### DIFF
--- a/cfd_protocol/src/lib.rs
+++ b/cfd_protocol/src/lib.rs
@@ -880,16 +880,14 @@ mod tests {
     use super::*;
 
     use bdk::bitcoin::Network;
-    use std::str::FromStr;
 
     // TODO add proptest for this
 
     #[test]
     fn test_fee_subtraction_bigger_than_dust() {
-        let key = PublicKey::from_str(
-            "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af",
-        )
-        .unwrap();
+        let key = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af"
+            .parse()
+            .unwrap();
         let dummy_address = Address::p2wpkh(&key, Network::Regtest).unwrap();
         let dummy_dust_limit = dummy_address.script_pubkey().dust_value();
 
@@ -917,12 +915,12 @@ mod tests {
 
     #[test]
     fn test_fee_subtraction_smaller_than_dust() {
-        let key = PublicKey::from_str(
-            "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af",
-        )
-        .unwrap();
+        let key = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af"
+            .parse()
+            .unwrap();
         let dummy_address = Address::p2wpkh(&key, Network::Regtest).unwrap();
         let dummy_dust_limit = dummy_address.script_pubkey().dust_value();
+
         let orig_maker_amount = dummy_dust_limit.as_sat() - 1;
         let orig_taker_amount = 1000;
         let payout = Payout::new(

--- a/cfd_protocol/src/lib.rs
+++ b/cfd_protocol/src/lib.rs
@@ -4,7 +4,7 @@ use bdk::bitcoin::hashes::*;
 use bdk::bitcoin::util::bip143::SigHashCache;
 use bdk::bitcoin::util::psbt::{Global, PartiallySignedTransaction};
 use bdk::bitcoin::{
-    Address, Amount, Network, OutPoint, PublicKey, SigHash, SigHashType, Transaction, TxIn, TxOut,
+    Address, Amount, OutPoint, PublicKey, SigHash, SigHashType, Transaction, TxIn, TxOut,
 };
 use bdk::database::BatchDatabase;
 use bdk::descriptor::Descriptor;
@@ -692,10 +692,7 @@ impl CommitTransaction {
 
         let output = TxOut {
             value: lock_tx_amount,
-            script_pubkey: descriptor
-                .address(Network::Regtest)
-                .expect("can derive address from descriptor")
-                .script_pubkey(),
+            script_pubkey: descriptor.script_pubkey(),
         };
 
         let mut inner = Transaction {
@@ -802,10 +799,7 @@ impl LockTransaction {
 
         let lock_output = TxOut {
             value: amount.as_sat(),
-            script_pubkey: lock_descriptor
-                .address(Network::Regtest)
-                .expect("can derive address from descriptor")
-                .script_pubkey(),
+            script_pubkey: lock_descriptor.script_pubkey(),
         };
 
         let lock_tx = Transaction {
@@ -884,6 +878,8 @@ impl SigHashExt for SigHash {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use bdk::bitcoin::Network;
     use std::str::FromStr;
 
     // TODO add proptest for this


### PR DESCRIPTION
And other stuff related to PR #16.

It looks like the protocol doesn't need to know about what network it runs on? Is that weird?