### PR TITLE
Make HTTP listen address configurable

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -12,6 +12,7 @@ use model::WalletInfo;
 use rocket::fairing::AdHoc;
 use rocket_db_pools::Database;
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::task::Poll;
@@ -54,9 +55,9 @@ struct Opts {
     #[clap(long, default_value = "9999")]
     p2p_port: u16,
 
-    /// The port to listen on for the HTTP API.
-    #[clap(long, default_value = "8001")]
-    http_port: u16,
+    /// The IP address to listen on for the HTTP API.
+    #[clap(long, default_value = "127.0.0.1:8001")]
+    http_address: SocketAddr,
 
     /// Where to permanently store data, defaults to the current working directory.
     #[clap(long)]
@@ -171,7 +172,8 @@ async fn main() -> Result<()> {
 
     let figment = rocket::Config::figment()
         .merge(("databases.maker.url", data_dir.join("maker.sqlite")))
-        .merge(("port", opts.http_port));
+        .merge(("address", opts.http_address.ip()))
+        .merge(("port", opts.http_address.port()));
 
     let listener = tokio::net::TcpListener::bind(&format!("0.0.0.0:{}", opts.p2p_port)).await?;
     let local_addr = listener.local_addr().unwrap();

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -57,9 +57,9 @@ struct Opts {
     #[clap(long, default_value = "127.0.0.1:9999")]
     maker: SocketAddr,
 
-    /// The port to listen on for the HTTP API.
-    #[clap(long, default_value = "8000")]
-    http_port: u16,
+    /// The IP address to listen on for the HTTP API.
+    #[clap(long, default_value = "127.0.0.1:8000")]
+    http_address: SocketAddr,
 
     /// Where to permanently store data, defaults to the current working directory.
     #[clap(long)]
@@ -180,7 +180,8 @@ async fn main() -> Result<()> {
 
     let figment = rocket::Config::figment()
         .merge(("databases.taker.url", data_dir.join("taker.sqlite")))
-        .merge(("port", opts.http_port));
+        .merge(("address", opts.http_address.ip()))
+        .merge(("port", opts.http_address.port()));
 
     rocket::custom(figment)
         .manage(order_feed_receiver)


### PR DESCRIPTION
Maker and taker by default only listened on localhost:XXXX. Given our architecture it is very likely that the taker and maker might run on remote machine. 