### PR TITLE
Remove the spread

### DIFF
--- a/frontend/src/MakerApp.tsx
+++ b/frontend/src/MakerApp.tsx
@@ -28,8 +28,6 @@ import { Cfd, intoCfd, intoOrder, Order, PriceInfo, StateGroupKey, WalletInfo } 
 import Wallet from "./components/Wallet";
 import { CfdSellOrderPayload, postCfdSellOrderRequest } from "./MakerClient";
 
-const SPREAD = 1.03;
-
 export default function App() {
     let source = useEventSource({ source: "/api/feed", options: { withCredentials: true } });
 
@@ -47,7 +45,7 @@ export default function App() {
 
     useEffect(() => {
         if (autoRefresh && priceInfo) {
-            setOrderPrice((priceInfo.ask * SPREAD).toFixed(2).toString());
+            setOrderPrice((priceInfo.ask).toFixed(2).toString());
         }
     }, [priceInfo, autoRefresh]);
 


### PR DESCRIPTION
It does not make sense to put a spread on top of the price; this just results in a shitty UX, because the user always starts with a loss.
We need proper interest on top of the amount, i.e. a fixed rate that the maker always gets that is independent of the price.