### PR TITLE
Stop CfdTable from refreshing

### DIFF
--- a/frontend/src/components/cfdtables/CfdTable.tsx
+++ b/frontend/src/components/cfdtables/CfdTable.tsx
@@ -269,6 +269,9 @@ export function Table({ columns, tableData, hiddenColumns, renderDetails }: Tabl
             initialState: {
                 hiddenColumns,
             },
+            // @ts-ignore: this field exists and it works as expected.
+            autoResetExpanded: false,
+            autoResetSortBy: false,
         },
         useSortBy,
         useExpanded,


### PR DESCRIPTION
CfdTable uses react-table which resets its state if the data sources changes. We don't want some state to reset, e.g. sorting and un-expanding because that will mess with the user if the table suddenly changes.

Note: it looks like that the provided types are missing this field. It's been tested and it works as expected but we need to @ts-ignore because tsc would complain.

resolves #165