### PR TITLE
Use tokio_ext::spawn_fallible instead of log_error!

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -250,7 +250,6 @@ async fn main() -> Result<()> {
                             cfd_maker_actor_inbox.clone(),
                             cfds.clone(),
                         )
-                        .await
                         .unwrap(),
                     ),
                 );

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -415,7 +415,7 @@ impl Actor {
         tracing::info!("Lock transaction published with txid {}", txid);
 
         self.monitor_actor
-            .do_send_async(monitor::StartMonitoring {
+            .send(monitor::StartMonitoring {
                 id: order_id,
                 params: MonitorParams::from_dlc_and_timelocks(dlc, cfd.refund_timelock_in_blocks()),
             })
@@ -450,7 +450,7 @@ impl Actor {
         append_cfd_state(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;
 
         self.monitor_actor
-            .do_send_async(monitor::StartMonitoring {
+            .send(monitor::StartMonitoring {
                 id: order_id,
                 params: MonitorParams::from_dlc_and_timelocks(dlc, cfd.refund_timelock_in_blocks()),
             })
@@ -521,7 +521,7 @@ impl Actor {
         // 4. Remove current order
         self.current_order_id = None;
         self.takers
-            .do_send_async(maker_inc_connections::BroadcastOrder(None))
+            .send(maker_inc_connections::BroadcastOrder(None))
             .await?;
         self.order_feed_sender.send(None)?;
 
@@ -658,8 +658,9 @@ impl Actor {
 
         // Remove order for all
         self.current_order_id = None;
+
         self.takers
-            .do_send_async(maker_inc_connections::BroadcastOrder(None))
+            .send(maker_inc_connections::BroadcastOrder(None))
             .await?;
         self.order_feed_sender.send(None)?;
 

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -859,9 +859,10 @@ impl Actor {
 
 #[async_trait]
 impl Handler<CfdAction> for Actor {
-    async fn handle(&mut self, msg: CfdAction, ctx: &mut Context<Self>) {
+    async fn handle(&mut self, msg: CfdAction, ctx: &mut Context<Self>) -> Result<()> {
         use CfdAction::*;
-        if let Err(e) = match msg {
+
+        match msg {
             AcceptOrder { order_id } => self.handle_accept_order(order_id, ctx).await,
             RejectOrder { order_id } => self.handle_reject_order(order_id).await,
             AcceptSettlement { order_id } => self.handle_accept_settlement(order_id).await,
@@ -869,8 +870,6 @@ impl Handler<CfdAction> for Actor {
             AcceptRollOver { order_id } => self.handle_accept_roll_over(order_id, ctx).await,
             RejectRollOver { order_id } => self.handle_reject_roll_over(order_id).await,
             Commit { order_id } => self.handle_commit(order_id).await,
-        } {
-            tracing::error!("Message handler failed: {:#}", e);
         }
     }
 }
@@ -988,7 +987,7 @@ impl Message for CfdRollOverCompleted {
 }
 
 impl Message for CfdAction {
-    type Result = ();
+    type Result = Result<()>;
 }
 
 impl Message for FromTaker {

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -965,8 +965,8 @@ impl Handler<FromTaker> for Actor {
 
 #[async_trait]
 impl Handler<oracle::Attestation> for Actor {
-    async fn handle(&mut self, msg: oracle::Attestation, _ctx: &mut Context<Self>) {
-        log_error!(self.handle_oracle_attestation(msg))
+    async fn handle(&mut self, msg: oracle::Attestation, _ctx: &mut Context<Self>) -> Result<()> {
+        self.handle_oracle_attestation(msg).await
     }
 }
 

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -606,7 +606,7 @@ impl xtra::Message for Event {
 }
 
 impl xtra::Message for Sync {
-    type Result = ();
+    type Result = Result<()>;
 }
 
 impl<C> xtra::Actor for Actor<C> where C: Send + 'static {}
@@ -628,8 +628,8 @@ impl<C> xtra::Handler<Sync> for Actor<C>
 where
     C: bdk::electrum_client::ElectrumApi + Send + 'static,
 {
-    async fn handle(&mut self, _: Sync, _ctx: &mut xtra::Context<Self>) {
-        log_error!(self.sync());
+    async fn handle(&mut self, _: Sync, _ctx: &mut xtra::Context<Self>) -> Result<()> {
+        self.sync().await
     }
 }
 

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -307,14 +307,6 @@ where
         Ok(())
     }
 
-    async fn handle_oracle_attestation(&mut self, attestation: oracle::Attestation) -> Result<()> {
-        for (order_id, MonitorParams { cets, .. }) in self.cfds.clone().into_iter() {
-            self.monitor_cet_finality(cets, attestation.clone(), order_id)?;
-        }
-
-        Ok(())
-    }
-
     async fn update_state(
         &mut self,
         latest_block_height: BlockHeight,
@@ -633,12 +625,20 @@ where
     }
 }
 
-#[async_trait]
-impl xtra::Handler<oracle::Attestation> for Actor {
-    async fn handle(&mut self, msg: oracle::Attestation, _ctx: &mut xtra::Context<Self>) {
-        log_error!(self.handle_oracle_attestation(msg));
-    }
-}
+// #[async_trait]
+// impl xtra::Handler<oracle::Attestation> for Actor {
+//     async fn handle(
+//         &mut self,
+//         msg: oracle::Attestation,
+//         _ctx: &mut xtra::Context<Self>,
+//     ) -> Result<()> {
+//         for (order_id, MonitorParams { cets, .. }) in self.cfds.clone().into_iter() {
+//             self.monitor_cet_finality(cets, msg.clone(), order_id)?;
+//         }
+
+//         Ok(())
+//     }
+// }
 
 #[cfg(test)]
 mod tests {

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -44,7 +44,7 @@ pub struct Actor<C = bdk::electrum_client::Client> {
 }
 
 impl Actor<bdk::electrum_client::Client> {
-    pub async fn new(
+    pub fn new(
         electrum_rpc_url: &str,
         event_channel: impl StrongMessageChannel<Event> + 'static,
         cfds: Vec<Cfd>,

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -303,7 +303,7 @@ impl xtra::Message for GetAnnouncement {
 }
 
 impl xtra::Message for Attestation {
-    type Result = ();
+    type Result = Result<()>;
 }
 
 impl xtra::Message for NewAnnouncementFetched {

--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -148,58 +148,35 @@ pub fn post_cfd_action(
     action: CfdAction,
     cfd_action_channel: &State<Box<dyn MessageChannel<maker_cfd::CfdAction>>>,
     _auth: Authenticated,
-) -> Result<status::Accepted<()>, status::BadRequest<()>> {
+) -> Result<status::Accepted<()>, status::Custom<()>> {
     use maker_cfd::CfdAction::*;
-    match action {
-        CfdAction::AcceptOrder => {
-            cfd_action_channel
-                .do_send(AcceptOrder { order_id: id })
-                .expect("actor to always be available");
-        }
-        CfdAction::RejectOrder => {
-            cfd_action_channel
-                .do_send(RejectOrder { order_id: id })
-                .expect("actor to always be available");
-        }
+    let result = match action {
+        CfdAction::AcceptOrder => cfd_action_channel.do_send(AcceptOrder { order_id: id }),
+        CfdAction::RejectOrder => cfd_action_channel.do_send(RejectOrder { order_id: id }),
         CfdAction::AcceptSettlement => {
-            cfd_action_channel
-                .do_send(AcceptSettlement { order_id: id })
-                .expect("actor to always be available");
+            cfd_action_channel.do_send(AcceptSettlement { order_id: id })
         }
         CfdAction::RejectSettlement => {
-            cfd_action_channel
-                .do_send(RejectSettlement { order_id: id })
-                .expect("actor to always be available");
+            cfd_action_channel.do_send(RejectSettlement { order_id: id })
         }
-
-        CfdAction::AcceptRollOver => {
-            cfd_action_channel
-                .do_send(AcceptRollOver { order_id: id })
-                .expect("actor to always be available");
-        }
-        CfdAction::RejectRollOver => {
-            cfd_action_channel
-                .do_send(RejectRollOver { order_id: id })
-                .expect("actor to always be available");
-        }
-        CfdAction::Commit => {
-            cfd_action_channel
-                .do_send(Commit { order_id: id })
-                .expect("actor to always be available");
-        }
+        CfdAction::AcceptRollOver => cfd_action_channel.do_send(AcceptRollOver { order_id: id }),
+        CfdAction::RejectRollOver => cfd_action_channel.do_send(RejectRollOver { order_id: id }),
+        CfdAction::Commit => cfd_action_channel.do_send(Commit { order_id: id }),
         CfdAction::Settle => {
             tracing::error!("Collaborative settlement can only be triggered by taker");
 
-            return Err(status::BadRequest(None));
+            return Err(status::Custom(Status::BadRequest, ()));
         }
         CfdAction::RollOver => {
             tracing::error!("RollOver proposal can only be triggered by taker");
 
-            return Err(status::BadRequest(None));
+            return Err(status::Custom(Status::BadRequest, ()));
         }
-    }
+    };
 
-    Ok(status::Accepted(None))
+    result
+        .map(|()| status::Accepted(None))
+        .map_err(|_| status::Custom(Status::InternalServerError, ()))
 }
 
 #[rocket::get("/alive")]

--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -148,7 +148,7 @@ pub fn post_cfd_action(
     action: CfdAction,
     cfd_action_channel: &State<Box<dyn MessageChannel<maker_cfd::CfdAction>>>,
     _auth: Authenticated,
-) -> Result<status::Accepted<()>, status::BadRequest<String>> {
+) -> Result<status::Accepted<()>, status::BadRequest<()>> {
     use maker_cfd::CfdAction::*;
     match action {
         CfdAction::AcceptOrder => {
@@ -188,14 +188,14 @@ pub fn post_cfd_action(
                 .expect("actor to always be available");
         }
         CfdAction::Settle => {
-            return Err(status::BadRequest(Some(
-                "Collaborative settlement can only be triggered by taker".to_string(),
-            )));
+            tracing::error!("Collaborative settlement can only be triggered by taker");
+
+            return Err(status::BadRequest(None));
         }
         CfdAction::RollOver => {
-            return Err(status::BadRequest(Some(
-                "RollOver proposal can only be triggered by taker".to_string(),
-            )));
+            tracing::error!("RollOver proposal can only be triggered by taker");
+
+            return Err(status::BadRequest(None));
         }
     }
 

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -208,7 +208,7 @@ async fn main() -> Result<()> {
                     .create(None)
                     .spawn_global();
 
-                let (monitor_actor_address, mut monitor_actor_context) = xtra::Context::new(None);
+                let (monitor_actor_address, monitor_actor_context) = xtra::Context::new(None);
                 let (oracle_actor_address, mut oracle_actor_context) = xtra::Context::new(None);
 
                 let mut conn = db.acquire().await.unwrap();
@@ -231,11 +231,19 @@ async fn main() -> Result<()> {
                     .map(move |item| taker_cfd::MakerStreamMessage { item });
 
                 tokio::spawn(cfd_actor_inbox.clone().attach_stream(read));
-                tokio::spawn(
-                    monitor_actor_context
-                        .notify_interval(Duration::from_secs(20), || monitor::Sync)
-                        .unwrap(),
-                );
+                tokio::spawn({
+                    let monitor_actor_address = monitor_actor_address.clone();
+
+                    async move {
+                        while let Ok(result) = monitor_actor_address.send(monitor::Sync).await {
+                            if let Err(e) = result {
+                                tracing::warn!("Sync failed: {:#}", e);
+                            };
+
+                            tokio::time::sleep(Duration::from_secs(20)).await;
+                        }
+                    }
+                });
                 tokio::spawn(
                     monitor_actor_context.run(
                         monitor::Actor::new(

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -243,7 +243,6 @@ async fn main() -> Result<()> {
                             cfd_actor_inbox.clone(),
                             cfds.clone(),
                         )
-                        .await
                         .unwrap(),
                     ),
                 );

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -658,8 +658,8 @@ impl Handler<monitor::Event> for Actor {
 
 #[async_trait]
 impl Handler<oracle::Attestation> for Actor {
-    async fn handle(&mut self, msg: oracle::Attestation, _ctx: &mut Context<Self>) {
-        log_error!(self.handle_oracle_attestation(msg))
+    async fn handle(&mut self, msg: oracle::Attestation, _ctx: &mut Context<Self>) -> Result<()> {
+        self.handle_oracle_attestation(msg).await
     }
 }
 


### PR DESCRIPTION
Just an idea. What do you think @klochowicz ?

I think we can replace our `log_error!` usage with a combination of `send` and `spawn_fallible`.