### PR TITLE
Rename order price to offer price

### DIFF
--- a/frontend/src/MakerApp.tsx
+++ b/frontend/src/MakerApp.tsx
@@ -108,7 +108,7 @@ export default function App() {
                             value={format(maxQuantity)}
                         />
 
-                        <Text>Order Price:</Text>
+                        <Text>Offer Price:</Text>
                         <HStack>
                             <CurrencyInputField
                                 onChange={(valueString: string) => {


### PR DESCRIPTION
I want to trigger a new `preview` build and wasn't sure if there is another way. Looks like a last release build failed: https://github.com/comit-network/hermes/runs/3868563726?check_suite_focus=true
And I want to see if this was a glitch or if something else went wrong.