### PR TITLE
Lock in profit on collaborative close price

### DIFF
--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -547,8 +547,6 @@ impl Cfd {
     }
 
     pub fn profit(&self, current_price: Usd) -> Result<(SignedAmount, Percent)> {
-        // TODO: We should use the payout curve here and not just the current price!
-
         let closing_price = match (self.attestation(), self.collaborative_close()) {
             (Some(_attestation), Some(collaborative_close)) => collaborative_close.price,
             (None, Some(collaborative_close)) => collaborative_close.price,

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -1,4 +1,4 @@
-use crate::model::cfd::{CetStatus, Cfd, CfdState, Dlc, OrderId, TimestampedTransaction};
+use crate::model::cfd::{CetStatus, Cfd, CfdState, CollaborativeSettlement, Dlc, OrderId};
 use crate::model::BitMexPriceEventId;
 use crate::oracle::Attestation;
 use crate::{log_error, model, oracle};
@@ -84,7 +84,7 @@ impl Actor<bdk::electrum_client::Client> {
                     actor.monitor_commit_refund_timelock(&params, cfd.order.id);
                     actor.monitor_refund_finality(&params,cfd.order.id);
 
-                    if let Some(TimestampedTransaction { tx, ..}
+                    if let Some(CollaborativeSettlement { tx, ..}
                     ) = cfd.state.get_collaborative_close()  {
                         let close_params = (tx.txid(),
                             tx.output.first().expect("have output").script_pubkey.clone());

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -3,8 +3,8 @@ use crate::db::{
     load_cfd_by_order_id, load_cfds_by_oracle_event_id, load_order_by_id,
 };
 use crate::model::cfd::{
-    Attestation, Cfd, CfdState, CfdStateChangeEvent, CfdStateCommon, Dlc, Order, OrderId, Origin,
-    Role, RollOverProposal, SettlementKind, SettlementProposal, TimestampedTransaction,
+    Attestation, Cfd, CfdState, CfdStateChangeEvent, CfdStateCommon, CollaborativeSettlement, Dlc,
+    Order, OrderId, Origin, Role, RollOverProposal, SettlementKind, SettlementProposal,
     UpdateCfdProposal, UpdateCfdProposals,
 };
 use crate::model::{BitMexPriceEventId, Usd};
@@ -204,6 +204,7 @@ impl Actor {
                 timestamp: proposal.timestamp,
                 taker: proposal.taker,
                 maker: proposal.maker,
+                price: proposal.price,
             })
             .await?;
         Ok(())
@@ -370,7 +371,7 @@ impl Actor {
             .await?;
 
         cfd.handle(CfdStateChangeEvent::ProposalSigned(
-            TimestampedTransaction::new(tx, dlc.script_pubkey_for(cfd.role())),
+            CollaborativeSettlement::new(tx, dlc.script_pubkey_for(cfd.role()), proposal.price),
         ))?;
         insert_new_cfd_state_by_order_id(cfd.order.id, &cfd.state, &mut conn).await?;
 

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -31,6 +31,7 @@ pub enum TakerToMaker {
         taker: Amount,
         #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
         maker: Amount,
+        price: Usd,
     },
     InitiateSettlement {
         order_id: OrderId,


### PR DESCRIPTION
fixes #312 

Once we have collaborative close present in the state(s) we lock in the profit based on the price of the collaborative close.
Note: Currently no automated validation on the maker side if the given amounts and price of collaborative settlement are sane.