### PR TITLE
Fix commit transaction publication

### DIFF
--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -461,6 +461,9 @@ impl Actor {
 
         insert_new_cfd_state_by_order_id(order_id, new_state.clone(), &mut conn).await?;
 
+        self.cfd_feed_actor_inbox
+            .send(load_all_cfds(&mut conn).await?)?;
+
         // TODO: Not sure that should be done here...
         //  Consider bubbling the refund availability up to the user, and let user trigger
         //  transaction publication

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -445,6 +445,9 @@ impl Actor {
         let new_state = cfd.handle(CfdStateChangeEvent::CommitTxSent)?;
         insert_new_cfd_state_by_order_id(cfd.order.id, new_state, &mut conn).await?;
 
+        self.cfd_feed_actor_inbox
+            .send(load_all_cfds(&mut conn).await?)?;
+
         Ok(())
     }
 

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -322,7 +322,7 @@ impl Display for CfdState {
                 write!(f, "Open")
             }
             CfdState::PendingCommit { .. } => {
-                write!(f, "Pending Committ")
+                write!(f, "Pending Commit")
             }
             CfdState::OpenCommitted { .. } => {
                 write!(f, "Open Committed")
@@ -624,8 +624,9 @@ impl Cfd {
     }
 
     pub fn commit_tx(&self) -> Result<Transaction> {
-        let dlc = if let CfdState::Open { dlc, .. } | CfdState::PendingOpen { dlc, .. } =
-            self.state.clone()
+        let dlc = if let CfdState::Open { dlc, .. }
+        | CfdState::PendingOpen { dlc, .. }
+        | CfdState::PendingCommit { dlc, .. } = self.state.clone()
         {
             dlc
         } else {
@@ -652,7 +653,7 @@ impl Cfd {
 
         let signed_commit_tx = finalize_spend_transaction(
             dlc.commit.0,
-            &dlc.commit.2,
+            &dlc.lock.1,
             (our_pubkey, our_sig),
             (counterparty_pubkey, counterparty_sig),
         )?;

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -475,9 +475,9 @@ impl Cfd {
                     }
                 }
                 monitor::Event::CommitFinality(_) => {
-                    let dlc = if let Open { dlc, .. } = self.state.clone() {
+                    let dlc = if let PendingCommit { dlc, .. } = self.state.clone() {
                         dlc
-                    } else if let PendingOpen { dlc, .. } = self.state.clone() {
+                    } else if let PendingOpen { dlc, .. } | Open { dlc, .. } = self.state.clone() {
                         tracing::debug!(%order_id, "Was in unexpected state {}, jumping ahead to OpenCommitted", self.state);
                         dlc
                     } else {

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -337,6 +337,9 @@ impl Actor {
 
         insert_new_cfd_state_by_order_id(order_id, new_state.clone(), &mut conn).await?;
 
+        self.cfd_feed_actor_inbox
+            .send(load_all_cfds(&mut conn).await?)?;
+
         // TODO: Not sure that should be done here...
         //  Consider bubbling the refund availability up to the user, and let user trigger
         //  transaction publication

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -370,6 +370,9 @@ impl Actor {
         let new_state = cfd.handle(CfdStateChangeEvent::CommitTxSent)?;
         insert_new_cfd_state_by_order_id(cfd.order.id, new_state, &mut conn).await?;
 
+        self.cfd_feed_actor_inbox
+            .send(load_all_cfds(&mut conn).await?)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
1. Finalize with correct descriptor (of lock tx)
2. Restart fix: Allow retrieving the commit tx in state `PendingCommit` so we can re-publish in that state.
3. Update cfd feed after state transition to `PendingCommit` to see updated state in UI.

Yeeeei:

![image](https://user-images.githubusercontent.com/5557790/135588239-91a9e48d-a7f9-4302-948d-12482f8bcf27.png)

and then:

![image](https://user-images.githubusercontent.com/5557790/135589935-11af6133-8262-41fb-a45c-3dc4ae9e777e.png)
