### PR TITLE
Transition cfd to new state when handling an event

### DIFF
--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -411,7 +411,7 @@ impl Actor {
 
     async fn handle_commit(&mut self, order_id: OrderId) -> Result<()> {
         let mut conn = self.db.acquire().await?;
-        let cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
+        let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
 
         let signed_commit_tx = cfd.commit_tx()?;
 
@@ -435,12 +435,10 @@ impl Actor {
         let order_id = event.order_id();
 
         let mut conn = self.db.acquire().await?;
-        let cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
+        let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
 
         let new_state = cfd.handle(CfdStateChangeEvent::Monitor(event))?;
-
         insert_new_cfd_state_by_order_id(order_id, new_state.clone(), &mut conn).await?;
-
         self.cfd_feed_actor_inbox
             .send(load_all_cfds(&mut conn).await?)?;
 

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -449,7 +449,7 @@ impl Cfd {
     #[allow(dead_code)]
     pub const CET_TIMELOCK: u32 = 12;
 
-    pub fn handle(&self, event: CfdStateChangeEvent) -> Result<CfdState> {
+    pub fn handle(&mut self, event: CfdStateChangeEvent) -> Result<CfdState> {
         use CfdState::*;
 
         // TODO: Display impl
@@ -590,6 +590,8 @@ impl Cfd {
                 }
             }
         };
+
+        self.state = new_state.clone();
 
         Ok(new_state)
     }

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -311,7 +311,7 @@ impl Actor {
         let order_id = event.order_id();
 
         let mut conn = self.db.acquire().await?;
-        let cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
+        let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
 
         let new_state = cfd.handle(CfdStateChangeEvent::Monitor(event))?;
 
@@ -339,7 +339,7 @@ impl Actor {
     // TODO: Duplicated with maker
     async fn handle_commit(&mut self, order_id: OrderId) -> Result<()> {
         let mut conn = self.db.acquire().await?;
-        let cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
+        let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
 
         let signed_commit_tx = cfd.commit_tx()?;
 


### PR DESCRIPTION
Previously we only returned the new state, but we also have to set it internally, otherwise the cfd might be out of date.

This was a problem when getting the refund transaction from the cfd directly after a state transition to `MustRefund`.
The cfd instance had not actually transitioned to the new state, even though it was saved in the database.