### PR TITLE
Login as the repository

### DIFF
--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -167,7 +167,7 @@ jobs:
         uses: docker/login-action@v1.10.0
         with:
           registry: ghcr.io
-          username:  ${{ github.repository_owner }}
+          username:  ${{ github.repository }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish docker images

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           # First delete release + tag, ignore failures
           gh release delete preview || true
+          sleep 5
           gh api -X DELETE /repos/{owner}/{repo}/git/refs/tags/preview || true
-
+          sleep 5
           gh release create preview --prerelease --title preview


### PR DESCRIPTION
This allows us to publish to {orgname}/{reponame} i.e. comit-network/hermes/packages


Worked on my fork: https://github.com/bonomat/hermes/pkgs/container/hermes%2Fmaker