### PR TITLE
Replace `Address` with `MessageChannel` in some key places

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -260,9 +260,11 @@ async fn main() -> Result<()> {
                         .unwrap(),
                 );
                 tokio::spawn(oracle_actor_context.run(oracle::Actor::new(
-                    cfd_maker_actor_inbox.clone(),
-                    monitor_actor_address,
                     cfds,
+                    [
+                        Box::new(cfd_maker_actor_inbox.clone()),
+                        Box::new(monitor_actor_address),
+                    ],
                 )));
 
                 oracle_actor_address

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -89,7 +89,7 @@ pub struct Actor {
     monitor_actor: Address<monitor::Actor>,
     setup_state: SetupState,
     roll_over_state: RollOverState,
-    oracle_actor: Address<oracle::Actor<Actor, monitor::Actor>>,
+    oracle_actor: Address<oracle::Actor>,
     // Maker needs to also store TakerId to be able to send a reply back
     current_pending_proposals: HashMap<OrderId, (UpdateCfdProposal, TakerId)>,
     // TODO: Persist instead of using an in-memory hashmap for resiliency?
@@ -125,7 +125,7 @@ impl Actor {
         update_cfd_feed_sender: watch::Sender<UpdateCfdProposals>,
         takers: Address<maker_inc_connections::Actor>,
         monitor_actor: Address<monitor::Actor>,
-        oracle_actor: Address<oracle::Actor<Actor, monitor::Actor>>,
+        oracle_actor: Address<oracle::Actor>,
     ) -> Self {
         Self {
             db,

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -86,10 +86,10 @@ pub struct Actor {
     update_cfd_feed_sender: watch::Sender<UpdateCfdProposals>,
     takers: Address<maker_inc_connections::Actor>,
     current_order_id: Option<OrderId>,
-    monitor_actor: Address<monitor::Actor<Actor>>,
+    monitor_actor: Address<monitor::Actor>,
     setup_state: SetupState,
     roll_over_state: RollOverState,
-    oracle_actor: Address<oracle::Actor<Actor, monitor::Actor<Actor>>>,
+    oracle_actor: Address<oracle::Actor<Actor, monitor::Actor>>,
     // Maker needs to also store TakerId to be able to send a reply back
     current_pending_proposals: HashMap<OrderId, (UpdateCfdProposal, TakerId)>,
     // TODO: Persist instead of using an in-memory hashmap for resiliency?
@@ -124,8 +124,8 @@ impl Actor {
         order_feed_sender: watch::Sender<Option<Order>>,
         update_cfd_feed_sender: watch::Sender<UpdateCfdProposals>,
         takers: Address<maker_inc_connections::Actor>,
-        monitor_actor: Address<monitor::Actor<Actor>>,
-        oracle_actor: Address<oracle::Actor<Actor, monitor::Actor<Actor>>>,
+        monitor_actor: Address<monitor::Actor>,
+        oracle_actor: Address<oracle::Actor<Actor, monitor::Actor>>,
     ) -> Self {
         Self {
             db,

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -254,9 +254,11 @@ async fn main() -> Result<()> {
                         .unwrap(),
                 );
                 tokio::spawn(oracle_actor_context.run(oracle::Actor::new(
-                    cfd_actor_inbox.clone(),
-                    monitor_actor_address,
                     cfds,
+                    [
+                        Box::new(cfd_actor_inbox.clone()),
+                        Box::new(monitor_actor_address),
+                    ],
                 )));
 
                 oracle_actor_address

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -80,7 +80,7 @@ pub struct Actor {
     monitor_actor: Address<monitor::Actor>,
     setup_state: SetupState,
     roll_over_state: RollOverState,
-    oracle_actor: Address<oracle::Actor<Actor, monitor::Actor>>,
+    oracle_actor: Address<oracle::Actor>,
     current_pending_proposals: UpdateCfdProposals,
 }
 
@@ -95,7 +95,7 @@ impl Actor {
         update_cfd_feed_sender: watch::Sender<UpdateCfdProposals>,
         send_to_maker: Address<send_to_socket::Actor<wire::TakerToMaker>>,
         monitor_actor: Address<monitor::Actor>,
-        oracle_actor: Address<oracle::Actor<Actor, monitor::Actor>>,
+        oracle_actor: Address<oracle::Actor>,
     ) -> Self {
         Self {
             db,

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -77,10 +77,10 @@ pub struct Actor {
     order_feed_actor_inbox: watch::Sender<Option<Order>>,
     update_cfd_feed_sender: watch::Sender<UpdateCfdProposals>,
     send_to_maker: Address<send_to_socket::Actor<wire::TakerToMaker>>,
-    monitor_actor: Address<monitor::Actor<Actor>>,
+    monitor_actor: Address<monitor::Actor>,
     setup_state: SetupState,
     roll_over_state: RollOverState,
-    oracle_actor: Address<oracle::Actor<Actor, monitor::Actor<Actor>>>,
+    oracle_actor: Address<oracle::Actor<Actor, monitor::Actor>>,
     current_pending_proposals: UpdateCfdProposals,
 }
 
@@ -94,8 +94,8 @@ impl Actor {
         order_feed_actor_inbox: watch::Sender<Option<Order>>,
         update_cfd_feed_sender: watch::Sender<UpdateCfdProposals>,
         send_to_maker: Address<send_to_socket::Actor<wire::TakerToMaker>>,
-        monitor_actor: Address<monitor::Actor<Actor>>,
-        oracle_actor: Address<oracle::Actor<Actor, monitor::Actor<Actor>>>,
+        monitor_actor: Address<monitor::Actor>,
+        oracle_actor: Address<oracle::Actor<Actor, monitor::Actor>>,
     ) -> Self {
         Self {
             db,


### PR DESCRIPTION
We may need to use `MessageChannel` instead of `Address` elsewhere (perhaps everywhere), but these definitely need to change.

---

Work towards #231.