### PR TITLE
Refactor Cfd to be based on Order

### DIFF
--- a/daemon/sqlx-data.json
+++ b/daemon/sqlx-data.json
@@ -28,8 +28,8 @@
       ]
     }
   },
-  "7941da81b43abcaa82d51bbfecaed51f13fc637dc611cebb87eea638ba055a42": {
-    "query": "\n        select\n            cfds.id as cfd_id,\n            orders.uuid as order_id,\n            orders.initial_price as initial_price,\n            orders.leverage as leverage,\n            orders.trading_pair as trading_pair,\n            orders.position as position,\n            orders.origin as origin,\n            orders.liquidation_price as liquidation_price,\n            cfds.quantity_usd as quantity_usd,\n            cfd_states.state as state\n        from cfds as cfds\n        inner join orders as orders on cfds.order_id = orders.id\n        inner join cfd_states as cfd_states on cfd_states.cfd_id = cfds.id\n        where cfd_states.state in (\n            select\n              state\n              from cfd_states\n            where cfd_id = cfds.id\n            order by id desc\n            limit 1\n        )\n        ",
+  "57c0eb6669321997352d87372431788aa039dd1898ca0b11ba4600f743ff4d93": {
+    "query": "\n        select\n            cfds.id as cfd_id,\n            orders.uuid as order_id,\n            orders.initial_price as price,\n            orders.min_quantity as min_quantity,\n            orders.max_quantity as max_quantity,\n            orders.leverage as leverage,\n            orders.trading_pair as trading_pair,\n            orders.position as position,\n            orders.origin as origin,\n            orders.liquidation_price as liquidation_price,\n            orders.creation_timestamp as creation_timestamp,\n            orders.term as term,\n            cfds.quantity_usd as quantity_usd,\n            cfd_states.state as state\n        from cfds as cfds\n        inner join orders as orders on cfds.order_id = orders.id\n        inner join cfd_states as cfd_states on cfd_states.cfd_id = cfds.id\n        where cfd_states.state in (\n            select\n              state\n              from cfd_states\n            where cfd_id = cfds.id\n            order by id desc\n            limit 1\n        )\n        ",
     "describe": {
       "columns": [
         {
@@ -43,43 +43,63 @@
           "type_info": "Text"
         },
         {
-          "name": "initial_price",
+          "name": "price",
           "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "name": "leverage",
+          "name": "min_quantity",
           "ordinal": 3,
-          "type_info": "Int64"
+          "type_info": "Text"
         },
         {
-          "name": "trading_pair",
+          "name": "max_quantity",
           "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "name": "position",
+          "name": "leverage",
           "ordinal": 5,
-          "type_info": "Text"
+          "type_info": "Int64"
         },
         {
-          "name": "origin",
+          "name": "trading_pair",
           "ordinal": 6,
           "type_info": "Text"
         },
         {
-          "name": "liquidation_price",
+          "name": "position",
           "ordinal": 7,
           "type_info": "Text"
         },
         {
-          "name": "quantity_usd",
+          "name": "origin",
           "ordinal": 8,
           "type_info": "Text"
         },
         {
-          "name": "state",
+          "name": "liquidation_price",
           "ordinal": 9,
+          "type_info": "Text"
+        },
+        {
+          "name": "creation_timestamp",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "term",
+          "ordinal": 11,
+          "type_info": "Text"
+        },
+        {
+          "name": "quantity_usd",
+          "ordinal": 12,
+          "type_info": "Text"
+        },
+        {
+          "name": "state",
+          "ordinal": 13,
           "type_info": "Text"
         }
       ],
@@ -87,6 +107,10 @@
         "Right": 0
       },
       "nullable": [
+        false,
+        false,
+        false,
+        false,
         false,
         false,
         false,

--- a/daemon/src/maker_cfd_actor.rs
+++ b/daemon/src/maker_cfd_actor.rs
@@ -1,6 +1,6 @@
 use std::time::SystemTime;
 
-use crate::db::{insert_cfd, insert_order, load_all_cfds, load_order_by_id, Origin};
+use crate::db::{insert_cfd, insert_order, load_all_cfds, load_order_by_id};
 use crate::model::cfd::{Cfd, CfdState, CfdStateCommon, FinalizedCfd, Order, OrderId};
 use crate::model::{TakerId, Usd};
 use crate::wire::SetupMsg;
@@ -101,7 +101,6 @@ where
                                     transition_timestamp: SystemTime::now(),
                                 },
                             },
-                            current_order.position,
                         );
                         insert_cfd(cfd, &mut conn).await.unwrap();
 
