### PR TITLE
Add standard release workflows

### DIFF
--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -1,0 +1,129 @@
+name: "Build release binary"
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build_binaries:
+    name: Build release binary
+    strategy:
+      matrix:
+        include:
+          - bin: taker
+            target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive_ext: tar
+          - bin: taker
+            target: armv7-unknown-linux-gnueabihf
+            os: ubuntu-latest
+            archive_ext: tar
+          - bin: taker
+            target: x86_64-apple-darwin
+            os: macos-latest
+            archive_ext: tar
+          - bin: taker
+            target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive_ext: zip
+          - bin: maker
+            target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive_ext: tar
+          - bin: maker
+            target: armv7-unknown-linux-gnueabihf
+            os: ubuntu-latest
+            archive_ext: tar
+          - bin: maker
+            target: x86_64-apple-darwin
+            os: macos-latest
+            archive_ext: tar
+          - bin: maker
+            target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive_ext: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v2.3.4
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+          token: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+
+      - name: Install toolchain from `rust-toolchain.toml`
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@v1.3.0
+
+      - name: Install compiler for armhf arch
+        if: matrix.target == 'armv7-unknown-linux-gnueabihf'
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-arm-linux-gnueabihf
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: yarn
+          cache-dependency-path: 'frontend/yarn.lock'
+
+      - name: Build ${{ matrix.bin }} frontend
+        shell: bash
+        run: |
+          cd frontend;
+          yarn
+          APP=${{ matrix.bin }} yarn build
+
+      - name: Build ${{ matrix.target }} ${{ matrix.bin }} release binary
+        run: cargo build --target=${{ matrix.target }} --release --bin ${{ matrix.bin }}
+
+      - name: Smoke test the binary
+        if: matrix.target != 'armv7-unknown-linux-gnueabihf' # armv7-unknown-linux-gnueabihf is only cross-compiled, no smoke test
+        run: target/${{ matrix.target }}/release/${{ matrix.bin }} --help
+
+      # Remove once python 3 is the default
+      - uses: actions/setup-python@v2.2.2
+        with:
+          python-version: '3.x'
+
+      - id: create-archive-name
+        shell: python # Use python to have a prettier name for the archive on Windows.
+        run: |
+          import platform
+          os_info = platform.uname()
+
+          arch = os_info.machine
+
+          triple = "${{ matrix.target }}".split("-")
+          arch = triple[0]
+
+          archive_name=f'${{ matrix.bin }}_${{ github.event.release.tag_name }}_{os_info.system}_{arch}.${{ matrix.archive_ext }}'
+
+          print(f'::set-output name=archive::{archive_name}')
+
+      - name: Pack macos archive
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: gtar -C ./target/${{ matrix.target }}/release --create --file=${{ steps.create-archive-name.outputs.archive }} ${{ matrix.bin }}
+
+      - name: Pack linux archive
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: tar -C ./target/${{ matrix.target }}/release --create --file=${{ steps.create-archive-name.outputs.archive }} ${{ matrix.bin }}
+
+      - name: Pack windows archive
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          cp target/${{ matrix.target }}/release/${{ matrix.bin }}.exe ./${{ matrix.bin }}.exe
+          7z a -tzip ${{ steps.create-archive-name.outputs.archive }} ./${{ matrix.bin }}.exe
+
+      - name: Upload archive
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ steps.create-archive-name.outputs.archive }}
+          asset_name: ${{ steps.create-archive-name.outputs.archive }}
+          asset_content_type: application/gzip

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,35 @@
+name: "Create release"
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  create_release:
+    name: Create from merged release branch
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Extract version from branch name
+        id: extract-version
+        shell: python
+        run: |
+          branch_name = "${{ github.event.pull_request.head.ref }}"
+          version = branch_name.split("/")[1]
+
+          print(f"::set-output name=version::{version}")
+
+      - name: Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.extract-version.outputs.version }}
+          release_name: ${{ steps.extract-version.outputs.version }}
+          draft: false
+          prerelease: false
+          body: ${{ steps.changelog.outputs.description }}
+          commitish: ${{ github.event.pull_request.merge_commit_sha }}

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -1,0 +1,64 @@
+name: "Draft new release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The new version in X.Y.Z format.'
+        required: true
+
+jobs:
+  draft-new-release:
+    name: "Draft a new release"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          token: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+
+      - name: Create release branch
+        run: git checkout -b release/${{ github.event.inputs.version }}
+
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "${{ secrets.BOTTY_NAME }}"
+          git config user.email ${{ secrets.BOTTY_EMAIL }}
+
+      - name: Bump version in Cargo.toml
+        uses: thomaseizinger/set-crate-version@1.0.0
+        with:
+          version: ${{ github.event.inputs.version }}
+          manifest: daemon/Cargo.toml
+
+      - name: Update Cargo.lock
+        run: cargo update --workspace
+
+      - name: Commit changelog and manifest files
+        id: make-commit
+        run: |
+          git add Cargo.lock daemon/Cargo.toml
+          git commit --message "Prepare release ${{ github.event.inputs.version }}"
+
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
+
+      - name: Create pull request
+        run: |
+          # Force push to allow for easier re-runs of the action
+          git push origin ${{ env.RELEASE_BRANCH }} --force
+          # Use heredoc to define multiline string: https://stackoverflow.com/a/23930212/2489334
+          BODY=$(cat <<-EOF
+          Hi @${{ github.actor }}!
+          This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+          I've bumped the versions in the manifest files in this commit: ${{ steps.make-commit.outputs.commit }}.
+          Merging this PR will create a GitHub release and publish the library to crates.io!
+          EOF
+          )
+          gh pr create \
+            --reviewer ${{ github.actor }} \
+            --title "Release version ${{ github.event.inputs.version }}" \
+            --head ${{ env.RELEASE_BRANCH }} \
+            --body "$BODY"
+        env:
+          # Using a bot account is important to trigger subsequent workflows.
+          # See https://devopsdirective.com/posts/2020/07/stupid-github-actions/#2----recursive-action.
+          GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,20 @@
+name: "Create 'preview' release"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  create_release:
+    name: Create preview release
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Update 'preview' release
+        run: |
+          gh release delete preview || true # First delete, ignore failures
+          gh release create preview --prerelease --title preview


### PR DESCRIPTION
These are mostly copy-pasted from xmr-btc-swap modulo the changelog
handling (because we don't have a changelog).

The gist is:

- We attach release binaries to every release that is created.
- Every merge to master creates a `preview` release.
- A merge from a branch that is named `release/x.y.z` creates a
release `x.y.z`.
- A new release branch can be created via `draft-new-release.yml`.

Fixes #65.

Example runs of these workflows can be found here: https://github.com/thomaseizinger/hermes/actions