### PR TITLE
Only fetch announcements when needed

### DIFF
--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -590,7 +590,7 @@ impl Actor {
             .with_context(|| format!("Announcement {} not found", cfd.order.oracle_event_id))?;
 
         self.oracle_actor
-            .do_send_async(oracle::MonitorEvent {
+            .do_send_async(oracle::MonitorAttestation {
                 event_id: offer_announcement.id.clone(),
             })
             .await?;
@@ -781,7 +781,7 @@ impl Actor {
             .await?;
 
         self.oracle_actor
-            .do_send_async(oracle::MonitorEvent {
+            .do_send_async(oracle::MonitorAttestation {
                 event_id: announcement.id.clone(),
             })
             .await?;

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -198,6 +198,10 @@ impl Actor {
         let oracle_event_id =
             oracle::next_announcement_after(time::OffsetDateTime::now_utc() + Order::TERM)?;
 
+        self.oracle_actor
+            .do_send_async(oracle::FetchAnnouncement(oracle_event_id.clone()))
+            .await?;
+
         let order = Order::new(
             price,
             min_quantity,
@@ -599,7 +603,7 @@ impl Actor {
                 })
             }),
             receiver,
-            (self.oracle_pk, offer_announcement.clone().into()),
+            (self.oracle_pk, offer_announcement),
             cfd,
             self.wallet.clone(),
             Role::Maker,

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -34,7 +34,7 @@ pub struct Sync;
 #[derive(Debug, Clone)]
 pub struct FetchAnnouncement(pub OracleEventId);
 
-pub struct MonitorEvent {
+pub struct MonitorAttestation {
     pub event_id: OracleEventId,
 }
 
@@ -214,8 +214,8 @@ where
 }
 
 #[async_trait]
-impl<CFD: 'static, M: 'static> xtra::Handler<MonitorEvent> for Actor<CFD, M> {
-    async fn handle(&mut self, msg: MonitorEvent, _ctx: &mut xtra::Context<Self>) {
+impl<CFD: 'static, M: 'static> xtra::Handler<MonitorAttestation> for Actor<CFD, M> {
+    async fn handle(&mut self, msg: MonitorAttestation, _ctx: &mut xtra::Context<Self>) {
         if !self.pending_attestations.insert(msg.event_id.clone()) {
             tracing::trace!("Attestation {} already being monitored", msg.event_id);
         }
@@ -320,7 +320,7 @@ where
 impl xtra::Message for Sync {
     type Result = ();
 }
-impl xtra::Message for MonitorEvent {
+impl xtra::Message for MonitorAttestation {
     type Result = ();
 }
 

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -32,7 +32,7 @@ use std::ops::RangeInclusive;
 pub async fn new(
     mut sink: impl Sink<SetupMsg, Error = anyhow::Error> + Unpin,
     mut stream: impl FusedStream<Item = SetupMsg> + Unpin,
-    (oracle_pk, announcement): (schnorrsig::PublicKey, Announcement),
+    (oracle_pk, announcement): (schnorrsig::PublicKey, oracle::Announcement),
     cfd: Cfd,
     wallet: Wallet,
     role: Role,
@@ -74,7 +74,7 @@ pub async fn new(
     }
 
     let payouts = HashMap::from_iter([(
-        announcement.clone(),
+        announcement.into(),
         payout_curve::calculate(cfd.order.price, cfd.quantity_usd, cfd.order.leverage)?,
     )]);
 

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -293,7 +293,7 @@ impl Actor {
             .with_context(|| format!("Announcement {} not found", cfd.order.oracle_event_id))?;
 
         self.oracle_actor
-            .do_send_async(oracle::MonitorEvent {
+            .do_send_async(oracle::MonitorAttestation {
                 event_id: offer_announcement.id.clone(),
             })
             .await?;
@@ -402,7 +402,7 @@ impl Actor {
             .with_context(|| format!("Announcement {} not found", oracle_event_id))?;
 
         self.oracle_actor
-            .do_send_async(oracle::MonitorEvent {
+            .do_send_async(oracle::MonitorAttestation {
                 event_id: announcement.id.clone(),
             })
             .await?;


### PR DESCRIPTION
Fixes #275.

I think this is what you meant with #275, @thomaseizinger. It does result in immediately deleting some code you wrote in #279. I do think we'll end up reintroducing it once we actually use more than one oracle event per CFD, but it seems unnecessary to keep it around until then. Let me know if you disagree.