### PR TITLE
Remove the span that does not align the table header properly

### DIFF
--- a/frontend/src/components/cfdtables/CfdTable.tsx
+++ b/frontend/src/components/cfdtables/CfdTable.tsx
@@ -208,9 +208,10 @@ export function Table({ columns, tableData, hiddenColumns, renderDetails }: Tabl
                                     {...column.getHeaderProps(column.getSortByToggleProps())}
                                     // @ts-ignore
                                     isNumeric={column.isNumeric}
+                                    textAlign={"right"}
                                 >
                                     {column.render("Header")}
-                                    <chakra.span pl="4">
+                                    <chakra.span>
                                         {// @ts-ignore
                                         column.isSorted
                                             ? (


### PR DESCRIPTION
When sorting the triangle appears next to the header text - that is expected and standard behavior.
The span was always rendered (also with no sorting), and message up the alignment of the text.

Before:

![image](https://user-images.githubusercontent.com/5557790/135078601-f463f6ef-b2d8-4f73-b9f1-c139f24e05f1.png)

After:

![image](https://user-images.githubusercontent.com/5557790/135078962-c47fa3f8-bb28-4503-ad25-cc0a523d03ea.png)

when sorting (triangle appears for a few secs then disappears again):

![image](https://user-images.githubusercontent.com/5557790/135079083-4ab03009-096d-41b9-b59f-455a86d8df06.png)


