### PR TITLE
Borrow CfdState when updating state in the database

### DIFF
--- a/daemon/src/housekeeping.rs
+++ b/daemon/src/housekeeping.rs
@@ -14,7 +14,7 @@ pub async fn transition_non_continue_cfds_to_setup_failed(
     for cfd in cfds.iter().filter(|cfd| Cfd::is_cleanup(cfd)) {
         insert_new_cfd_state_by_order_id(
             cfd.order.id,
-            CfdState::SetupFailed {
+            &CfdState::SetupFailed {
                 common: CfdStateCommon {
                     transition_timestamp: SystemTime::now(),
                 },

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -273,7 +273,7 @@ impl Actor {
         let mut conn = self.db.acquire().await?;
         insert_new_cfd_state_by_order_id(
             order_id,
-            CfdState::ContractSetup {
+            &CfdState::ContractSetup {
                 common: CfdStateCommon {
                     transition_timestamp: SystemTime::now(),
                 },
@@ -332,7 +332,7 @@ impl Actor {
         let mut conn = self.db.acquire().await?;
         insert_new_cfd_state_by_order_id(
             order_id,
-            CfdState::Rejected {
+            &CfdState::Rejected {
                 common: CfdStateCommon {
                     transition_timestamp: SystemTime::now(),
                 },
@@ -372,7 +372,7 @@ impl Actor {
         cfd.handle(CfdStateChangeEvent::ProposalSigned(
             TimestampedTransaction::new(tx),
         ))?;
-        insert_new_cfd_state_by_order_id(cfd.order.id, cfd.state, &mut conn).await?;
+        insert_new_cfd_state_by_order_id(cfd.order.id, &cfd.state, &mut conn).await?;
 
         self.remove_pending_proposal(&order_id)?;
 
@@ -498,7 +498,7 @@ impl Actor {
 
         insert_new_cfd_state_by_order_id(
             order_id,
-            CfdState::PendingOpen {
+            &CfdState::PendingOpen {
                 common: CfdStateCommon {
                     transition_timestamp: SystemTime::now(),
                 },
@@ -544,7 +544,7 @@ impl Actor {
         let mut conn = self.db.acquire().await?;
         insert_new_cfd_state_by_order_id(
             order_id,
-            CfdState::Open {
+            &CfdState::Open {
                 common: CfdStateCommon {
                     transition_timestamp: SystemTime::now(),
                 },
@@ -583,7 +583,7 @@ impl Actor {
             return Ok(());
         }
 
-        insert_new_cfd_state_by_order_id(order_id, cfd.state.clone(), &mut conn).await?;
+        insert_new_cfd_state_by_order_id(order_id, &cfd.state, &mut conn).await?;
 
         self.cfd_feed_actor_inbox
             .send(load_all_cfds(&mut conn).await?)?;
@@ -620,7 +620,7 @@ impl Actor {
             bail!("If we can get the commit tx we should be able to transition")
         }
 
-        insert_new_cfd_state_by_order_id(cfd.order.id, cfd.state.clone(), &mut conn).await?;
+        insert_new_cfd_state_by_order_id(cfd.order.id, &cfd.state, &mut conn).await?;
         self.cfd_feed_actor_inbox
             .send(load_all_cfds(&mut conn).await?)?;
 
@@ -658,7 +658,7 @@ impl Actor {
                 continue;
             }
 
-            insert_new_cfd_state_by_order_id(cfd.order.id, cfd.state.clone(), &mut conn).await?;
+            insert_new_cfd_state_by_order_id(cfd.order.id, &cfd.state, &mut conn).await?;
             self.cfd_feed_actor_inbox
                 .send(load_all_cfds(&mut conn).await?)?;
 
@@ -684,8 +684,7 @@ impl Actor {
                     bail!("If we can get the CET we should be able to transition")
                 }
 
-                insert_new_cfd_state_by_order_id(cfd.order.id, cfd.state.clone(), &mut conn)
-                    .await?;
+                insert_new_cfd_state_by_order_id(cfd.order.id, &cfd.state, &mut conn).await?;
 
                 self.cfd_feed_actor_inbox
                     .send(load_all_cfds(&mut conn).await?)?;


### PR DESCRIPTION
The function signature didn't need to take the whole state, as it was only
borrowed internally.

Removes the need for many `.clone()` calls sprinkled in the codebase.