### PR TITLE
Add meta_state to cfd for simplifying ui

### DIFF
--- a/frontend/src/MakerApp.tsx
+++ b/frontend/src/MakerApp.tsx
@@ -62,16 +62,10 @@ export default function App() {
         },
     });
 
-    const runningStates = ["Accepted", "Contract Setup", "Pending Open"];
-    const running = cfds.filter((value) => runningStates.includes(value.state));
-    const openStates = ["Requested"];
-    const open = cfds.filter((value) => openStates.includes(value.state));
-    const closedStates = ["Rejected", "Closed"];
-    const closed = cfds.filter((value) => closedStates.includes(value.state));
-    // TODO: remove this. It just helps to detect immediately if we missed a state.
-    const unsorted = cfds.filter((value) =>
-        !runningStates.includes(value.state) && !closedStates.includes(value.state) && !openStates.includes(value.state)
-    );
+    const acceptOrReject = cfds.filter((value) => value.state.meta_state === "acceptreject");
+    const opening = cfds.filter((value) => value.state.meta_state === "opening");
+    const open = cfds.filter((value) => value.state.meta_state === "open");
+    const closed = cfds.filter((value) => value.state.meta_state === "closed");
 
     const labelWidth = 110;
 
@@ -138,24 +132,24 @@ export default function App() {
 
             <Tabs marginTop={5}>
                 <TabList>
-                    <Tab>Running [{running.length}]</Tab>
                     <Tab>Open [{open.length}]</Tab>
+                    <Tab>Accept/Reject [{acceptOrReject.length}]</Tab>
+                    <Tab>Opening [{opening.length}]</Tab>
                     <Tab>Closed [{closed.length}]</Tab>
-                    <Tab>Unsorted [{unsorted.length}] (should be empty)</Tab>
                 </TabList>
 
                 <TabPanels>
                     <TabPanel>
-                        <CfdTable data={running} />
+                        <CfdTable data={open} />
                     </TabPanel>
                     <TabPanel>
-                        <CfdTableMaker data={open} />
+                        <CfdTableMaker data={acceptOrReject} />
+                    </TabPanel>
+                    <TabPanel>
+                        <CfdTable data={opening} />
                     </TabPanel>
                     <TabPanel>
                         <CfdTable data={closed} />
-                    </TabPanel>
-                    <TabPanel>
-                        <CfdTable data={unsorted} />
                     </TabPanel>
                 </TabPanels>
             </Tabs>

--- a/frontend/src/TakerApp.tsx
+++ b/frontend/src/TakerApp.tsx
@@ -107,14 +107,9 @@ export default function App() {
         },
     });
 
-    const runningStates = ["Request sent", "Requested", "Contract Setup", "Pending Open"];
-    const running = cfds.filter((value) => runningStates.includes(value.state));
-    const closedStates = ["Rejected", "Closed"];
-    const closed = cfds.filter((value) => closedStates.includes(value.state));
-    // TODO: remove this. It just helps to detect immediately if we missed a state.
-    const unsorted = cfds.filter((value) =>
-        !runningStates.includes(value.state) && !closedStates.includes(value.state)
-    );
+    const open = cfds.filter((value) => value.state.meta_state === "open");
+    const opening = cfds.filter((value) => value.state.meta_state === "opening");
+    const closed = cfds.filter((value) => value.state.meta_state === "closed");
 
     const labelWidth = 120;
 
