### PR TITLE
Use sqlite for BDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,6 @@
 .pnp.*
 
 # Artifacts from running the daemons
-/maker.sqlite
-/maker_wallet_db/
-/taker.sqlite
-/taker_wallet_db/
+/*.sqlite*
 /maker_seed
 /taker_seed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,8 +145,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "0.11.1-dev"
-source = "git+https://github.com/bitcoindevkit/bdk/#8c21bcf40a1fe76637b65c3e483b6c46351f28fa"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecf7e997526ceefbab7dd99fc0da6834ed8853bd051f53523415ed1dc82b870d"
 dependencies = [
  "async-trait",
  "bdk-macros",
@@ -164,8 +165,9 @@ dependencies = [
 
 [[package]]
 name = "bdk-macros"
-version = "0.5.0"
-source = "git+https://github.com/bitcoindevkit/bdk/#8c21bcf40a1fe76637b65c3e483b6c46351f28fa"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81c1980e50ae23bb6efa9283ae8679d6ea2c6fa6a99fe62533f65f4a25a1a56c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,9 @@ dependencies = [
  "log",
  "miniscript",
  "rand 0.7.3",
+ "rusqlite",
  "serde",
  "serde_json",
- "sled",
  "tokio",
 ]
 
@@ -425,15 +425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
-name = "crc32fast"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,19 +432,6 @@ checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
@@ -647,6 +625,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "figment"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,16 +676,6 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -813,15 +793,6 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1182,15 +1153,6 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "memoffset"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
-dependencies = [
- "autocfg 1.0.1",
-]
 
 [[package]]
 name = "mime"
@@ -1914,6 +1876,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57adcf67c8faaf96f3248c2a7b419a0dbc52ebe36ba83dd57fe83827c1ea4eb3"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-embed"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,22 +2205,6 @@ name = "slab"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
-
-[[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot",
-]
 
 [[package]]
 name = "smallvec"

--- a/cfd_protocol/Cargo.toml
+++ b/cfd_protocol/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.12" }
+bdk = { version = "0.12", default-features = false }
 bit-vec = "0.6"
 itertools = "0.10"
 rand = "0.6"

--- a/cfd_protocol/Cargo.toml
+++ b/cfd_protocol/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-bdk = { git = "https://github.com/bitcoindevkit/bdk/" }
+bdk = { version = "0.12" }
 bit-vec = "0.6"
 itertools = "0.10"
 rand = "0.6"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 anyhow = "1"
 async-trait = "0.1.51"
 atty = "0.2"
-bdk = { git = "https://github.com/bitcoindevkit/bdk/" }
+bdk = { version = "0.12" }
 bytes = "1"
 cfd_protocol = { path = "../cfd_protocol" }
 clap = "3.0.0-beta.4"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 anyhow = "1"
 async-trait = "0.1.51"
 atty = "0.2"
-bdk = { version = "0.12", default-features = false, features = ["key-value-db", "electrum"] }
+bdk = { version = "0.12", default-features = false, features = ["sqlite", "electrum"] }
 bytes = "1"
 cfd_protocol = { path = "../cfd_protocol" }
 clap = "3.0.0-beta.4"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 anyhow = "1"
 async-trait = "0.1.51"
 atty = "0.2"
-bdk = { version = "0.12" }
+bdk = { version = "0.12", default-features = false, features = ["key-value-db", "electrum"] }
 bytes = "1"
 cfd_protocol = { path = "../cfd_protocol" }
 clap = "3.0.0-beta.4"

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<()> {
 
     let wallet = Wallet::new(
         &opts.electrum,
-        &data_dir.join("maker_wallet_db"),
+        &data_dir.join("maker_wallet.sqlite"),
         ext_priv_key,
     )
     .await?;

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -94,7 +94,7 @@ async fn main() -> Result<()> {
 
     let wallet = Wallet::new(
         &opts.electrum,
-        &data_dir.join("taker_wallet_db"),
+        &data_dir.join("taker_wallet.sqlite"),
         ext_priv_key,
     )
     .await?;

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -13,11 +13,9 @@ use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::sync::Mutex;
 
-const SLED_TREE_NAME: &str = "wallet";
-
 #[derive(Clone)]
 pub struct Wallet {
-    wallet: Arc<Mutex<bdk::Wallet<ElectrumBlockchain, bdk::sled::Tree>>>,
+    wallet: Arc<Mutex<bdk::Wallet<ElectrumBlockchain, bdk::database::SqliteDatabase>>>,
 }
 
 #[derive(thiserror::Error, Debug, Clone, Copy)]
@@ -33,8 +31,7 @@ impl Wallet {
         let client = bdk::electrum_client::Client::new(electrum_rpc_url)
             .context("Failed to initialize Electrum RPC client")?;
 
-        // TODO: Replace with sqlite once https://github.com/bitcoindevkit/bdk/pull/376 is merged.
-        let db = bdk::sled::open(wallet_dir)?.open_tree(SLED_TREE_NAME)?;
+        let db = bdk::database::SqliteDatabase::new(wallet_dir.display().to_string());
 
         let wallet = bdk::Wallet::new(
             bdk::template::Bip84(ext_priv_key, KeychainKind::External),


### PR DESCRIPTION
- Update to bdk 0.12
- Selectively depend on bdk features
- Use sqlite for BDK's database
