### PR TITLE
Add a script that can start all processes in a single terminal

### DIFF
--- a/start_all.sh
+++ b/start_all.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# A simple command to spin up the complete package, ie. both daemons and frontends.
+# A single 'ctrl+c' stops all processes.
+(trap 'kill 0' SIGINT; cargo run --bin maker & cargo run --bin taker & APP=maker yarn --cwd=./frontend dev  & APP=taker yarn --cwd=./frontend dev)


### PR DESCRIPTION
Not suitable for all use-cases as the logs are jumbled up, but it makes
regression testing more approachable.

Hitting a single `ctrl+c` stops all processes.