### PR TITLE
Remove `AdaptorSignature` wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,20 +1785,18 @@ dependencies = [
 [[package]]
 name = "secp256k1-zkp"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e57b977141f57b224fc579c23dac5978b5f594281450fe8b5e2b6aa816d0fde"
+source = "git+https://github.com/ElementsProject/rust-secp256k1-zkp#0dba4c033a929164dd21c488d2a5a9790919f65c"
 dependencies = [
- "bitcoin_hashes 0.9.7",
  "rand 0.6.5",
  "secp256k1",
  "secp256k1-zkp-sys",
+ "serde",
 ]
 
 [[package]]
 name = "secp256k1-zkp-sys"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45a3c4e1291985397df9770f864ed88bd51ee684b13a384f49d2fedb29f86f0"
+source = "git+https://github.com/ElementsProject/rust-secp256k1-zkp#0dba4c033a929164dd21c488d2a5a9790919f65c"
 dependencies = [
  "cc",
  "secp256k1-sys",

--- a/cfd_protocol/Cargo.toml
+++ b/cfd_protocol/Cargo.toml
@@ -9,7 +9,7 @@ bdk = { git = "https://github.com/bitcoindevkit/bdk/" }
 itertools = "0.10"
 rand = "0.6"
 rand_chacha = "0.1"
-secp256k1-zkp = { version = "0.4", features = ["hashes", "global-context"] }
+secp256k1-zkp = { git = "https://github.com/ElementsProject/rust-secp256k1-zkp", default-features = false, features = ["bitcoin_hashes", "global-context", "serde"] }
 
 [dev-dependencies]
 bitcoin = { version = "0.27", features = ["rand", "bitcoinconsensus"] }

--- a/daemon/src/setup_contract_actor.rs
+++ b/daemon/src/setup_contract_actor.rs
@@ -1,5 +1,5 @@
 use crate::model::cfd::{Cfd, FinalizedCfd};
-use crate::wire::{AdaptorSignature, Msg0, Msg1, SetupMsg};
+use crate::wire::{Msg0, Msg1, SetupMsg};
 use anyhow::{Context, Result};
 use bdk::bitcoin::secp256k1::{schnorrsig, SecretKey, Signature, SECP256K1};
 use bdk::bitcoin::{Amount, PublicKey, Transaction, Txid};
@@ -133,14 +133,14 @@ pub fn new(
             revocation: rev_sk,
             publish: publish_sk,
             lock: lock_tx,
-            commit: (commit_tx, *msg1.commit),
+            commit: (commit_tx, msg1.commit),
             cets: msg1
                 .cets
                 .into_iter()
                 .map(|(txid, sig)| {
                     let (cet, msg) = cet_by_id.remove(&txid).expect("unknown CET");
 
-                    (cet, *sig, msg)
+                    (cet, sig, msg)
                 })
                 .collect::<Vec<_>>(),
             refund: (refund_tx, msg1.refund),
@@ -227,7 +227,7 @@ fn verify_cets(
         Vec<u8>,
         schnorrsig::PublicKey,
     )],
-    cets: &[(Txid, AdaptorSignature)],
+    cets: &[(Txid, EcdsaAdaptorSignature)],
     commit_desc: &Descriptor<PublicKey>,
     commit_amount: Amount,
 ) -> Result<()> {
@@ -255,7 +255,7 @@ fn verify_adaptor_signature(
     tx: &Transaction,
     spent_descriptor: &Descriptor<PublicKey>,
     spent_amount: Amount,
-    encsig: &AdaptorSignature,
+    encsig: &EcdsaAdaptorSignature,
     encryption_point: &PublicKey,
     pk: &PublicKey,
 ) -> Result<()> {
@@ -280,7 +280,7 @@ fn verify_signature(
 
 fn verify_cet_encsig(
     tx: &Transaction,
-    encsig: &AdaptorSignature,
+    encsig: &EcdsaAdaptorSignature,
     msg: &[u8],
     pk: &PublicKey,
     (oracle_pk, nonce_pk): (&schnorrsig::PublicKey, &schnorrsig::PublicKey),

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -4,21 +4,8 @@ use crate::Order;
 use bdk::bitcoin::secp256k1::Signature;
 use bdk::bitcoin::util::psbt::PartiallySignedTransaction;
 use bdk::bitcoin::{Address, Amount, PublicKey, Txid};
-use cfd_protocol::{CfdTransactions, PartyParams, PunishParams};
+use cfd_protocol::{CfdTransactions, EcdsaAdaptorSignature, PartyParams, PunishParams};
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DisplayFromStr};
-
-#[serde_as]
-#[derive(Debug, Serialize, Deserialize)]
-pub struct AdaptorSignature(#[serde_as(as = "DisplayFromStr")] cfd_protocol::EcdsaAdaptorSignature);
-
-impl std::ops::Deref for AdaptorSignature {
-    type Target = cfd_protocol::EcdsaAdaptorSignature;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload")]
@@ -130,19 +117,19 @@ impl From<Msg0> for (PartyParams, PunishParams) {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Msg1 {
-    pub commit: AdaptorSignature,
-    pub cets: Vec<(Txid, AdaptorSignature)>,
+    pub commit: EcdsaAdaptorSignature,
+    pub cets: Vec<(Txid, EcdsaAdaptorSignature)>,
     pub refund: Signature,
 }
 
 impl From<CfdTransactions> for Msg1 {
     fn from(txs: CfdTransactions) -> Self {
         Self {
-            commit: AdaptorSignature(txs.commit.1),
+            commit: txs.commit.1,
             cets: txs
                 .cets
                 .into_iter()
-                .map(|(tx, sig, _, _)| (tx.txid(), AdaptorSignature(sig)))
+                .map(|(tx, sig, _, _)| (tx.txid(), sig))
                 .collect(),
             refund: txs.refund.1,
         }


### PR DESCRIPTION
`EcdsaAdaptorSignature` implements `Serialize` and `Deserialize` on latest master of `rust-secp256k1-zkp` so we can remove the wrapper.