### PR TITLE
Add close_transaction API to cfd_protocol lib

### DIFF
--- a/cfd_protocol/src/lib.rs
+++ b/cfd_protocol/src/lib.rs
@@ -5,8 +5,9 @@ pub mod interval;
 
 pub use oracle::{attest, nonce};
 pub use protocol::{
-    commit_descriptor, compute_adaptor_point, create_cfd_transactions, finalize_spend_transaction,
-    lock_descriptor, punish_transaction, renew_cfd_transactions, spending_tx_sighash,
-    CfdTransactions, PartyParams, Payout, PunishParams, TransactionExt, WalletExt,
+    close_transaction, commit_descriptor, compute_adaptor_point, create_cfd_transactions,
+    finalize_spend_transaction, lock_descriptor, punish_transaction, renew_cfd_transactions,
+    spending_tx_sighash, CfdTransactions, PartyParams, Payout, PunishParams, TransactionExt,
+    WalletExt,
 };
 pub use secp256k1_zkp;

--- a/cfd_protocol/src/protocol.rs
+++ b/cfd_protocol/src/protocol.rs
@@ -1,5 +1,5 @@
 pub use transaction_ext::TransactionExt;
-pub use transactions::punish_transaction;
+pub use transactions::{close_transaction, punish_transaction};
 
 use crate::interval;
 use crate::protocol::sighash_ext::SigHashExt;


### PR DESCRIPTION
Work towards #71.

Notes:
- We use a flat fee like with all the other chain transactions. Both punish and close could take a `feerate` argument since they are both meant to be published soon after constructing them. We don't need to solve this now, but I remembered it.
- Both parties must know `lock_descriptor`, `lock_amount` and `lock_outpoint` in order to build the close transaction. Maybe it would be best to remember the descriptor and the txid and calculate the other two when necessary.

---

What are the next steps? Should I try to use this new API in the binaries?