### PR TITLE
Make expand row explicit

### DIFF
--- a/frontend/src/components/cfdtables/CfdTable.tsx
+++ b/frontend/src/components/cfdtables/CfdTable.tsx
@@ -65,7 +65,7 @@ export function CfdTable(
                 id: "expander",
                 Header: () => null,
                 Cell: ({ row }: any) => (
-                    <span {...row.getToggleRowExpandedProps()}>
+                    <span>
                         {row.isExpanded
                             ? <IconButton
                                 aria-label="Reduce"
@@ -319,9 +319,6 @@ export function Table({ columns, tableData, hiddenColumns, renderDetails }: Tabl
                             <React.Fragment key={row.id}>
                                 <Tr
                                     {...row.getRowProps()}
-                                    onClick={() =>
-                                        // @ts-ignore
-                                        row.toggleRowExpanded()}
                                 >
                                     {row.cells.map((cell) => (
                                         // @ts-ignore


### PR DESCRIPTION
By removing the onclick handler on the table row, clicking any button in the row does not fire the onclick handler of the row as well.
This has the effect that for expanding the row you need to click the expand button.