@@ -180,20 +175,19 @@ export default function App() {
             </HStack>
             <Tabs marginTop={5}>
                 <TabList>
-                    <Tab>Running [{running.length}]</Tab>
+                    <Tab>Open [{open.length}]</Tab>
+                    <Tab>Opening [{opening.length}]</Tab>
                     <Tab>Closed [{closed.length}]</Tab>
-                    <Tab>Unsorted [{unsorted.length}] (should be empty)</Tab>
                 </TabList>
-
                 <TabPanels>
                     <TabPanel>
-                        <CfdTable data={running} />
+                        <CfdTable data={open} />
+                    </TabPanel>
+                    <TabPanel>
+                        <CfdTable data={opening} />
                     </TabPanel>
                     <TabPanel>
                         <CfdTable data={closed} />
-                    </TabPanel>
-                    <TabPanel>
-                        <CfdTable data={unsorted} />
                     </TabPanel>
                 </TabPanels>
             </Tabs>

--- a/frontend/src/components/Types.tsx
+++ b/frontend/src/components/Types.tsx
@@ -1,7 +1,12 @@
+export interface Position {
+    label: string;
+    colorScheme: string;
+}
+
 export interface Order {
     id: string;
     trading_pair: string;
-    position: string;
+    position: Position;
     price: number;
     min_quantity: number;
     max_quantity: number;
@@ -17,7 +22,7 @@ export interface Cfd {
 
     leverage: number;
     trading_pair: string;
-    position: string;
+    position: Position;
     liquidation_price: number;
 
     quantity_usd: number;
@@ -27,8 +32,14 @@ export interface Cfd {
     profit_btc: number;
     profit_usd: number;
 
-    state: string;
+    state: State;
     state_transition_timestamp: number;
+}
+
+export interface State {
+    label: string;
+    meta_state: string;
+    colorScheme: string;
 }
 
 export interface WalletInfo {

--- a/frontend/src/components/cfdtables/CfdTable.tsx
+++ b/frontend/src/components/cfdtables/CfdTable.tsx
@@ -48,12 +48,8 @@ export function CfdTable(
             {
                 Header: "Position",
                 accessor: ({ position }) => {
-                    let colorScheme = "green";
-                    if (position.toLocaleLowerCase() === "buy") {
-                        colorScheme = "purple";
-                    }
                     return (
-                        <Badge colorScheme={colorScheme}>{position}</Badge>
+                        <Badge colorScheme={position.colorScheme}>{position.label}</Badge>
                     );
                 },
                 isNumeric: true,
@@ -104,15 +100,8 @@ export function CfdTable(
             {
                 Header: "State",
                 accessor: ({ state }) => {
-                    let colorScheme = "gray";
-                    if (state.toLowerCase() === "rejected") {
-                        colorScheme = "red";
-                    }
-                    if (state.toLowerCase() === "contract setup") {
-                        colorScheme = "green";
-                    }
                     return (
-                        <Badge colorScheme={colorScheme}>{state}</Badge>
+                        <Badge colorScheme={state.colorScheme}>{state.label}</Badge>
                     );
                 },
             },
@@ -208,7 +197,6 @@ export function Table({ columns, tableData, hiddenColumns, renderDetails }: Tabl
                                     {...column.getHeaderProps(column.getSortByToggleProps())}
                                     // @ts-ignore
                                     isNumeric={column.isNumeric}
-                                    textAlign={"right"}
                                 >
                                     {column.render("Header")}
                                     <chakra.span>

--- a/frontend/src/components/cfdtables/CfdTableMaker.tsx
+++ b/frontend/src/components/cfdtables/CfdTableMaker.tsx
@@ -95,12 +95,8 @@ export function CfdTableMaker(
             {
                 Header: "Position",
                 accessor: ({ position }) => {
-                    let colorScheme = "green";
-                    if (position.toLocaleLowerCase() === "buy") {
-                        colorScheme = "purple";
-                    }
                     return (
-                        <Badge colorScheme={colorScheme}>{position}</Badge>
+                        <Badge colorScheme={position.colorScheme}>{position.label}</Badge>
                     );
                 },
                 isNumeric: true,
@@ -151,7 +147,8 @@ export function CfdTableMaker(
             {
                 Header: "Action",
                 accessor: ({ state, order_id }) => {
-                    if (state.toLowerCase() === "requested") {
+                    // TODO: Integrate in actions, and return actions only for maker, then combine table with maker (we don't need a separate maker table then)
+                    if (state.label.toLowerCase() === "requested") {
                         return (<HStack>
                             <IconButton
                                 colorScheme="green"
@@ -170,15 +167,8 @@ export function CfdTableMaker(
                         </HStack>);
                     }
 
-                    let colorScheme = "gray";
-                    if (state.toLowerCase() === "rejected") {
-                        colorScheme = "red";
-                    }
-                    if (state.toLowerCase() === "contract setup") {
-                        colorScheme = "green";
-                    }
                     return (
-                        <Badge colorScheme={colorScheme}>{state}</Badge>
+                        <Badge colorScheme={state.colorScheme}>{state.label}</Badge>
                     );
                 },
             },


### PR DESCRIPTION
followup from #148 

On a granular level, a CFD can be in multiple states. On an abstract level a CFD is either open (hasn't been accepted/rejected yet), running (it's ongoing) or closed (it has been terminated).
By introducing this meta state into our cfd model we simplify the UI logic.