### PR TITLE
Use blue instead of red for sell positions

### DIFF
--- a/frontend/src/components/Types.tsx
+++ b/frontend/src/components/Types.tsx
@@ -19,7 +19,7 @@ export class Position {
             case PositionKey.BUY:
                 return "green";
             case PositionKey.SELL:
-                return "red";
+                return "blue";
         }
     }
 }


### PR DESCRIPTION
Red colour is best used for drawing attention to unusual things or marking a
hazardous action.
Sell positions on the maker side are an expected & common thing, so there is no
need for the sell positions to stand out.