### PR TITLE
Handle existing cfds on daemon startup

### DIFF
--- a/daemon/src/cleanup.rs
+++ b/daemon/src/cleanup.rs
@@ -1,0 +1,27 @@
+use crate::db::{insert_new_cfd_state_by_order_id, load_all_cfds};
+use crate::model::cfd::{Cfd, CfdState, CfdStateCommon};
+use anyhow::Result;
+use sqlx::SqlitePool;
+use std::time::SystemTime;
+
+pub async fn transition_non_continue_cfds_to_setup_failed(db: SqlitePool) -> Result<()> {
+    let mut conn = db.acquire().await?;
+
+    let cfds = load_all_cfds(&mut conn).await?;
+
+    for cfd in cfds.iter().filter(|cfd| Cfd::is_cleanup(cfd)) {
+        insert_new_cfd_state_by_order_id(
+            cfd.order.id,
+            CfdState::SetupFailed {
+                common: CfdStateCommon {
+                    transition_timestamp: SystemTime::now(),
+                },
+                info: format!("Was in state {} which cannot be continued.", cfd.state),
+            },
+            &mut conn,
+        )
+        .await?;
+    }
+
+    Ok(())
+}

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -67,6 +67,7 @@ enum SetupState {
 }
 
 impl Actor {
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         db: sqlx::SqlitePool,
         wallet: Wallet,
@@ -75,11 +76,25 @@ impl Actor {
         order_feed_sender: watch::Sender<Option<Order>>,
         takers: Address<maker_inc_connections::Actor>,
         monitor_actor: Address<monitor::Actor<Actor>>,
+        cfds: Vec<Cfd>,
     ) -> Result<Self> {
         let mut conn = db.acquire().await?;
 
         // populate the CFD feed with existing CFDs
         cfd_feed.update(&mut conn).await?;
+
+        for dlc in cfds.iter().filter_map(|cfd| Cfd::pending_open_dlc(cfd)) {
+            let txid = wallet.try_broadcast_transaction(dlc.lock.0.clone()).await?;
+
+            tracing::info!("Lock transaction published with txid {}", txid);
+        }
+
+        for cfd in cfds.iter().filter(|cfd| Cfd::is_must_refund(cfd)) {
+            let signed_refund_tx = cfd.refund_tx()?;
+            let txid = wallet.try_broadcast_transaction(signed_refund_tx).await?;
+
+            tracing::info!("Refund transaction published on chain: {}", txid);
+        }
 
         Ok(Self {
             db,
@@ -186,24 +201,10 @@ impl Actor {
         // refund timelock
         let cfd = load_cfd_by_order_id(msg.order_id, &mut conn).await?;
 
-        let script_pubkey = dlc.address.script_pubkey();
         self.monitor_actor
             .do_send_async(monitor::StartMonitoring {
                 id: msg.order_id,
-                params: MonitorParams {
-                    lock: (dlc.lock.0.txid(), dlc.lock.1),
-                    commit: (dlc.commit.0.txid(), dlc.commit.2),
-                    cets: dlc
-                        .cets
-                        .into_iter()
-                        .map(|(tx, _, range)| (tx.txid(), script_pubkey.clone(), range))
-                        .collect(),
-                    refund: (
-                        dlc.refund.0.txid(),
-                        script_pubkey,
-                        cfd.refund_timelock_in_blocks(),
-                    ),
-                },
+                params: MonitorParams::from_dlc_and_timelocks(dlc, cfd.refund_timelock_in_blocks()),
             })
             .await?;
 


### PR DESCRIPTION
fixes #137 

Cfd actor handles upon startup:

*  "cleaning up" cfds that were left in a state that cannot be continued (any state before `PendingOpen` will be transitioned to `SafelyAborted`)
* transaction (re-)publication for states that publish a transaction (at the moment: `PendingOpen` and `MustRefund`)
  * note: publishing commit transaction through user interaction is not done yet, see #69 (I will see to work on that next)

Monitor actor handles upon start:

* trigger necessary monitoring based on state.