@@ -125,7 +124,7 @@ where
                     maker_cfd_actor::Command::NewOrder(order) => {
                         // 1. Save to DB
                         let mut conn = db.acquire().await.unwrap();
-                        insert_order(&order, &mut conn, Origin::Ours).await.unwrap();
+                        insert_order(&order, &mut conn).await.unwrap();
 
                         // 2. Update actor state to current order
                         current_order_id.replace(order.id);

--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -69,16 +69,6 @@ pub enum Position {
     Sell,
 }
 
-impl Position {
-    #[allow(dead_code)]
-    pub fn counter_position(&self) -> Self {
-        match self {
-            Position::Buy => Position::Sell,
-            Position::Sell => Position::Buy,
-        }
-    }
-}
-
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TakerId(Uuid);
 

--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -1,5 +1,5 @@
 use crate::maker_cfd_actor;
-use crate::model::cfd::{Cfd, Order};
+use crate::model::cfd::{Cfd, Order, Origin};
 use crate::model::Usd;
 use crate::to_sse_event::ToSseEvent;
 use anyhow::Result;
@@ -67,7 +67,7 @@ pub async fn post_sell_order(
     order: Json<CfdNewOrderRequest>,
     cfd_actor_inbox: &State<mpsc::UnboundedSender<maker_cfd_actor::Command>>,
 ) -> Result<status::Accepted<()>, status::BadRequest<String>> {
-    let order = Order::from_default_with_price(order.price)
+    let order = Order::from_default_with_price(order.price, Origin::Ours)
         .map_err(|e| status::BadRequest(Some(e.to_string())))?
         .with_min_quantity(order.min_quantity)
         .with_max_quantity(order.max_quantity);

--- a/daemon/src/taker_cfd_actor.rs
+++ b/daemon/src/taker_cfd_actor.rs
@@ -1,6 +1,5 @@
 use crate::db::{
     insert_cfd, insert_new_cfd_state_by_order_id, insert_order, load_all_cfds, load_order_by_id,
-    Origin,
 };
 use crate::model::cfd::{Cfd, CfdState, CfdStateCommon, FinalizedCfd, Order, OrderId};
 use crate::model::Usd;
@@ -66,7 +65,6 @@ where
                                     transition_timestamp: SystemTime::now(),
                                 },
                             },
-                            current_order.position.counter_position(),
                         );
 
                         insert_cfd(cfd, &mut conn).await.unwrap();
@@ -80,9 +78,7 @@ where
                     }
                     Command::NewOrder(Some(order)) => {
                         let mut conn = db.acquire().await.unwrap();
-                        insert_order(&order, &mut conn, Origin::Theirs)
-                            .await
-                            .unwrap();
+                        insert_order(&order, &mut conn).await.unwrap();
                         order_feed_actor_inbox.send(Some(order)).unwrap();
                     }
 

--- a/daemon/src/taker_inc_message_actor.rs
+++ b/daemon/src/taker_inc_message_actor.rs
@@ -1,3 +1,4 @@
+use crate::model::cfd::Origin;
 use crate::{taker_cfd_actor, wire};
 use futures::{Future, StreamExt};
 use tokio::net::tcp::OwnedReadHalf;
@@ -18,7 +19,11 @@ pub fn new(
     async move {
         while let Some(message) = messages.next().await {
             match message {
-                Ok(wire::MakerToTaker::CurrentOrder(order)) => {
+                Ok(wire::MakerToTaker::CurrentOrder(mut order)) => {
+                    if let Some(order) = order.as_mut() {
+                        order.origin = Origin::Theirs;
+                    }
+
                     cfd_actor
                         .send(taker_cfd_actor::Command::NewOrder(order))
                         .unwrap();

--- a/daemon/src/to_sse_event.rs
+++ b/daemon/src/to_sse_event.rs
@@ -63,12 +63,12 @@ impl ToSseEvent for Vec<model::cfd::Cfd> {
                 let (profit_btc, profit_usd) = cfd.calc_profit(current_price).unwrap();
 
                 Cfd {
-                    order_id: cfd.order_id,
-                    initial_price: cfd.initial_price,
-                    leverage: cfd.leverage,
-                    trading_pair: cfd.trading_pair.clone(),
-                    position: cfd.position.clone(),
-                    liquidation_price: cfd.liquidation_price,
+                    order_id: cfd.order.id,
+                    initial_price: cfd.order.price,
+                    leverage: cfd.order.leverage,
+                    trading_pair: cfd.order.trading_pair.clone(),
+                    position: cfd.position(),
+                    liquidation_price: cfd.order.liquidation_price,
                     quantity_usd: cfd.quantity_usd,
                     profit_btc,
                     profit_usd,


### PR DESCRIPTION
Flattening the Cfd out in the internal mode has caused duplication and confusion.
This refactor puts the Order into the Cfd to make relations clearer.

Note that once we have multiple leverage the leverage and liquidation price will have to move into the Cfd because they depend on the user's choice then.
This should be trivial to do.