### PR TITLE
Transition `PendingOpen` to `PendingOpen` upon attestation

### DIFF
--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -741,7 +741,14 @@ impl Cfd {
                 }
             }
             CfdStateChangeEvent::OracleAttestation(attestation) => match self.state.clone() {
-                CfdState::PendingOpen { dlc, .. } | CfdState::Open { dlc, .. } => CfdState::Open {
+                CfdState::PendingOpen { dlc, .. } => CfdState::PendingOpen {
+                    common: CfdStateCommon {
+                        transition_timestamp: SystemTime::now(),
+                    },
+                    dlc,
+                    attestation: Some(attestation),
+                },
+                CfdState::Open { dlc, .. } => CfdState::Open {
                     common: CfdStateCommon {
                         transition_timestamp: SystemTime::now(),
                     },


### PR DESCRIPTION
In a real-world scenario this should actually never happen, but it is still weird to see `PendingOpen` jump to `Open` when testing with timelocks and attestations.
Since this is "more correct" we distinguish fine-granular.