### PR TITLE
Make cache to be per target

### DIFF
--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -54,6 +54,8 @@ jobs:
         run: rustup show
 
       - uses: Swatinem/rust-cache@v1.3.0
+        with:
+          key: ${{ matrix.target }}
 
       - name: Install compiler for armhf arch
         if: matrix.target == 'armv7-unknown-linux-gnueabihf'


### PR DESCRIPTION
Otherwise the armv7 build uses the x64 cache which is no good.
