### PR TITLE
Replace negative .gitignores with build script

### DIFF
--- a/daemon/build.rs
+++ b/daemon/build.rs
@@ -1,0 +1,6 @@
+fn main() -> std::io::Result<()> {
+    std::fs::create_dir_all("../frontend/dist/maker")?;
+    std::fs::create_dir_all("../frontend/dist/taker")?;
+
+    Ok(())
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 dist-ssr
 *.local
+dist/

--- a/frontend/dist/maker/.gitignore
+++ b/frontend/dist/maker/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/frontend/dist/taker/.gitignore
+++ b/frontend/dist/taker/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
Vite deletes the `dist` directory on re-builds. That will also delete
the gitignore which makes the generated files show up in Git.
We need those directories to exist otherwise `rust-embed` fails.

Use a build-script to create them when we compile the daemons.
