### PR TITLE
Wrap bdk::wallet inside a struct

### DIFF
--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -1,8 +1,7 @@
+use crate::wallet::Wallet;
 use anyhow::Result;
 use bdk::bitcoin::secp256k1::{schnorrsig, SECP256K1};
 use bdk::bitcoin::{Amount, Network};
-use bdk::blockchain::{ElectrumBlockchain, NoopProgress};
-use bdk::KeychainKind;
 use clap::Clap;
 use model::cfd::{Cfd, Order};
 use rocket::fairing::AdHoc;
@@ -24,6 +23,7 @@ mod setup_contract_actor;
 mod taker_cfd_actor;
 mod taker_inc_message_actor;
 mod to_sse_event;
+mod wallet;
 mod wire;
 
 const CONNECTION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
@@ -69,23 +69,14 @@ async fn main() -> Result<()> {
 
     let seed = Seed::initialize(&data_dir.join("taker_seed"), opts.generate_seed).await?;
 
-    let client = bdk::electrum_client::Client::new(&opts.electrum).unwrap();
-
-    // TODO: Replace with sqlite once https://github.com/bitcoindevkit/bdk/pull/376 is merged.
-    let db = bdk::sled::open(data_dir.join("taker_wallet_db"))?;
-    let wallet_db = db.open_tree("wallet")?;
-
     let ext_priv_key = seed.derive_extended_priv_key(Network::Testnet)?;
 
-    let wallet = bdk::Wallet::new(
-        bdk::template::Bip84(ext_priv_key, KeychainKind::External),
-        Some(bdk::template::Bip84(ext_priv_key, KeychainKind::Internal)),
-        ext_priv_key.network,
-        wallet_db,
-        ElectrumBlockchain::from(client),
+    let wallet = Wallet::new(
+        &opts.electrum,
+        &data_dir.join("taker_wallet_db"),
+        ext_priv_key,
     )
-    .unwrap();
-    wallet.sync(NoopProgress, None).unwrap(); // TODO: Use LogProgress once we have logging.
+    .await?;
 
     let oracle = schnorrsig::KeyPair::new(SECP256K1, &mut rand::thread_rng()); // TODO: Fetch oracle public key from oracle.
 

--- a/daemon/src/taker_cfd_actor.rs
+++ b/daemon/src/taker_cfd_actor.rs
@@ -3,12 +3,11 @@ use crate::db::{
 };
 use crate::model::cfd::{Cfd, CfdState, CfdStateCommon, FinalizedCfd, Order, OrderId};
 use crate::model::Usd;
+use crate::wallet::Wallet;
 use crate::wire::SetupMsg;
 use crate::{setup_contract_actor, wire};
 use bdk::bitcoin::secp256k1::schnorrsig;
 use bdk::bitcoin::{self};
-use bdk::database::BatchDatabase;
-use cfd_protocol::WalletExt;
 use core::panic;
 use futures::Future;
 use std::time::SystemTime;
@@ -24,17 +23,14 @@ pub enum Command {
     CfdSetupCompleted(FinalizedCfd),
 }
 
-pub fn new<B, D>(
+pub fn new(
     db: sqlx::SqlitePool,
-    wallet: bdk::Wallet<B, D>,
+    wallet: Wallet,
     oracle_pk: schnorrsig::PublicKey,
     cfd_feed_actor_inbox: watch::Sender<Vec<Cfd>>,
     order_feed_actor_inbox: watch::Sender<Option<Order>>,
     out_msg_maker_inbox: mpsc::UnboundedSender<wire::TakerToMaker>,
-) -> (impl Future<Output = ()>, mpsc::UnboundedSender<Command>)
-where
-    D: BatchDatabase,
-{
+) -> (impl Future<Output = ()>, mpsc::UnboundedSender<Command>) {
     let (sender, mut receiver) = mpsc::unbounded_channel();
     let mut current_contract_setup = None;
 

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -1,0 +1,49 @@
+use anyhow::{Context, Result};
+use bdk::bitcoin::util::bip32::ExtendedPrivKey;
+use bdk::bitcoin::{Amount, PublicKey};
+use bdk::blockchain::{ElectrumBlockchain, NoopProgress};
+use bdk::KeychainKind;
+use cfd_protocol::{PartyParams, WalletExt};
+use std::path::Path;
+
+const SLED_TREE_NAME: &str = "wallet";
+
+pub struct Wallet<B = ElectrumBlockchain, D = bdk::sled::Tree> {
+    wallet: bdk::Wallet<B, D>,
+}
+
+impl Wallet {
+    pub async fn new(
+        electrum_rpc_url: &str,
+        wallet_dir: &Path,
+        ext_priv_key: ExtendedPrivKey,
+    ) -> Result<Self> {
+        let client = bdk::electrum_client::Client::new(electrum_rpc_url)
+            .context("Failed to initialize Electrum RPC client")?;
+
+        // TODO: Replace with sqlite once https://github.com/bitcoindevkit/bdk/pull/376 is merged.
+        let db = bdk::sled::open(wallet_dir)?.open_tree(SLED_TREE_NAME)?;
+
+        let wallet = bdk::Wallet::new(
+            bdk::template::Bip84(ext_priv_key, KeychainKind::External),
+            Some(bdk::template::Bip84(ext_priv_key, KeychainKind::Internal)),
+            ext_priv_key.network,
+            db,
+            ElectrumBlockchain::from(client),
+        )?;
+
+        wallet
+            .sync(NoopProgress, None)
+            .context("Failed to sync the wallet")?; // TODO: Use LogProgress once we have logging.
+
+        Ok(Self { wallet })
+    }
+
+    pub fn build_party_params(
+        &self,
+        amount: Amount,
+        identity_pk: PublicKey,
+    ) -> Result<PartyParams> {
+        self.wallet.build_party_params(amount, identity_pk)
+    }
+}


### PR DESCRIPTION
Removes code duplication in maker and taker wallet initialisation and avoids
generics in the cfd actors.