### PR TITLE
Margin calculation & refactoring

### DIFF
--- a/daemon/migrations/20210903050345_create_cfd_and_offer_tables.sql
+++ b/daemon/migrations/20210903050345_create_cfd_and_offer_tables.sql
@@ -11,7 +11,8 @@ create table if not exists offers
     leverage           integer     not null,
     liquidation_price  text        not null,
     creation_timestamp text        not null,
-    term               text        not null
+    term               text        not null,
+    origin             text        not null
 );
 
 create unique index if not exists offers_uuid
@@ -32,8 +33,8 @@ create unique index if not exists cfd_offer_uuid
 
 create table if not exists cfd_states
 (
-    id                   integer primary key autoincrement,
-    cfd_id               integer not null,
-    state                text    not null,
+    id     integer primary key autoincrement,
+    cfd_id integer not null,
+    state  text    not null,
     foreign key (cfd_id) references cfds (id)
 );

--- a/daemon/sqlx-data.json
+++ b/daemon/sqlx-data.json
@@ -18,18 +18,8 @@
       ]
     }
   },
-  "29bc1b2bd17146eb36e2c61acc1bed3c9b5b3014e35874c752cbd50016e99b74": {
-    "query": "\n            insert into offers (\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp,\n                term\n            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 10
-      },
-      "nullable": []
-    }
-  },
-  "4896e2d2e2c6cc03f9ae2b7de85279f295fb7e70e083e0a1a3faf3e7551650f3": {
-    "query": "\n        select\n            cfds.id as cfd_id,\n            offers.uuid as offer_id,\n            offers.initial_price as initial_price,\n            offers.leverage as leverage,\n            offers.trading_pair as trading_pair,\n            offers.position as position,\n            offers.liquidation_price as liquidation_price,\n            cfds.quantity_usd as quantity_usd,\n            cfd_states.state as state\n        from cfds as cfds\n        inner join offers as offers on cfds.offer_id = offers.id\n        inner join cfd_states as cfd_states on cfd_states.cfd_id = cfds.id\n        where cfd_states.state in (\n            select\n              state\n              from cfd_states\n            where cfd_id = cfds.id\n            order by id desc\n            limit 1\n        )\n        ",
+  "2bfe23378b852e9c98f1db3e7c7694e1a7037183eb6fa8d81916cdb46c760547": {
+    "query": "\n        select\n            cfds.id as cfd_id,\n            offers.uuid as offer_id,\n            offers.initial_price as initial_price,\n            offers.leverage as leverage,\n            offers.trading_pair as trading_pair,\n            offers.position as position,\n            offers.origin as origin,\n            offers.liquidation_price as liquidation_price,\n            cfds.quantity_usd as quantity_usd,\n            cfd_states.state as state\n        from cfds as cfds\n        inner join offers as offers on cfds.offer_id = offers.id\n        inner join cfd_states as cfd_states on cfd_states.cfd_id = cfds.id\n        where cfd_states.state in (\n            select\n              state\n              from cfd_states\n            where cfd_id = cfds.id\n            order by id desc\n            limit 1\n        )\n        ",
     "describe": {
       "columns": [
         {
@@ -63,18 +53,23 @@
           "type_info": "Text"
         },
         {
-          "name": "liquidation_price",
+          "name": "origin",
           "ordinal": 6,
           "type_info": "Text"
         },
         {
-          "name": "quantity_usd",
+          "name": "liquidation_price",
           "ordinal": 7,
           "type_info": "Text"
         },
         {
-          "name": "state",
+          "name": "quantity_usd",
           "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "state",
+          "ordinal": 9,
           "type_info": "Text"
         }
       ],
@@ -90,8 +85,19 @@
         false,
         false,
         false,
+        false,
         false
       ]
+    }
+  },
+  "4a8db91aaef56a804d0151460297175355c9adee100b87fa9052245cdd18d7e9": {
+    "query": "\n            insert into offers (\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp,\n                term,\n                origin\n            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 11
+      },
+      "nullable": []
     }
   },
   "50abbb297394739ec9d85917f8c32aa8bcfa0bfe140b24e9eeda4ce8d30d4f8d": {
@@ -190,6 +196,11 @@
           "name": "term",
           "ordinal": 10,
           "type_info": "Text"
+        },
+        {
+          "name": "origin",
+          "ordinal": 11,
+          "type_info": "Text"
         }
       ],
       "parameters": {
@@ -197,6 +208,7 @@
       },
       "nullable": [
         true,
+        false,
         false,
         false,
         false,

--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -1,5 +1,7 @@
 use std::fmt::{Display, Formatter};
 
+use anyhow::{Context, Result};
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +14,33 @@ pub struct Usd(pub Decimal);
 
 impl Usd {
     pub const ZERO: Self = Self(Decimal::ZERO);
+
+    pub fn checked_add(&self, other: Usd) -> Result<Usd> {
+        let result = self.0.checked_add(other.0).context("addition error")?;
+        Ok(Usd(result))
+    }
+
+    pub fn checked_sub(&self, other: Usd) -> Result<Usd> {
+        let result = self.0.checked_sub(other.0).context("subtraction error")?;
+        Ok(Usd(result))
+    }
+
+    pub fn checked_mul(&self, other: Usd) -> Result<Usd> {
+        let result = self
+            .0
+            .checked_mul(other.0)
+            .context("multiplication error")?;
+        Ok(Usd(result))
+    }
+
+    pub fn checked_div(&self, other: Usd) -> Result<Usd> {
+        let result = self.0.checked_div(other.0).context("division error")?;
+        Ok(Usd(result))
+    }
+
+    pub fn try_into_u64(&self) -> Result<u64> {
+        self.0.to_u64().context("could not fit decimal into u64")
+    }
 }
 
 impl Display for Usd {
@@ -20,7 +49,13 @@ impl Display for Usd {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+impl From<Decimal> for Usd {
+    fn from(decimal: Decimal) -> Self {
+        Usd(decimal)
+    }
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Leverage(pub u8);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -32,6 +67,16 @@ pub enum TradingPair {
 pub enum Position {
     Buy,
     Sell,
+}
+
+impl Position {
+    #[allow(dead_code)]
+    pub fn counter_position(&self) -> Self {
+        match self {
+            Position::Buy => Position::Sell,
+            Position::Sell => Position::Buy,
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -1,5 +1,6 @@
 use crate::maker_cfd_actor;
-use crate::model::cfd::{Cfd, CfdNewOfferRequest, CfdOffer};
+use crate::model::cfd::{Cfd, CfdOffer};
+use crate::model::Usd;
 use crate::to_sse_event::ToSseEvent;
 use anyhow::Result;
 use bdk::bitcoin::Amount;
@@ -7,6 +8,7 @@ use rocket::response::status;
 use rocket::response::stream::EventStream;
 use rocket::serde::json::Json;
 use rocket::State;
+use serde::Deserialize;
 use tokio::select;
 use tokio::sync::{mpsc, watch};
 
@@ -47,6 +49,17 @@ pub async fn maker_feed(
             }
         }
     }
+}
+
+/// The maker POSTs this to create a new CfdOffer
+// TODO: Use Rocket form?
+#[derive(Debug, Clone, Deserialize)]
+pub struct CfdNewOfferRequest {
+    pub price: Usd,
+    // TODO: [post-MVP] Representation of the contract size; at the moment the contract size is
+    // always 1 USD
+    pub min_quantity: Usd,
+    pub max_quantity: Usd,
 }
 
 #[rocket::post("/offer/sell", data = "<offer>")]

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -112,7 +112,8 @@ async fn main() -> Result<()> {
             rocket::routes![
                 routes_taker::feed,
                 routes_taker::post_cfd,
-                routes_taker::get_health_check
+                routes_taker::get_health_check,
+                routes_taker::margin_calc,
             ],
         )
         .launch()

--- a/daemon/src/to_sse_event.rs
+++ b/daemon/src/to_sse_event.rs
@@ -1,20 +1,116 @@
-use crate::model::cfd::{Cfd, CfdOffer};
+use crate::model;
+use crate::model::cfd::CfdOfferId;
+use crate::model::{Leverage, Position, TradingPair, Usd};
 use bdk::bitcoin::Amount;
 use rocket::response::stream::Event;
+use serde::Serialize;
+use std::time::UNIX_EPOCH;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Cfd {
+    pub offer_id: CfdOfferId,
+    pub initial_price: Usd,
+
+    pub leverage: Leverage,
+    pub trading_pair: TradingPair,
+    pub position: Position,
+    pub liquidation_price: Usd,
+
+    pub quantity_usd: Usd,
+
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
+    pub margin: Amount,
+
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
+    pub profit_btc: Amount,
+    pub profit_usd: Usd,
+
+    pub state: String,
+    pub state_transition_unix_timestamp: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CfdOffer {
+    pub id: CfdOfferId,
+
+    pub trading_pair: TradingPair,
+    pub position: Position,
+
+    pub price: Usd,
+
+    pub min_quantity: Usd,
+    pub max_quantity: Usd,
+
+    pub leverage: Leverage,
+    pub liquidation_price: Usd,
+
+    pub creation_unix_timestamp: u64,
+    pub term_in_secs: u64,
+}
 
 pub trait ToSseEvent {
     fn to_sse_event(&self) -> Event;
 }
 
-impl ToSseEvent for Vec<Cfd> {
+impl ToSseEvent for Vec<model::cfd::Cfd> {
+    // TODO: This conversion can fail, we might want to change the API
     fn to_sse_event(&self) -> Event {
-        Event::json(self).event("cfds")
+        let cfds = self
+            .iter()
+            .map(|cfd| {
+                // TODO: Get the actual current price here
+                let current_price = Usd::ZERO;
+                let (profit_btc, profit_usd) = cfd.calc_profit(current_price).unwrap();
+
+                Cfd {
+                    offer_id: cfd.offer_id,
+                    initial_price: cfd.initial_price,
+                    leverage: cfd.leverage,
+                    trading_pair: cfd.trading_pair.clone(),
+                    position: cfd.position.clone(),
+                    liquidation_price: cfd.liquidation_price,
+                    quantity_usd: cfd.quantity_usd,
+                    profit_btc,
+                    profit_usd,
+                    state: cfd.state.to_string(),
+                    state_transition_unix_timestamp: cfd
+                        .state
+                        .get_transition_timestamp()
+                        .duration_since(UNIX_EPOCH)
+                        .expect("timestamp to be convertable to duration since epoch")
+                        .as_secs(),
+
+                    // TODO: Depending on the state the margin might be set (i.e. in Open we save it
+                    // in the DB internally) and does not have to be calculated
+                    margin: cfd.calc_margin().unwrap(),
+                }
+            })
+            .collect::<Vec<Cfd>>();
+
+        Event::json(&cfds).event("cfds")
     }
 }
 
-impl ToSseEvent for Option<CfdOffer> {
+impl ToSseEvent for Option<model::cfd::CfdOffer> {
     fn to_sse_event(&self) -> Event {
-        Event::json(self).event("offer")
+        let offer = self.clone().map(|offer| CfdOffer {
+            id: offer.id,
+            trading_pair: offer.trading_pair,
+            position: offer.position,
+            price: offer.price,
+            min_quantity: offer.min_quantity,
+            max_quantity: offer.max_quantity,
+            leverage: offer.leverage,
+            liquidation_price: offer.liquidation_price,
+            creation_unix_timestamp: offer
+                .creation_timestamp
+                .duration_since(UNIX_EPOCH)
+                .expect("timestamp to be convertiblae to dureation since epoch")
+                .as_secs(),
+            term_in_secs: offer.term.as_secs(),
+        });
+
+        Event::json(&offer).event("offer")
     }
 }
 

--- a/frontend/src/components/CfdTile.tsx
+++ b/frontend/src/components/CfdTile.tsx
@@ -24,8 +24,14 @@ export default function CfdTile(
                     <Text>{cfd.trading_pair}</Text>
                     <Text>Position</Text>
                     <Text>{cfd.position}</Text>
-                    <Text>Amount</Text>
+                    <Text>CFD Price</Text>
+                    <Text>{cfd.initial_price}</Text>
+                    <Text>Leverage</Text>
+                    <Text>{cfd.leverage}</Text>
+                    <Text>Quantity</Text>
                     <Text>{cfd.quantity_usd}</Text>
+                    <Text>Margin</Text>
+                    <Text>{cfd.margin}</Text>
                     <Text>Liquidation Price</Text>
                     <Text
                         overflow="hidden"
@@ -40,12 +46,12 @@ export default function CfdTile(
                     <Text>Open since</Text>
                     {/* TODO: Format date in a more compact way */}
                     <Text>
-                        {(new Date(cfd.state.payload.common.transition_timestamp.secs_since_epoch * 1000).toString())}
+                        {(new Date(cfd.state_transition_unix_timestamp * 1000).toString())}
                     </Text>
                     <Text>Status</Text>
-                    <Text>{cfd.state.type}</Text>
+                    <Text>{cfd.state}</Text>
                 </SimpleGrid>
-                {cfd.state.type === "Open"
+                {cfd.state === "Open"
                     && <Box paddingBottom={5}><Button colorScheme="blue" variant="solid">Close</Button></Box>}
             </VStack>
         </Box>

--- a/frontend/src/components/Types.tsx
+++ b/frontend/src/components/Types.tsx
@@ -1,13 +1,3 @@
-export interface RustDuration {
-    secs: number;
-    nanos: number;
-}
-
-export interface RustTimestamp {
-    secs_since_epoch: number;
-    nanos_since_epoch: number;
-}
-
 export interface Offer {
     id: string;
     trading_pair: string;
@@ -17,22 +7,8 @@ export interface Offer {
     max_quantity: number;
     leverage: number;
     liquidation_price: number;
-    creation_timestamp: RustTimestamp;
-    term: RustDuration;
-}
-
-export interface CfdStateCommon {
-    transition_timestamp: RustTimestamp;
-}
-
-export interface CfdStatePayload {
-    common: CfdStateCommon;
-    settlement_timestamp?: RustTimestamp; // only in state Open
-}
-
-export interface CfdState {
-    type: string;
-    payload: CfdStatePayload;
+    creation_unix_timestamp: number;
+    term_in_secs: number;
 }
 
 export interface Cfd {
@@ -45,8 +21,12 @@ export interface Cfd {
     liquidation_price: number;
 
     quantity_usd: number;
+
+    margin: number;
+
     profit_btc: number;
     profit_usd: number;
 
-    state: CfdState;
+    state: string;
+    state_transition_unix_timestamp: number;
 }


### PR DESCRIPTION
Sry, should have cut more contained commits, will see to do that next time 😬

The buy margin is calculated from `initial_price`, `quantity` and `leverage`.
The sell margin is calculated from `initial_price` and `quantity` (no leverage trading for the seller at the moment).

Includes several refactors:
- Separate API interface for `Cfd` and `CfdOffer` when mapping `toSseEvent`. This allows internal modelling to be different than the exposed API.
  - Remove the profit calculation internally, it is only relevant on the UI feed API level.
  - Move code that is specific to taker/maker http API from `model` to the respective `routes` module.
- Some simplification of the calculation model of `Usd` (could be further improved by deriving calculation traits)