### PR TITLE
Fix `payout_curve::calculate` dummy implementation

### DIFF
--- a/daemon/src/payout_curve.rs
+++ b/daemon/src/payout_curve.rs
@@ -17,9 +17,9 @@ pub fn calculate(
             maker_payin + taker_payin,
             bitcoin::Amount::ZERO,
         )?,
-        generate_payouts((dollars - 10)..=(dollars + 10), maker_payin, taker_payin)?,
+        generate_payouts((dollars - 9)..=(dollars + 10), maker_payin, taker_payin)?,
         generate_payouts(
-            (dollars + 10)..=MAX_PRICE_DEC,
+            (dollars + 11)..=MAX_PRICE_DEC,
             bitcoin::Amount::ZERO,
             maker_payin + taker_payin,
         )?,

--- a/daemon/src/payout_curve.rs
+++ b/daemon/src/payout_curve.rs
@@ -2,7 +2,7 @@ use crate::model::{Leverage, Usd};
 use anyhow::Result;
 use bdk::bitcoin;
 use cfd_protocol::interval::MAX_PRICE_DEC;
-use cfd_protocol::Payout;
+use cfd_protocol::{generate_payouts, Payout};
 
 pub fn calculate(
     price: Usd,
@@ -12,13 +12,13 @@ pub fn calculate(
 ) -> Result<Vec<Payout>> {
     let dollars = price.try_into_u64()?;
     let payouts = vec![
-        Payout::new(
+        generate_payouts(
             0..=(dollars - 10),
             maker_payin + taker_payin,
             bitcoin::Amount::ZERO,
         )?,
-        Payout::new((dollars - 10)..=(dollars + 10), maker_payin, taker_payin)?,
-        Payout::new(
+        generate_payouts((dollars - 10)..=(dollars + 10), maker_payin, taker_payin)?,
+        generate_payouts(
             (dollars + 10)..=MAX_PRICE_DEC,
             bitcoin::Amount::ZERO,
             maker_payin + taker_payin,


### PR DESCRIPTION
A compiler error slipped in #181. 

I also added an extra minor fix with https://github.com/comit-network/hermes/commit/62c8ffb65b796a7a41e76c91b947e20c0fe24530.