### PR TITLE
Optimise data structure used for settlement proposals

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -114,7 +114,7 @@ async fn main() -> Result<()> {
     let (order_feed_sender, order_feed_receiver) = watch::channel::<Option<Order>>(None);
     let (wallet_feed_sender, wallet_feed_receiver) = watch::channel::<WalletInfo>(wallet_info);
     let (settlement_feed_sender, settlement_feed_receiver) =
-        watch::channel::<SettlementProposals>(SettlementProposals::Incoming(HashMap::new()));
+        watch::channel::<SettlementProposals>(HashMap::new());
 
     let figment = rocket::Config::figment()
         .merge(("databases.maker.url", data_dir.join("maker.sqlite")))

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -355,11 +355,13 @@ pub struct SettlementProposal {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Variants used by different binaries
-pub enum SettlementProposals {
-    Incoming(HashMap<OrderId, SettlementProposal>),
-    Outgoing(HashMap<OrderId, SettlementProposal>),
+#[allow(dead_code)] // Variants (for now) used by different binaries.
+pub enum SettlementKind {
+    Incoming,
+    Outgoing,
 }
+
+pub type SettlementProposals = HashMap<OrderId, (SettlementProposal, SettlementKind)>;
 
 /// Represents a cfd (including state)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<()> {
     let (order_feed_sender, order_feed_receiver) = watch::channel::<Option<Order>>(None);
     let (wallet_feed_sender, wallet_feed_receiver) = watch::channel::<WalletInfo>(wallet_info);
     let (settlement_feed_sender, settlement_feed_receiver) =
-        watch::channel::<SettlementProposals>(SettlementProposals::Outgoing(HashMap::new()));
+        watch::channel::<SettlementProposals>(HashMap::new());
 
     let (read, write) = loop {
         let socket = tokio::net::TcpSocket::new_v4()?;


### PR DESCRIPTION
New HashMap can store both incoming and outgoing settlement proposals at the
same time and resulted in some code simplification, as there are less types
needed to convey the intention.

Provide a type alias for convenience (this also ensures that both binaries store
settlement proposals in the same way)