### PR TITLE
Add missing await for the message announcing NewTakerOnline

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -180,12 +180,13 @@ async fn main() -> Result<()> {
                                 tokio::spawn(in_taker_actor);
                                 tokio::spawn(out_msg_actor);
 
-                                maker_inc_connections_address.do_send_async(
-                                    maker_inc_connections_actor::NewTakerOnline {
+                                maker_inc_connections_address
+                                    .do_send_async(maker_inc_connections_actor::NewTakerOnline {
                                         taker_id,
                                         out_msg_actor_inbox,
-                                    },
-                                );
+                                    })
+                                    .await
+                                    .unwrap();
                             };
                         }
                     }


### PR DESCRIPTION
Without the await, the message was never sent and the taker could not see new offers.