### PR TITLE
Fetch attestations only when it is time

### DIFF
--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -1,5 +1,5 @@
 use crate::model::cfd::{Cfd, CfdState, Order, OrderId, Origin};
-use crate::model::{Leverage, OracleEventId, Position};
+use crate::model::{BitMexPriceEventId, Leverage, Position};
 use anyhow::{Context, Result};
 use rocket_db_pools::sqlx;
 use sqlx::pool::PoolConnection;
@@ -88,7 +88,7 @@ pub async fn load_order_by_id(
     let creation_timestamp = serde_json::from_str(row.creation_timestamp.as_str()).unwrap();
     let term = serde_json::from_str(row.term.as_str()).unwrap();
     let origin = serde_json::from_str(row.origin.as_str()).unwrap();
-    let oracle_event_id = OracleEventId(row.oracle_event_id);
+    let oracle_event_id = BitMexPriceEventId(row.oracle_event_id);
 
     Ok(Order {
         id: uuid,
@@ -299,7 +299,7 @@ pub async fn load_cfd_by_order_id(
     let creation_timestamp = serde_json::from_str(row.creation_timestamp.as_str()).unwrap();
     let term = serde_json::from_str(row.term.as_str()).unwrap();
     let origin: Origin = serde_json::from_str(row.origin.as_str()).unwrap();
-    let oracle_event_id = OracleEventId(row.oracle_event_id.clone());
+    let oracle_event_id = BitMexPriceEventId(row.oracle_event_id.clone());
 
     let quantity = serde_json::from_str(row.quantity_usd.as_str()).unwrap();
     let latest_state = serde_json::from_str(row.state.as_str()).unwrap();
@@ -377,7 +377,7 @@ pub async fn load_all_cfds(conn: &mut PoolConnection<Sqlite>) -> anyhow::Result<
             let creation_timestamp = serde_json::from_str(row.creation_timestamp.as_str()).unwrap();
             let term = serde_json::from_str(row.term.as_str()).unwrap();
             let origin: Origin = serde_json::from_str(row.origin.as_str()).unwrap();
-            let oracle_event_id = OracleEventId(row.oracle_event_id.clone());
+            let oracle_event_id = BitMexPriceEventId(row.oracle_event_id.clone());
 
             let quantity = serde_json::from_str(row.quantity_usd.as_str()).unwrap();
             let latest_state = serde_json::from_str(row.state.as_str()).unwrap();
@@ -410,7 +410,7 @@ pub async fn load_all_cfds(conn: &mut PoolConnection<Sqlite>) -> anyhow::Result<
 
 /// Loads all CFDs with the latest state as the CFD state
 pub async fn load_cfds_by_oracle_event_id(
-    oracle_event_id: OracleEventId,
+    oracle_event_id: BitMexPriceEventId,
     conn: &mut PoolConnection<Sqlite>,
 ) -> anyhow::Result<Vec<Cfd>> {
     let rows = sqlx::query!(
@@ -462,7 +462,7 @@ pub async fn load_cfds_by_oracle_event_id(
             let creation_timestamp = serde_json::from_str(row.creation_timestamp.as_str()).unwrap();
             let term = serde_json::from_str(row.term.as_str()).unwrap();
             let origin: Origin = serde_json::from_str(row.origin.as_str()).unwrap();
-            let oracle_event_id = OracleEventId(row.oracle_event_id.clone());
+            let oracle_event_id = BitMexPriceEventId(row.oracle_event_id.clone());
 
             let quantity = serde_json::from_str(row.quantity_usd.as_str()).unwrap();
             let latest_state = serde_json::from_str(row.state.as_str()).unwrap();
@@ -580,8 +580,8 @@ mod tests {
         let pool = setup_test_db().await;
         let mut conn = pool.acquire().await.unwrap();
 
-        let oracle_event_id_1 = OracleEventId("dummy_1".to_string());
-        let oracle_event_id_2 = OracleEventId("dummy_2".to_string());
+        let oracle_event_id_1 = BitMexPriceEventId("dummy_1".to_string());
+        let oracle_event_id_2 = BitMexPriceEventId("dummy_2".to_string());
 
         let cfd_1 = Cfd::default()
             .with_order(Order::default().with_oracle_event_id(oracle_event_id_1.clone()));
@@ -686,14 +686,14 @@ mod tests {
                 Usd(dec!(100)),
                 Usd(dec!(1000)),
                 Origin::Theirs,
-                OracleEventId("Dummy".to_string()),
+                BitMexPriceEventId("Dummy".to_string()),
             )
             .unwrap()
         }
     }
 
     impl Order {
-        pub fn with_oracle_event_id(mut self, oracle_event_id: OracleEventId) -> Self {
+        pub fn with_oracle_event_id(mut self, oracle_event_id: BitMexPriceEventId) -> Self {
             self.oracle_event_id = oracle_event_id;
             self
         }

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -652,8 +652,6 @@ mod tests {
         // file has to exist in order to connect with sqlite
         File::create(temp_db.clone()).unwrap();
 
-        dbg!(&temp_db);
-
         let pool = SqlitePool::connect(format!("sqlite:{}", temp_db.display()).as_str())
             .await
             .unwrap();

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -33,6 +33,7 @@ mod maker_cfd;
 mod maker_inc_connections;
 mod model;
 mod monitor;
+mod olivia;
 mod oracle;
 mod payout_curve;
 mod routes;

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -153,7 +153,7 @@ async fn main() -> Result<()> {
         ext_priv_key,
     )
     .await?;
-    let wallet_info = wallet.sync().await.unwrap();
+    let wallet_info = wallet.sync().await?;
 
     let auth_password = seed.derive_auth_password::<auth::Password>();
 
@@ -178,7 +178,12 @@ async fn main() -> Result<()> {
         .merge(("address", opts.http_address.ip()))
         .merge(("port", opts.http_address.port()));
 
-    let listener = tokio::net::TcpListener::bind(&format!("0.0.0.0:{}", opts.p2p_port)).await?;
+    let p2p_socket = format!("0.0.0.0:{}", opts.p2p_port)
+        .parse::<SocketAddr>()
+        .unwrap();
+    let listener = tokio::net::TcpListener::bind(p2p_socket)
+        .await
+        .with_context(|| format!("Failed to listen on {}", p2p_socket))?;
     let local_addr = listener.local_addr().unwrap();
 
     tracing::info!("Listening on {}", local_addr);

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -42,6 +42,7 @@ mod seed;
 mod send_to_socket;
 mod setup_contract;
 mod to_sse_event;
+mod tokio_ext;
 mod wallet;
 mod wallet_sync;
 mod wire;

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -200,7 +200,7 @@ impl Actor {
             oracle::next_announcement_after(time::OffsetDateTime::now_utc() + Order::TERM)?;
 
         self.oracle_actor
-            .do_send_async(oracle::FetchAnnouncement(oracle_event_id.clone()))
+            .do_send_async(oracle::FetchAnnouncement(oracle_event_id))
             .await?;
 
         let order = Order::new(
@@ -586,13 +586,13 @@ impl Actor {
 
         let offer_announcement = self
             .oracle_actor
-            .send(oracle::GetAnnouncement(cfd.order.oracle_event_id.clone()))
+            .send(oracle::GetAnnouncement(cfd.order.oracle_event_id))
             .await?
             .with_context(|| format!("Announcement {} not found", cfd.order.oracle_event_id))?;
 
         self.oracle_actor
             .do_send_async(oracle::MonitorAttestation {
-                event_id: offer_announcement.id.clone(),
+                event_id: offer_announcement.id,
             })
             .await?;
 
@@ -767,7 +767,7 @@ impl Actor {
             oracle::next_announcement_after(time::OffsetDateTime::now_utc() + Order::TERM)?;
         let announcement = self
             .oracle_actor
-            .send(oracle::GetAnnouncement(oracle_event_id.clone()))
+            .send(oracle::GetAnnouncement(oracle_event_id))
             .await?
             .with_context(|| format!("Announcement {} not found", oracle_event_id))?;
 
@@ -783,7 +783,7 @@ impl Actor {
 
         self.oracle_actor
             .do_send_async(oracle::MonitorAttestation {
-                event_id: announcement.id.clone(),
+                event_id: announcement.id,
             })
             .await?;
 
@@ -892,12 +892,12 @@ impl Actor {
         );
 
         let mut conn = self.db.acquire().await?;
-        let cfds = load_cfds_by_oracle_event_id(attestation.id.clone(), &mut conn).await?;
+        let cfds = load_cfds_by_oracle_event_id(attestation.id, &mut conn).await?;
 
         for mut cfd in cfds {
             if cfd
                 .handle(CfdStateChangeEvent::OracleAttestation(Attestation::new(
-                    attestation.id.clone(),
+                    attestation.id,
                     attestation.price,
                     attestation.scalars.clone(),
                     cfd.dlc()

--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -1,6 +1,6 @@
 use crate::actors::log_error;
 use crate::model::cfd::{Order, OrderId};
-use crate::model::{OracleEventId, TakerId};
+use crate::model::{BitMexPriceEventId, TakerId};
 use crate::{maker_cfd, send_to_socket, wire};
 use anyhow::{Context as AnyhowContext, Result};
 use async_trait::async_trait;
@@ -38,7 +38,7 @@ pub enum TakerCommand {
     },
     NotifyRollOverAccepted {
         id: OrderId,
-        oracle_event_id: OracleEventId,
+        oracle_event_id: BitMexPriceEventId,
     },
     NotifyRollOverRejected {
         id: OrderId,

--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -1,12 +1,9 @@
-use std::fmt::{Display, Formatter};
-
 use anyhow::{Context, Result};
+use bdk::bitcoin::{Address, Amount};
+use reqwest::Url;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-
-use bdk::bitcoin::{Address, Amount};
-use reqwest::Url;
 use std::fmt;
 use std::str::FromStr;
 use std::time::SystemTime;
@@ -46,8 +43,8 @@ impl Usd {
     }
 }
 
-impl Display for Usd {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Usd {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
@@ -61,8 +58,8 @@ impl From<Decimal> for Usd {
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Percent(pub Decimal);
 
-impl Display for Percent {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Percent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.round_dp(2).fmt(f)
     }
 }
@@ -96,8 +93,8 @@ impl Default for TakerId {
     }
 }
 
-impl Display for TakerId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for TakerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
@@ -121,8 +118,8 @@ impl BitMexPriceEventId {
     }
 }
 
-impl Display for BitMexPriceEventId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for BitMexPriceEventId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -135,6 +135,15 @@ impl BitMexPriceEventId {
         Self::new(timestamp, 20)
     }
 
+    /// Checks whether this event has likely already occurred.
+    ///
+    /// We can't be sure about it because our local clock might be off from the oracle's clock.
+    pub fn has_likely_occured(&self) -> bool {
+        let now = OffsetDateTime::now_utc();
+
+        now > self.timestamp
+    }
+
     pub fn to_olivia_url(self) -> Url {
         "https://h00.ooo"
             .parse::<Url>()
@@ -209,5 +218,13 @@ mod tests {
         let now = BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc());
 
         assert_eq!(now.timestamp.nanosecond(), 0);
+    }
+
+    #[test]
+    fn has_occured_if_in_the_past() {
+        let past_event =
+            BitMexPriceEventId::with_20_digits(datetime!(2021-09-23 10:00:00).assume_utc());
+
+        assert!(past_event.has_likely_occured());
     }
 }

--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -5,7 +5,6 @@ use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::str::FromStr;
 use std::time::SystemTime;
 use uuid::Uuid;
 
@@ -111,7 +110,8 @@ pub struct BitMexPriceEventId(pub String);
 
 impl BitMexPriceEventId {
     pub fn to_olivia_url(&self) -> Url {
-        Url::from_str("https://h00.ooo")
+        "https://h00.ooo"
+            .parse::<Url>()
             .expect("valid URL from constant")
             .join(self.0.as_str())
             .expect("Event id can be joined")
@@ -135,7 +135,9 @@ mod tests {
 
         assert_eq!(
             url,
-            Url::from_str("https://h00.ooo/x/BitMEX/BXBT/2021-09-23T10:00:00.price?n=20").unwrap()
+            "https://h00.ooo/x/BitMEX/BXBT/2021-09-23T10:00:00.price?n=20"
+                .parse()
+                .unwrap()
         );
     }
 }

--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -110,9 +110,9 @@ pub struct WalletInfo {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct OracleEventId(pub String);
+pub struct BitMexPriceEventId(pub String);
 
-impl OracleEventId {
+impl BitMexPriceEventId {
     pub fn to_olivia_url(&self) -> Url {
         Url::from_str("https://h00.ooo")
             .expect("valid URL from constant")
@@ -121,7 +121,7 @@ impl OracleEventId {
     }
 }
 
-impl Display for OracleEventId {
+impl Display for BitMexPriceEventId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
@@ -133,7 +133,7 @@ mod tests {
 
     #[test]
     fn to_olivia_url() {
-        let url = OracleEventId("/x/BitMEX/BXBT/2021-09-23T10:00:00.price?n=20".to_string())
+        let url = BitMexPriceEventId("/x/BitMEX/BXBT/2021-09-23T10:00:00.price?n=20".to_string())
             .to_olivia_url();
 
         assert_eq!(

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -1,4 +1,4 @@
-use crate::model::{Leverage, OracleEventId, Percent, Position, TakerId, TradingPair, Usd};
+use crate::model::{BitMexPriceEventId, Leverage, Percent, Position, TakerId, TradingPair, Usd};
 use crate::{monitor, oracle};
 use anyhow::{bail, Context, Result};
 use bdk::bitcoin::secp256k1::{SecretKey, Signature};
@@ -97,7 +97,7 @@ pub struct Order {
     /// The id of the event to be used for price attestation
     ///
     /// The maker includes this into the Order based on the Oracle announcement to be used.
-    pub oracle_event_id: OracleEventId,
+    pub oracle_event_id: BitMexPriceEventId,
 }
 
 #[allow(dead_code)] // Only one binary and the tests use this.
@@ -109,7 +109,7 @@ impl Order {
         min_quantity: Usd,
         max_quantity: Usd,
         origin: Origin,
-        oracle_event_id: OracleEventId,
+        oracle_event_id: BitMexPriceEventId,
     ) -> Result<Self> {
         let leverage = Leverage(2);
         let maintenance_margin_rate = dec!(0.005);
@@ -286,7 +286,7 @@ pub enum CfdState {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Attestation {
-    pub id: OracleEventId,
+    pub id: BitMexPriceEventId,
     pub scalars: Vec<SecretKey>,
     #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
     payout: Amount,
@@ -296,7 +296,7 @@ pub struct Attestation {
 
 impl Attestation {
     pub fn new(
-        id: OracleEventId,
+        id: BitMexPriceEventId,
         price: u64,
         scalars: Vec<SecretKey>,
         dlc: Dlc,
@@ -1483,7 +1483,7 @@ pub struct Dlc {
     /// The fully signed lock transaction ready to be published on chain
     pub lock: (Transaction, Descriptor<PublicKey>),
     pub commit: (Transaction, EcdsaAdaptorSignature, Descriptor<PublicKey>),
-    pub cets: HashMap<OracleEventId, Vec<Cet>>,
+    pub cets: HashMap<BitMexPriceEventId, Vec<Cet>>,
     pub refund: (Transaction, Signature),
 
     #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -1,6 +1,6 @@
 use crate::actors::log_error;
 use crate::model::cfd::{CetStatus, Cfd, CfdState, Dlc, OrderId};
-use crate::model::OracleEventId;
+use crate::model::BitMexPriceEventId;
 use crate::oracle::Attestation;
 use crate::{model, oracle};
 use anyhow::{Context, Result};
@@ -27,7 +27,7 @@ pub struct StartMonitoring {
 pub struct MonitorParams {
     lock: (Txid, Descriptor<PublicKey>),
     commit: (Txid, Descriptor<PublicKey>),
-    cets: HashMap<OracleEventId, Vec<Cet>>,
+    cets: HashMap<BitMexPriceEventId, Vec<Cet>>,
     refund: (Txid, Script, u32),
     revoked_commits: Vec<(Txid, Script)>,
 }
@@ -209,7 +209,7 @@ where
 
     fn monitor_cet_finality(
         &mut self,
-        cets: HashMap<OracleEventId, Vec<Cet>>,
+        cets: HashMap<BitMexPriceEventId, Vec<Cet>>,
         attestation: Attestation,
         order_id: OrderId,
     ) -> Result<()> {
@@ -581,8 +581,8 @@ impl From<model::cfd::Cet> for Cet {
 }
 
 fn map_cets(
-    cets: HashMap<OracleEventId, Vec<model::cfd::Cet>>,
-) -> HashMap<OracleEventId, Vec<Cet>> {
+    cets: HashMap<BitMexPriceEventId, Vec<model::cfd::Cet>>,
+) -> HashMap<BitMexPriceEventId, Vec<Cet>> {
     cets.into_iter()
         .map(|(event_id, cets)| {
             (

--- a/daemon/src/olivia.rs
+++ b/daemon/src/olivia.rs
@@ -1,0 +1,5 @@
+use time::format_description::FormatItem;
+use time::macros::format_description;
+
+pub const EVENT_TIME_FORMAT: &[FormatItem] =
+    format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]");

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -111,8 +111,9 @@ where
     CFD: 'static,
     M: 'static,
 {
-    async fn update_pending_announcements(&mut self, ctx: &mut xtra::Context<Self>) -> Result<()> {
+    fn update_pending_announcements(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("self to be alive");
+
         for event_id in self.pending_announcements.iter().cloned() {
             let this = this.clone();
             tokio::spawn(async move {
@@ -143,8 +144,6 @@ where
                 Ok(())
             });
         }
-
-        Ok(())
     }
 }
 
@@ -154,9 +153,7 @@ where
     M: xtra::Handler<Attestation>,
 {
     async fn update_state(&mut self, ctx: &mut xtra::Context<Self>) -> Result<()> {
-        self.update_pending_announcements(ctx)
-            .await
-            .context("failed to update pending announcements")?;
+        self.update_pending_announcements(ctx);
         self.update_pending_attestations()
             .await
             .context("failed to update pending attestations")?;

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -1,6 +1,7 @@
 use crate::actors::log_error;
 use crate::model::cfd::{Cfd, CfdState};
 use crate::model::BitMexPriceEventId;
+use crate::tokio_ext;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use cfd_protocol::secp256k1_zkp::{schnorrsig, SecretKey};
@@ -111,7 +112,7 @@ where
 
         for event_id in self.pending_announcements.iter().cloned() {
             let this = this.clone();
-            tokio::spawn(async move {
+            tokio_ext::spawn_fallible(async move {
                 let url = event_id.to_olivia_url();
 
                 tracing::debug!("Fetching announcement for {}", event_id);

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -1,5 +1,4 @@
 use crate::model::cfd::{Cet, Cfd, Dlc, RevokedCommit, Role};
-use crate::model::BitMexPriceEventId;
 use crate::wallet::Wallet;
 use crate::wire::{
     Msg0, Msg1, Msg2, RollOverMsg, RollOverMsg0, RollOverMsg1, RollOverMsg2, SetupMsg,
@@ -213,7 +212,7 @@ pub async fn new(
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;
-            Ok((BitMexPriceEventId(event_id), cets))
+            Ok((event_id.parse()?, cets))
         })
         .collect::<Result<HashMap<_, _>>>()?;
 
@@ -272,7 +271,7 @@ pub async fn roll_over(
     let payouts = HashMap::from_iter([(
         // TODO : we want to support multiple announcements
         Announcement {
-            id: announcement.id.0,
+            id: announcement.id.to_string(),
             nonce_pks: announcement.nonce_pks.clone(),
         },
         payout_curve::calculate(cfd.order.price, cfd.quantity_usd, cfd.order.leverage)?,
@@ -435,7 +434,7 @@ pub async fn roll_over(
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;
-            Ok((BitMexPriceEventId(event_id), cets))
+            Ok((event_id.parse()?, cets))
         })
         .collect::<Result<HashMap<_, _>>>()?;
 

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -1,5 +1,5 @@
 use crate::model::cfd::{Cet, Cfd, Dlc, RevokedCommit, Role};
-use crate::model::OracleEventId;
+use crate::model::BitMexPriceEventId;
 use crate::wallet::Wallet;
 use crate::wire::{
     Msg0, Msg1, Msg2, RollOverMsg, RollOverMsg0, RollOverMsg1, RollOverMsg2, SetupMsg,
@@ -213,7 +213,7 @@ pub async fn new(
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;
-            Ok((OracleEventId(event_id), cets))
+            Ok((BitMexPriceEventId(event_id), cets))
         })
         .collect::<Result<HashMap<_, _>>>()?;
 
@@ -435,7 +435,7 @@ pub async fn roll_over(
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;
-            Ok((OracleEventId(event_id), cets))
+            Ok((BitMexPriceEventId(event_id), cets))
         })
         .collect::<Result<HashMap<_, _>>>()?;
 

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -42,6 +42,7 @@ mod send_to_socket;
 mod setup_contract;
 mod taker_cfd;
 mod to_sse_event;
+mod tokio_ext;
 mod wallet;
 mod wallet_sync;
 mod wire;

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -32,6 +32,7 @@ mod keypair;
 mod logger;
 mod model;
 mod monitor;
+mod olivia;
 mod oracle;
 mod payout_curve;
 mod routes;

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -244,7 +244,7 @@ impl Actor {
                 order.origin = Origin::Theirs;
 
                 self.oracle_actor
-                    .do_send_async(oracle::FetchAnnouncement(order.oracle_event_id.clone()))
+                    .do_send_async(oracle::FetchAnnouncement(order.oracle_event_id))
                     .await?;
 
                 let mut conn = self.db.acquire().await?;
@@ -289,13 +289,13 @@ impl Actor {
 
         let offer_announcement = self
             .oracle_actor
-            .send(oracle::GetAnnouncement(cfd.order.oracle_event_id.clone()))
+            .send(oracle::GetAnnouncement(cfd.order.oracle_event_id))
             .await?
             .with_context(|| format!("Announcement {} not found", cfd.order.oracle_event_id))?;
 
         self.oracle_actor
             .do_send_async(oracle::MonitorAttestation {
-                event_id: offer_announcement.id.clone(),
+                event_id: offer_announcement.id,
             })
             .await?;
 
@@ -398,13 +398,13 @@ impl Actor {
 
         let announcement = self
             .oracle_actor
-            .send(oracle::GetAnnouncement(oracle_event_id.clone()))
+            .send(oracle::GetAnnouncement(oracle_event_id))
             .await?
             .with_context(|| format!("Announcement {} not found", oracle_event_id))?;
 
         self.oracle_actor
             .do_send_async(oracle::MonitorAttestation {
-                event_id: announcement.id.clone(),
+                event_id: announcement.id,
             })
             .await?;
 
@@ -633,12 +633,12 @@ impl Actor {
         );
 
         let mut conn = self.db.acquire().await?;
-        let cfds = load_cfds_by_oracle_event_id(attestation.id.clone(), &mut conn).await?;
+        let cfds = load_cfds_by_oracle_event_id(attestation.id, &mut conn).await?;
 
         for mut cfd in cfds {
             if cfd
                 .handle(CfdStateChangeEvent::OracleAttestation(Attestation::new(
-                    attestation.id.clone(),
+                    attestation.id,
                     attestation.price,
                     attestation.scalars.clone(),
                     cfd.dlc()

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -8,7 +8,7 @@ use crate::model::cfd::{
     Role, RollOverProposal, SettlementKind, SettlementProposal, UpdateCfdProposal,
     UpdateCfdProposals,
 };
-use crate::model::{OracleEventId, Usd};
+use crate::model::{BitMexPriceEventId, Usd};
 use crate::monitor::{self, MonitorParams};
 use crate::wallet::Wallet;
 use crate::wire::{MakerToTaker, RollOverMsg, SetupMsg};
@@ -380,7 +380,7 @@ impl Actor {
     async fn handle_roll_over_accepted(
         &mut self,
         order_id: OrderId,
-        oracle_event_id: OracleEventId,
+        oracle_event_id: BitMexPriceEventId,
         ctx: &mut Context<Self>,
     ) -> Result<()> {
         tracing::info!(%order_id, "Roll; over request got accepted");

--- a/daemon/src/tokio_ext.rs
+++ b/daemon/src/tokio_ext.rs
@@ -1,0 +1,14 @@
+use std::fmt;
+use std::future::Future;
+
+pub fn spawn_fallible<F, E>(future: F)
+where
+    F: Future<Output = Result<(), E>> + Send + 'static,
+    E: fmt::Display,
+{
+    tokio::spawn(async move {
+        if let Err(e) = future.await {
+            tracing::warn!("Task failed: {:#}", e);
+        }
+    });
+}

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -57,7 +57,9 @@ impl Wallet {
 
     pub async fn sync(&self) -> Result<WalletInfo> {
         let wallet = self.wallet.lock().await;
-        wallet.sync(NoopProgress, None)?;
+        wallet
+            .sync(NoopProgress, None)
+            .context("Failed to sync wallet")?;
 
         let balance = wallet.get_balance()?;
 

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -1,5 +1,5 @@
 use crate::model::cfd::OrderId;
-use crate::model::{OracleEventId, Usd};
+use crate::model::{BitMexPriceEventId, Usd};
 use crate::Order;
 use anyhow::{bail, Result};
 use bdk::bitcoin::secp256k1::Signature;
@@ -72,7 +72,7 @@ pub enum MakerToTaker {
     RollOverProtocol(RollOverMsg),
     ConfirmRollOver {
         order_id: OrderId,
-        oracle_event_id: OracleEventId,
+        oracle_event_id: BitMexPriceEventId,
     },
     RejectRollOver(OrderId),
 }


### PR DESCRIPTION
- Rename `OracleEventId`
- Refer to types within `fmt` module via module qualifier
- fixup! Refer to types within `fmt` module via module qualifier
- Prefer `.parse` over `FromStr` to avoid an import
- Properly model event IDs
- Fix typo
- Only fetch attestation that are likely to have occured
- Introduce drop-in replacement for tokio::spawn that logs errors
