### PR TITLE
Fix `MAX_PRICE_DEC`

### DIFF
--- a/cfd_protocol/src/interval.rs
+++ b/cfd_protocol/src/interval.rs
@@ -5,7 +5,7 @@ use std::ops::RangeInclusive;
 mod digit_decomposition;
 
 /// Maximum supported BTC price in whole USD.
-const MAX_PRICE_DEC: u64 = (BASE as u64).pow(MAX_DIGITS as u32);
+const MAX_PRICE_DEC: u64 = (BASE as u64).pow(MAX_DIGITS as u32) - 1;
 
 /// Maximum number of binary digits for BTC price in whole USD.
 const MAX_DIGITS: usize = 20;


### PR DESCRIPTION
2^20 is 21 bits long, _not_ 20 bits long. If we allow a bound equal to 2^20 we would need 21 bits to represent it, past our limit of 20.

Thanks @bonomat for making me test what `proptest` didn't. 