### PR TITLE
Collaborative close payout

### DIFF
--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -304,7 +304,7 @@ impl Actor {
         let (tx, sig_maker) = dlc.close_transaction(proposal)?;
 
         cfd.handle(CfdStateChangeEvent::ProposalSigned(
-            TimestampedTransaction::new(tx.clone()),
+            TimestampedTransaction::new(tx.clone(), dlc.script_pubkey_for(cfd.role())),
         ))?;
         insert_new_cfd_state_by_order_id(cfd.order.id, cfd.state.clone(), &mut conn).await?;
 
@@ -319,6 +319,7 @@ impl Actor {
 
         cfd.handle(CfdStateChangeEvent::CloseSent(TimestampedTransaction::new(
             spend_tx,
+            dlc.script_pubkey_for(cfd.role()),
         )))?;
         insert_new_cfd_state_by_order_id(cfd.order.id, cfd.state, &mut conn).await?;
 

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -370,9 +370,12 @@ impl Actor {
             .await?;
 
         cfd.handle(CfdStateChangeEvent::ProposalSigned(
-            TimestampedTransaction::new(tx),
+            TimestampedTransaction::new(tx, dlc.script_pubkey_for(cfd.role())),
         ))?;
         insert_new_cfd_state_by_order_id(cfd.order.id, cfd.state, &mut conn).await?;
+
+        self.cfd_feed_actor_inbox
+            .send(load_all_cfds(&mut conn).await?)?;
 
         self.remove_pending_proposal(&order_id)?;
 


### PR DESCRIPTION
Distinguish between collaborative close and cet closing.
Moved the payout on the `Cfd` which decides what the payout of the `Cfd` is, where

- `None` means the payout is not decided yet (we can optimize that and potentially combine this with `profit` in another iteration)
- `Some(payout)` can be a refund, collaborative or cet payout

Refund is handled in an early exit guard based on the state.
Collaborative settlement has priority over cet payout (attestation). In case there is a collaborative settlement present we always return payout based on that.

Note: I am not totally sure if collaborative close payout should always have priority over attestation payout. We could do a more complex reasoning about the state as well, but I felt for now this is probably good enough and we can adapt based on experience. Happy for other suggestions :)