### PR TITLE
Use `MessageChannels` in `maker_inc_connections::Actor`

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -234,7 +234,8 @@ async fn main() -> Result<()> {
 
                 tokio::spawn(
                     maker_inc_connections_context.run(maker_inc_connections::Actor::new(
-                        cfd_maker_actor_inbox.clone(),
+                        &cfd_maker_actor_inbox,
+                        &cfd_maker_actor_inbox,
                     )),
                 );
                 tokio::spawn(


### PR DESCRIPTION
We would have liked to attach the stream of `TakerStreamMessage`s directly to the `MessageChannel`, but we failed and instead decided to let the `maker_inc_connections::Actor` send these messages to itself and then forward them to the `maker_cfd::Actor`.

---

I wasted a lot of time trying to send the message directly to the `maker_cfd::Actor`. I trust that @thomaseizinger can find a way, but I had to give up :disappointed: 