### PR TITLE
Allow accepting/rejecting settlement proposals in the maker daemon

### DIFF
--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -11,6 +11,7 @@ use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt;
 use std::ops::{Neg, RangeInclusive};
 use std::time::{Duration, SystemTime};
@@ -49,7 +50,7 @@ pub enum Origin {
 }
 
 /// Role in the Cfd
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Role {
     Maker,
     Taker,
@@ -348,6 +349,13 @@ pub struct SettlementProposal {
     pub timestamp: SystemTime,
     pub taker: Amount,
     pub maker: Amount,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Variants used by different binaries
+pub enum SettlementProposals {
+    Incoming(HashMap<OrderId, SettlementProposal>),
+    Outgoing(HashMap<OrderId, SettlementProposal>),
 }
 
 /// Represents a cfd (including state)

--- a/frontend/src/MakerApp.tsx
+++ b/frontend/src/MakerApp.tsx
@@ -64,7 +64,10 @@ export default function App() {
         },
     });
 
-    const acceptOrReject = cfds.filter((value) => value.state.getGroup() === StateGroupKey.ACCEPT_OR_REJECT);
+    const acceptOrRejectOrder = cfds.filter((value) => value.state.getGroup() === StateGroupKey.ACCEPT_OR_REJECT_ORDER);
+    const acceptOrRejectSettlement = cfds.filter((value) =>
+        value.state.getGroup() === StateGroupKey.ACCEPT_OR_REJECT_SETTLEMENT
+    );
     const opening = cfds.filter((value) => value.state.getGroup() === StateGroupKey.OPENING);
     const open = cfds.filter((value) => value.state.getGroup() === StateGroupKey.OPEN);
     const closed = cfds.filter((value) => value.state.getGroup() === StateGroupKey.CLOSED);
