### PR TITLE
Handle collab settlement response from the maker

### DIFF
--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -22,6 +22,8 @@ pub enum TakerCommand {
     NotifyInvalidOrderId { id: OrderId },
     NotifyOrderAccepted { id: OrderId },
     NotifyOrderRejected { id: OrderId },
+    NotifySettlementAccepted { id: OrderId },
+    NotifySettlementRejected { id: OrderId },
     Protocol(wire::SetupMsg),
 }
 
@@ -92,6 +94,14 @@ impl Actor {
             }
             TakerCommand::NotifyOrderRejected { id } => {
                 self.send_to_taker(msg.taker_id, wire::MakerToTaker::RejectOrder(id))
+                    .await?;
+            }
+            TakerCommand::NotifySettlementAccepted { id } => {
+                self.send_to_taker(msg.taker_id, wire::MakerToTaker::ConfirmSettlement(id))
+                    .await?;
+            }
+            TakerCommand::NotifySettlementRejected { id } => {
+                self.send_to_taker(msg.taker_id, wire::MakerToTaker::RejectSettlement(id))
                     .await?;
             }
             TakerCommand::Protocol(setup_msg) => {

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -58,6 +58,8 @@ pub enum MakerToTaker {
     CurrentOrder(Option<Order>),
     ConfirmOrder(OrderId), // TODO: Include payout curve in "accept" message from maker
     RejectOrder(OrderId),
+    ConfirmSettlement(OrderId),
+    RejectSettlement(OrderId),
     InvalidOrderId(OrderId),
     Protocol(SetupMsg),
 }
@@ -68,6 +70,8 @@ impl fmt::Display for MakerToTaker {
             MakerToTaker::CurrentOrder(_) => write!(f, "CurrentOrder"),
             MakerToTaker::ConfirmOrder(_) => write!(f, "ConfirmOrder"),
             MakerToTaker::RejectOrder(_) => write!(f, "RejectOrder"),
+            MakerToTaker::ConfirmSettlement(_) => write!(f, "ConfirmSettlement"),
+            MakerToTaker::RejectSettlement(_) => write!(f, "RejectSettlement"),
             MakerToTaker::InvalidOrderId(_) => write!(f, "InvalidOrderId"),
             MakerToTaker::Protocol(_) => write!(f, "Protocol"),
         }


### PR DESCRIPTION
- store TakerId for proposals to be able to respond to specific taker about
  settlement proposal when the user takes action
- send the collab settlement response (accept or reject) from the maker
- handle rejection (remove from the map), CFD state in the UI returns to "Open"