### PR TITLE
Allow for presence/non-presence of index page

### DIFF
--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -207,8 +207,9 @@ mod tests {
 
         assert_eq!(feed_response.status(), Status::Ok);
         assert_eq!(new_sell_order_response.status(), Status::Accepted);
-        assert_eq!(index_response.status(), Status::NotFound); // we don't embed the files in the
-                                                               // tests
+        assert!(
+            index_response.status() == Status::NotFound || index_response.status() == Status::Ok
+        );
     }
 
     /// Constructs a Rocket instance for testing.


### PR DESCRIPTION
A dev might have or might not have built the frontend. If he did not, a get request to `/` will result in a `HTTP::404`. If he did, the containing `index.html` will be returned leading to a `HTTP::200`.