@@ -156,7 +159,8 @@ export default function App() {
             <Tabs marginTop={5}>
                 <TabList>
                     <Tab>Open [{open.length}]</Tab>
-                    <Tab>Accept / Reject [{acceptOrReject.length}]</Tab>
+                    <Tab>Accept / Reject Order [{acceptOrRejectOrder.length}]</Tab>
+                    <Tab>Accept / Reject Settlement [{acceptOrRejectSettlement.length}]</Tab>
                     <Tab>Opening [{opening.length}]</Tab>
                     <Tab>Closed [{closed.length}]</Tab>
                 </TabList>
@@ -166,7 +170,10 @@ export default function App() {
                         <CfdTable data={open} />
                     </TabPanel>
                     <TabPanel>
-                        <CfdTable data={acceptOrReject} />
+                        <CfdTable data={acceptOrRejectOrder} />
+                    </TabPanel>
+                    <TabPanel>
+                        <CfdTable data={acceptOrRejectSettlement} />
                     </TabPanel>
                     <TabPanel>
                         <CfdTable data={opening} />

--- a/frontend/src/components/Types.tsx
+++ b/frontend/src/components/Types.tsx
@@ -137,8 +137,8 @@ export class State {
 }
 
 export enum Action {
-    ACCEPT = "accept",
-    REJECT = "reject",
+    ACCEPT_ORDER = "acceptOrder",
+    REJECT_ORDER = "rejectOrder",
     COMMIT = "commit",
     SETTLE = "settle",
 }

--- a/frontend/src/components/Types.tsx
+++ b/frontend/src/components/Types.tsx
@@ -56,9 +56,9 @@ export class State {
     public getLabel(): string {
         switch (this.key) {
             case StateKey.INCOMING_ORDER_REQUEST:
-                return "Take Requested";
+                return "Order Requested";
             case StateKey.OUTGOING_ORDER_REQUEST:
-                return "Take Requested";
+                return "Order Requested";
             case StateKey.ACCEPTED:
                 return "Accepted";
             case StateKey.REJECTED:
@@ -73,6 +73,10 @@ export class State {
                 return "Pending Commit";
             case StateKey.OPEN_COMMITTED:
                 return "Open (commit-tx published)";
+            case StateKey.INCOMING_SETTLEMENT_PROPOSAL:
+                return "Settlement Proposed";
+            case StateKey.OUTGOING_SETTLEMENT_PROPOSAL:
+                return "Settlement Proposed";
             case StateKey.MUST_REFUND:
                 return "Refunding";
             case StateKey.REFUNDED:
@@ -103,6 +107,8 @@ export class State {
 
             case StateKey.OUTGOING_ORDER_REQUEST:
             case StateKey.INCOMING_ORDER_REQUEST:
+            case StateKey.OUTGOING_SETTLEMENT_PROPOSAL:
+            case StateKey.INCOMING_SETTLEMENT_PROPOSAL:
             case StateKey.CONTRACT_SETUP:
             case StateKey.PENDING_OPEN:
             case StateKey.REFUNDED:
@@ -114,7 +120,7 @@ export class State {
     public getGroup(): StateGroupKey {
         switch (this.key) {
             case StateKey.INCOMING_ORDER_REQUEST:
-                return StateGroupKey.ACCEPT_OR_REJECT;
+                return StateGroupKey.ACCEPT_OR_REJECT_ORDER;
 
             case StateKey.OUTGOING_ORDER_REQUEST:
             case StateKey.ACCEPTED:
@@ -126,7 +132,11 @@ export class State {
             case StateKey.PENDING_COMMIT:
             case StateKey.OPEN_COMMITTED:
             case StateKey.MUST_REFUND:
+            case StateKey.OUTGOING_SETTLEMENT_PROPOSAL:
                 return StateGroupKey.OPEN;
+
+            case StateKey.INCOMING_SETTLEMENT_PROPOSAL:
+                return StateGroupKey.ACCEPT_OR_REJECT_SETTLEMENT;
 
             case StateKey.REJECTED:
             case StateKey.REFUNDED:
@@ -141,6 +151,8 @@ export enum Action {
     REJECT_ORDER = "rejectOrder",
     COMMIT = "commit",
     SETTLE = "settle",
+    ACCEPT_SETTLEMENT = "acceptSettlement",
+    REJECT_SETTLEMENT = "rejectSettlement",
 }
 
 const enum StateKey {
@@ -153,6 +165,8 @@ const enum StateKey {
     OPEN = "Open",
     PENDING_COMMIT = "PendingCommit",
     OPEN_COMMITTED = "OpenCommitted",
+    OUTGOING_SETTLEMENT_PROPOSAL = "OutgoingSettlementProposal",
+    INCOMING_SETTLEMENT_PROPOSAL = "IncomingSettlementProposal",
     MUST_REFUND = "MustRefund",
     REFUNDED = "Refunded",
     SETUP_FAILED = "SetupFailed",
@@ -161,9 +175,10 @@ const enum StateKey {
 export enum StateGroupKey {
     /// A CFD which is still being set up (not on chain yet)
     OPENING = "Opening",
-    ACCEPT_OR_REJECT = "Accept / Reject",
+    ACCEPT_OR_REJECT_ORDER = "Accept / Reject Order",
     /// A CFD that is an ongoing open position (on chain)
     OPEN = "Open",
+    ACCEPT_OR_REJECT_SETTLEMENT = "Accept / Reject Settlement",
     /// A CFD that has been successfully or not-successfully terminated
     CLOSED = "Closed",
 }

--- a/frontend/src/components/cfdtables/CfdTable.tsx
+++ b/frontend/src/components/cfdtables/CfdTable.tsx
@@ -195,6 +195,10 @@ function iconForAction(action: Action): any {
             return <WarningIcon />;
         case Action.SETTLE:
             return <CheckCircleIcon />;
+        case Action.ACCEPT_SETTLEMENT:
+            return <CheckIcon />;
+        case Action.REJECT_SETTLEMENT:
+            return <CloseIcon />;
     }
 }
 
@@ -208,6 +212,10 @@ function colorSchemaForAction(action: Action): string {
             return "red";
         case Action.SETTLE:
             return "green";
+        case Action.ACCEPT_SETTLEMENT:
+            return "green";
+        case Action.REJECT_SETTLEMENT:
+            return "red";
     }
 }
 

--- a/frontend/src/components/cfdtables/CfdTable.tsx
+++ b/frontend/src/components/cfdtables/CfdTable.tsx
@@ -187,9 +187,9 @@ export function CfdTable(
 
 function iconForAction(action: Action): any {
     switch (action) {
-        case Action.ACCEPT:
+        case Action.ACCEPT_ORDER:
             return <CheckIcon />;
-        case Action.REJECT:
+        case Action.REJECT_ORDER:
             return <CloseIcon />;
         case Action.COMMIT:
             return <WarningIcon />;
@@ -200,9 +200,9 @@ function iconForAction(action: Action): any {
 
 function colorSchemaForAction(action: Action): string {
     switch (action) {
-        case Action.ACCEPT:
+        case Action.ACCEPT_ORDER:
             return "green";
-        case Action.REJECT:
+        case Action.REJECT_ORDER:
             return "red";
         case Action.COMMIT:
             return "red";


### PR DESCRIPTION
Keep track of outgoing/incoming settlement proposals in a hashmap inside the CFD
rocket that is available as a Rocket state in order to derive correct CfdState
for the UI.

Add placeholders for actions for accepting/rejecting settlement offers in the maker.

Also:
    - rename Accept/Reject in few places to reduce ambiguity between interacting
      with an order and a settlement proposal.
    - allow only one in-flight settlement proposal from the taker