### PR TITLE
Fix docker image build

### DIFF
--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -14,52 +14,42 @@ jobs:
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive_ext: tar
-            docker_platforms: linux/amd64
           - bin: taker
             target: armv7-unknown-linux-gnueabihf
             os: ubuntu-latest
             archive_ext: tar
-            docker_platforms: linux/arm/v7
           - bin: taker
             target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             archive_ext: tar
-            docker_platforms: linux/arm64
           - bin: taker
             target: x86_64-apple-darwin
             os: macos-latest
             archive_ext: tar
-            docker_platforms: None
           - bin: taker
             target: x86_64-pc-windows-msvc
             os: windows-latest
             archive_ext: zip
-            docker_platforms: None
           - bin: maker
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive_ext: tar
-            docker_platforms: linux/amd64
           - bin: maker
             target: armv7-unknown-linux-gnueabihf
             os: ubuntu-latest
             archive_ext: tar
-            docker_platforms: linux/arm64
           - bin: maker
             target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             archive_ext: tar
-            docker_platforms: linux/arm64
           - bin: maker
             target: x86_64-apple-darwin
             os: macos-latest
             archive_ext: tar
-            docker_platforms: None
           - bin: maker
             target: x86_64-pc-windows-msvc
             os: windows-latest
             archive_ext: zip
-            docker_platforms: None
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout tagged commit
@@ -155,28 +145,65 @@ jobs:
           asset_name: ${{ steps.create-archive-name.outputs.archive }}
           asset_content_type: application/gzip
 
+
+  build_docker_image:
+    needs: build_binaries
+    name: Build docker images
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v2.3.4
+        with:
+          ref: ${{ github.event.release.target_commitish }}
       - name: Set up QEMU
-        if: matrix.os != 'windows-latest' && matrix.os != 'macos-latest'
         uses: docker/setup-qemu-action@v1
 
-      - name: Set up Docker Buildx
-        if: matrix.os != 'windows-latest' && matrix.os != 'macos-latest'
+      - name: Set up docker buildx
         uses: docker/setup-buildx-action@v1
 
       - name: Login into github registry
         uses: docker/login-action@v1.10.0
-        if: matrix.os != 'windows-latest' && matrix.os != 'macos-latest'
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username:  ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and publish docker image
-        if: matrix.os != 'windows-latest' && matrix.os != 'macos-latest'
+      - name: Build and publish docker images
         run: |
+          gh release download ${{ github.event.release.tag_name }} -p '*Linux_x86_64*' -p '*aarch64*' -p '*armv7*'
+
+          # We need to extract into sub folders to so that our dockerimage can fine the binaries.
+          #
+          # By providing `platform` to `docker buildx` the variable `TARGETPLATFORM` will be available
+          # when building the image. This variable is either
+          # `linux/amd64/`, `linux/arm64/` or `linux/arm/v7`. Hence we need to extract into subfolders.
+
+          7z x maker_${{ github.event.release.tag_name }}_Linux_aarch64.tar -olinux/arm64/
+          7z x taker_${{ github.event.release.tag_name }}_Linux_aarch64.tar -olinux/arm64/
+
+          7z x maker_${{ github.event.release.tag_name }}_Linux_x86_64.tar -olinux/amd64/
+          7z x taker_${{ github.event.release.tag_name }}_Linux_x86_64.tar -olinux/amd64/
+
+          7z x maker_${{ github.event.release.tag_name }}_Linux_armv7.tar -olinux/arm/v7
+          7z x taker_${{ github.event.release.tag_name }}_Linux_armv7.tar -olinux/arm/v7
+
           docker buildx build \
-            --push \
-            --platform=${{ matrix.docker_platforms }} \
-            --tag ghcr.io/${{ github.actor }}/hermes-${{ matrix.bin }}-${{ matrix.target }} \
-            --build-arg BINARY_PATH=target/${{ matrix.target }}/release/${{ matrix.bin }} \
-            .
+              --push \
+              --platform linux/amd64,linux/arm64,linux/arm/v7 \
+              --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
+              --tag ghcr.io/${{ github.repository }}/maker:${{ github.event.release.tag_name }} \
+              --build-arg BINARY_PATH=maker \
+              .
+
+          docker buildx build \
+              --push \
+              --platform linux/amd64,linux/arm64,linux/arm/v7 \
+              --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
+              --tag ghcr.io/${{ github.repository }}/taker:${{ github.event.release.tag_name }} \
+              --build-arg BINARY_PATH=taker \
+              .
+
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM debian:bullseye-slim
 
+ARG TARGETPLATFORM
 ARG BINARY_PATH
-RUN echo "Copying $BINARY_PATH into container"
 
-COPY $BINARY_PATH hermes
+RUN echo "Copying $TARGETPLATFORM/$BINARY_PATH into container"
+
+COPY $TARGETPLATFORM/$BINARY_PATH hermes
 
 RUN chmod a+x hermes
 


### PR DESCRIPTION
The new task does a few things:
1. Having an extra build target makes the workflow file cleaner
2. it downloads the release targets which we want to build docker images for
3. it extracts the tar files into sub folders. We need to extract into sub folders to so that our image can fine the binaries. By providing `platform` to `docker buildx` the variable `TARGETPLATFORM` will be available when building the image. This variable is either `linux/amd64/`, `linux/arm64/` or `linux/arm/v7`. Hence we need to extract into subfolders.
4. We create 2 images, one for the maker and one for the taker. The images are then pushed to our organisation's docker registry.