### PR TITLE
Better DB tests and various cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,6 @@ dependencies = [
  "serde_with",
  "sha2",
  "sqlx",
- "tempfile",
  "thiserror",
  "time",
  "tokio",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -53,5 +53,4 @@ path = "src/maker.rs"
 
 [dev-dependencies]
 pretty_assertions = "1"
-tempfile = "3"
 time = { version = "0.3", features = ["std"] }

--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -11,7 +11,7 @@ pub async fn insert_cfd(
     conn: &mut PoolConnection<Sqlite>,
     update_sender: &watch::Sender<Vec<Cfd>>,
 ) -> Result<()> {
-    db::insert_cfd(cfd, conn).await?;
+    db::insert_cfd(&cfd, conn).await?;
     update_sender.send(db::load_all_cfds(conn).await?)?;
     Ok(())
 }

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -105,7 +105,7 @@ pub async fn load_order_by_id(
     })
 }
 
-pub async fn insert_cfd(cfd: Cfd, conn: &mut PoolConnection<Sqlite>) -> anyhow::Result<()> {
+pub async fn insert_cfd(cfd: &Cfd, conn: &mut PoolConnection<Sqlite>) -> anyhow::Result<()> {
     let mut tx = conn.begin().await?;
 
     let order_uuid = serde_json::to_string(&cfd.order.id)?;
@@ -528,7 +528,7 @@ mod tests {
         let cfd = Cfd::dummy();
 
         insert_order(&cfd.order, &mut conn).await.unwrap();
-        insert_cfd(cfd.clone(), &mut conn).await.unwrap();
+        insert_cfd(&cfd, &mut conn).await.unwrap();
 
         let cfds_from_db = load_all_cfds(&mut conn).await.unwrap();
         let cfd_from_db = cfds_from_db.first().unwrap().clone();
@@ -543,7 +543,7 @@ mod tests {
         let order_id = cfd.order.id;
 
         insert_order(&cfd.order, &mut conn).await.unwrap();
-        insert_cfd(cfd.clone(), &mut conn).await.unwrap();
+        insert_cfd(&cfd, &mut conn).await.unwrap();
 
         let cfd_from_db = load_cfd_by_order_id(order_id, &mut conn).await.unwrap();
         assert_eq!(cfd, cfd_from_db)
@@ -557,7 +557,7 @@ mod tests {
         let order_id = cfd.order.id;
 
         insert_order(&cfd.order, &mut conn).await.unwrap();
-        insert_cfd(cfd.clone(), &mut conn).await.unwrap();
+        insert_cfd(&cfd, &mut conn).await.unwrap();
 
         let cfd_from_db = load_cfd_by_order_id(order_id, &mut conn).await.unwrap();
         assert_eq!(cfd, cfd_from_db);
@@ -566,7 +566,7 @@ mod tests {
         let order_id = cfd.order.id;
 
         insert_order(&cfd.order, &mut conn).await.unwrap();
-        insert_cfd(cfd.clone(), &mut conn).await.unwrap();
+        insert_cfd(&cfd, &mut conn).await.unwrap();
 
         let cfd_from_db = load_cfd_by_order_id(order_id, &mut conn).await.unwrap();
         assert_eq!(cfd, cfd_from_db);
@@ -584,7 +584,7 @@ mod tests {
         let cfd_1 = Cfd::dummy().with_order(Order::dummy().with_oracle_event_id(oracle_event_id_1));
 
         insert_order(&cfd_1.order, &mut conn).await.unwrap();
-        insert_cfd(cfd_1.clone(), &mut conn).await.unwrap();
+        insert_cfd(&cfd_1, &mut conn).await.unwrap();
 
         let cfd_from_db = load_cfds_by_oracle_event_id(oracle_event_id_1, &mut conn)
             .await
@@ -594,7 +594,7 @@ mod tests {
         let cfd_2 = Cfd::dummy().with_order(Order::dummy().with_oracle_event_id(oracle_event_id_1));
 
         insert_order(&cfd_2.order, &mut conn).await.unwrap();
-        insert_cfd(cfd_2.clone(), &mut conn).await.unwrap();
+        insert_cfd(&cfd_2, &mut conn).await.unwrap();
 
         let cfd_from_db = load_cfds_by_oracle_event_id(oracle_event_id_1, &mut conn)
             .await
@@ -604,7 +604,7 @@ mod tests {
         let cfd_3 = Cfd::dummy().with_order(Order::dummy().with_oracle_event_id(oracle_event_id_2));
 
         insert_order(&cfd_3.order, &mut conn).await.unwrap();
-        insert_cfd(cfd_3.clone(), &mut conn).await.unwrap();
+        insert_cfd(&cfd_3, &mut conn).await.unwrap();
 
         let cfd_from_db = load_cfds_by_oracle_event_id(oracle_event_id_2, &mut conn)
             .await
@@ -619,7 +619,7 @@ mod tests {
         let mut cfd_1 = Cfd::dummy();
 
         insert_order(&cfd_1.order, &mut conn).await.unwrap();
-        insert_cfd(cfd_1.clone(), &mut conn).await.unwrap();
+        insert_cfd(&cfd_1, &mut conn).await.unwrap();
 
         cfd_1.state = CfdState::Accepted {
             common: CfdStateCommon {
@@ -639,7 +639,7 @@ mod tests {
         let mut cfd_2 = Cfd::dummy();
 
         insert_order(&cfd_2.order, &mut conn).await.unwrap();
-        insert_cfd(cfd_2.clone(), &mut conn).await.unwrap();
+        insert_cfd(&cfd_2, &mut conn).await.unwrap();
 
         let cfds_from_db = load_all_cfds(&mut conn).await.unwrap();
         assert_eq!(cfds_from_db.len(), 2);

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -514,9 +514,8 @@ mod tests {
     async fn test_insert_and_load_order() {
         let mut conn = setup_test_db().await;
 
-        let order = Order::default();
+        let order = Order::dummy();
         insert_order(&order, &mut conn).await.unwrap();
-
         let order_loaded = load_order_by_id(order.id, &mut conn).await.unwrap();
 
         assert_eq!(order, order_loaded);
@@ -526,7 +525,7 @@ mod tests {
     async fn test_insert_and_load_cfd() {
         let mut conn = setup_test_db().await;
 
-        let cfd = Cfd::default();
+        let cfd = Cfd::dummy();
 
         insert_order(&cfd.order, &mut conn).await.unwrap();
         insert_cfd(cfd.clone(), &mut conn).await.unwrap();
@@ -540,7 +539,7 @@ mod tests {
     async fn test_insert_and_load_cfd_by_order_id() {
         let mut conn = setup_test_db().await;
 
-        let cfd = Cfd::default();
+        let cfd = Cfd::dummy();
         let order_id = cfd.order.id;
 
         insert_order(&cfd.order, &mut conn).await.unwrap();
@@ -554,7 +553,7 @@ mod tests {
     async fn test_insert_and_load_cfd_by_order_id_multiple() {
         let mut conn = setup_test_db().await;
 
-        let cfd = Cfd::default();
+        let cfd = Cfd::dummy();
         let order_id = cfd.order.id;
 
         insert_order(&cfd.order, &mut conn).await.unwrap();
@@ -563,7 +562,7 @@ mod tests {
         let cfd_from_db = load_cfd_by_order_id(order_id, &mut conn).await.unwrap();
         assert_eq!(cfd, cfd_from_db);
 
-        let cfd = Cfd::default();
+        let cfd = Cfd::dummy();
         let order_id = cfd.order.id;
 
         insert_order(&cfd.order, &mut conn).await.unwrap();
@@ -582,8 +581,7 @@ mod tests {
         let oracle_event_id_2 =
             BitMexPriceEventId::with_20_digits(datetime!(2021-10-25 18:00:00).assume_utc());
 
-        let cfd_1 =
-            Cfd::default().with_order(Order::default().with_oracle_event_id(oracle_event_id_1));
+        let cfd_1 = Cfd::dummy().with_order(Order::dummy().with_oracle_event_id(oracle_event_id_1));
 
         insert_order(&cfd_1.order, &mut conn).await.unwrap();
         insert_cfd(cfd_1.clone(), &mut conn).await.unwrap();
@@ -593,8 +591,7 @@ mod tests {
             .unwrap();
         assert_eq!(vec![cfd_1.clone()], cfd_from_db);
 
-        let cfd_2 =
-            Cfd::default().with_order(Order::default().with_oracle_event_id(oracle_event_id_1));
+        let cfd_2 = Cfd::dummy().with_order(Order::dummy().with_oracle_event_id(oracle_event_id_1));
 
         insert_order(&cfd_2.order, &mut conn).await.unwrap();
         insert_cfd(cfd_2.clone(), &mut conn).await.unwrap();
@@ -604,8 +601,7 @@ mod tests {
             .unwrap();
         assert_eq!(vec![cfd_1, cfd_2], cfd_from_db);
 
-        let cfd_3 =
-            Cfd::default().with_order(Order::default().with_oracle_event_id(oracle_event_id_2));
+        let cfd_3 = Cfd::dummy().with_order(Order::dummy().with_oracle_event_id(oracle_event_id_2));
 
         insert_order(&cfd_3.order, &mut conn).await.unwrap();
         insert_cfd(cfd_3.clone(), &mut conn).await.unwrap();
@@ -620,7 +616,7 @@ mod tests {
     async fn test_insert_new_cfd_state_and_load_with_multiple_cfd() {
         let mut conn = setup_test_db().await;
 
-        let mut cfd_1 = Cfd::default();
+        let mut cfd_1 = Cfd::dummy();
 
         insert_order(&cfd_1.order, &mut conn).await.unwrap();
         insert_cfd(cfd_1.clone(), &mut conn).await.unwrap();
@@ -640,7 +636,7 @@ mod tests {
         let cfd_from_db = cfds_from_db.first().unwrap().clone();
         assert_eq!(cfd_1, cfd_from_db);
 
-        let mut cfd_2 = Cfd::default();
+        let mut cfd_2 = Cfd::dummy();
 
         insert_order(&cfd_2.order, &mut conn).await.unwrap();
         insert_cfd(cfd_2.clone(), &mut conn).await.unwrap();
@@ -682,10 +678,10 @@ mod tests {
         pool.acquire().await.unwrap()
     }
 
-    impl Default for Cfd {
-        fn default() -> Self {
+    impl Cfd {
+        fn dummy() -> Self {
             Cfd::new(
-                Order::default(),
+                Order::dummy(),
                 Usd(dec!(1000)),
                 CfdState::OutgoingOrderRequest {
                     common: CfdStateCommon {
@@ -694,17 +690,15 @@ mod tests {
                 },
             )
         }
-    }
 
-    impl Cfd {
-        pub fn with_order(mut self, order: Order) -> Self {
+        fn with_order(mut self, order: Order) -> Self {
             self.order = order;
             self
         }
     }
 
-    impl Default for Order {
-        fn default() -> Self {
+    impl Order {
+        fn dummy() -> Self {
             Order::new(
                 Usd(dec!(1000)),
                 Usd(dec!(100)),
@@ -714,10 +708,8 @@ mod tests {
             )
             .unwrap()
         }
-    }
 
-    impl Order {
-        pub fn with_oracle_event_id(mut self, oracle_event_id: BitMexPriceEventId) -> Self {
+        fn with_oracle_event_id(mut self, oracle_event_id: BitMexPriceEventId) -> Self {
             self.oracle_event_id = oracle_event_id;
             self
         }

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -492,13 +492,10 @@ pub async fn load_cfds_by_oracle_event_id(
 
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
-
     use pretty_assertions::assert_eq;
     use rand::Rng;
     use rust_decimal_macros::dec;
     use sqlx::SqlitePool;
-    use tempfile::tempdir;
     use time::macros::datetime;
     use time::OffsetDateTime;
 
@@ -647,14 +644,7 @@ mod tests {
     }
 
     async fn setup_test_db() -> PoolConnection<Sqlite> {
-        let temp_db = tempdir().unwrap().into_path().join("tempdb");
-
-        // file has to exist in order to connect with sqlite
-        File::create(temp_db.clone()).unwrap();
-
-        let pool = SqlitePool::connect(format!("sqlite:{}", temp_db.display()).as_str())
-            .await
-            .unwrap();
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
 
         run_migrations(&pool).await.unwrap();
 

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -512,8 +512,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_and_load_order() {
-        let pool = setup_test_db().await;
-        let mut conn = pool.acquire().await.unwrap();
+        let mut conn = setup_test_db().await;
 
         let order = Order::default();
         insert_order(&order, &mut conn).await.unwrap();
@@ -525,8 +524,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_and_load_cfd() {
-        let pool = setup_test_db().await;
-        let mut conn = pool.acquire().await.unwrap();
+        let mut conn = setup_test_db().await;
 
         let cfd = Cfd::default();
 
@@ -540,8 +538,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_and_load_cfd_by_order_id() {
-        let pool = setup_test_db().await;
-        let mut conn = pool.acquire().await.unwrap();
+        let mut conn = setup_test_db().await;
 
         let cfd = Cfd::default();
         let order_id = cfd.order.id;
@@ -555,8 +552,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_and_load_cfd_by_order_id_multiple() {
-        let pool = setup_test_db().await;
-        let mut conn = pool.acquire().await.unwrap();
+        let mut conn = setup_test_db().await;
 
         let cfd = Cfd::default();
         let order_id = cfd.order.id;
@@ -579,8 +575,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_and_load_cfd_by_oracle_event_id() {
-        let pool = setup_test_db().await;
-        let mut conn = pool.acquire().await.unwrap();
+        let mut conn = setup_test_db().await;
 
         let oracle_event_id_1 =
             BitMexPriceEventId::with_20_digits(datetime!(2021-10-13 10:00:00).assume_utc());
@@ -623,8 +618,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_new_cfd_state_and_load_with_multiple_cfd() {
-        let pool = setup_test_db().await;
-        let mut conn = pool.acquire().await.unwrap();
+        let mut conn = setup_test_db().await;
 
         let mut cfd_1 = Cfd::default();
 
@@ -673,7 +667,7 @@ mod tests {
         assert!(cfds_from_db.contains(&cfd_2));
     }
 
-    async fn setup_test_db() -> SqlitePool {
+    async fn setup_test_db() -> PoolConnection<Sqlite> {
         let temp_db = tempdir().unwrap().into_path().join("tempdb");
 
         // file has to exist in order to connect with sqlite
@@ -685,7 +679,7 @@ mod tests {
 
         run_migrations(&pool).await.unwrap();
 
-        pool
+        pool.acquire().await.unwrap()
     }
 
     impl Default for Cfd {

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -493,7 +493,6 @@ pub async fn load_cfds_by_oracle_event_id(
 #[cfg(test)]
 mod tests {
     use std::fs::File;
-    use std::time::SystemTime;
 
     use pretty_assertions::assert_eq;
     use rust_decimal_macros::dec;
@@ -503,7 +502,7 @@ mod tests {
     use time::OffsetDateTime;
 
     use crate::db::insert_order;
-    use crate::model::cfd::{Cfd, CfdState, CfdStateCommon, Order};
+    use crate::model::cfd::{Cfd, CfdState, Order};
     use crate::model::Usd;
 
     use super::*;
@@ -591,9 +590,7 @@ mod tests {
 
         let mut cfd_1 = Cfd::dummy().insert(&mut conn).await;
 
-        cfd_1.state = CfdState::Accepted {
-            common: CfdStateCommon::default(),
-        };
+        cfd_1.state = CfdState::accepted();
         append_cfd_state(&cfd_1, &mut conn).await.unwrap();
 
         let cfds_from_db = load_all_cfds(&mut conn).await.unwrap();
@@ -604,9 +601,7 @@ mod tests {
         let cfds_from_db = load_all_cfds(&mut conn).await.unwrap();
         assert_eq!(vec![cfd_1.clone(), cfd_2.clone()], cfds_from_db);
 
-        cfd_2.state = CfdState::Rejected {
-            common: CfdStateCommon::default(),
-        };
+        cfd_2.state = CfdState::rejected();
         append_cfd_state(&cfd_2, &mut conn).await.unwrap();
 
         let cfds_from_db = load_all_cfds(&mut conn).await.unwrap();
@@ -643,11 +638,7 @@ mod tests {
             Cfd::new(
                 Order::dummy(),
                 Usd(dec!(1000)),
-                CfdState::OutgoingOrderRequest {
-                    common: CfdStateCommon {
-                        transition_timestamp: SystemTime::now(),
-                    },
-                },
+                CfdState::outgoing_order_request(),
             )
         }
 

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -498,6 +498,7 @@ mod tests {
     use std::fs::File;
     use std::time::SystemTime;
 
+    use pretty_assertions::assert_eq;
     use rust_decimal_macros::dec;
     use sqlx::SqlitePool;
     use tempfile::tempdir;

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -592,9 +592,7 @@ mod tests {
         let mut cfd_1 = Cfd::dummy().insert(&mut conn).await;
 
         cfd_1.state = CfdState::Accepted {
-            common: CfdStateCommon {
-                transition_timestamp: SystemTime::now(),
-            },
+            common: CfdStateCommon::default(),
         };
         append_cfd_state(&cfd_1, &mut conn).await.unwrap();
 
@@ -607,9 +605,7 @@ mod tests {
         assert_eq!(vec![cfd_1.clone(), cfd_2.clone()], cfds_from_db);
 
         cfd_2.state = CfdState::Rejected {
-            common: CfdStateCommon {
-                transition_timestamp: SystemTime::now(),
-            },
+            common: CfdStateCommon::default(),
         };
         append_cfd_state(&cfd_2, &mut conn).await.unwrap();
 

--- a/daemon/src/housekeeping.rs
+++ b/daemon/src/housekeeping.rs
@@ -1,4 +1,4 @@
-use crate::db::{insert_new_cfd_state_by_order_id, load_all_cfds};
+use crate::db::{append_cfd_state, load_all_cfds};
 use crate::model::cfd::{Cfd, CfdState, CfdStateCommon};
 use crate::wallet::Wallet;
 use anyhow::Result;
@@ -9,20 +9,17 @@ use std::time::SystemTime;
 pub async fn transition_non_continue_cfds_to_setup_failed(
     conn: &mut PoolConnection<Sqlite>,
 ) -> Result<()> {
-    let cfds = load_all_cfds(conn).await?;
+    let mut cfds = load_all_cfds(conn).await?;
 
-    for cfd in cfds.iter().filter(|cfd| Cfd::is_cleanup(cfd)) {
-        insert_new_cfd_state_by_order_id(
-            cfd.order.id,
-            &CfdState::SetupFailed {
-                common: CfdStateCommon {
-                    transition_timestamp: SystemTime::now(),
-                },
-                info: format!("Was in state {} which cannot be continued.", cfd.state),
+    for cfd in cfds.iter_mut().filter(|cfd| Cfd::is_cleanup(cfd)) {
+        cfd.state = CfdState::SetupFailed {
+            common: CfdStateCommon {
+                transition_timestamp: SystemTime::now(),
             },
-            conn,
-        )
-        .await?;
+            info: format!("Was in state {} which cannot be continued.", cfd.state),
+        };
+
+        append_cfd_state(cfd, conn).await?;
     }
 
     Ok(())

--- a/daemon/src/housekeeping.rs
+++ b/daemon/src/housekeeping.rs
@@ -4,7 +4,6 @@ use crate::wallet::Wallet;
 use anyhow::Result;
 use sqlx::pool::PoolConnection;
 use sqlx::Sqlite;
-use std::time::SystemTime;
 
 pub async fn transition_non_continue_cfds_to_setup_failed(
     conn: &mut PoolConnection<Sqlite>,
@@ -13,9 +12,7 @@ pub async fn transition_non_continue_cfds_to_setup_failed(
 
     for cfd in cfds.iter_mut().filter(|cfd| Cfd::is_cleanup(cfd)) {
         cfd.state = CfdState::SetupFailed {
-            common: CfdStateCommon {
-                transition_timestamp: SystemTime::now(),
-            },
+            common: CfdStateCommon::default(),
             info: format!("Was in state {} which cannot be continued.", cfd.state),
         };
 

--- a/daemon/src/housekeeping.rs
+++ b/daemon/src/housekeeping.rs
@@ -1,5 +1,5 @@
 use crate::db::{append_cfd_state, load_all_cfds};
-use crate::model::cfd::{Cfd, CfdState, CfdStateCommon};
+use crate::model::cfd::{Cfd, CfdState};
 use crate::wallet::Wallet;
 use anyhow::Result;
 use sqlx::pool::PoolConnection;
@@ -11,10 +11,10 @@ pub async fn transition_non_continue_cfds_to_setup_failed(
     let mut cfds = load_all_cfds(conn).await?;
 
     for cfd in cfds.iter_mut().filter(|cfd| Cfd::is_cleanup(cfd)) {
-        cfd.state = CfdState::SetupFailed {
-            common: CfdStateCommon::default(),
-            info: format!("Was in state {} which cannot be continued.", cfd.state),
-        };
+        cfd.state = CfdState::setup_failed(format!(
+            "Was in state {} which cannot be continued.",
+            cfd.state
+        ));
 
         append_cfd_state(cfd, conn).await?;
     }

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -401,9 +401,7 @@ impl Actor {
 
         let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
         cfd.state = CfdState::PendingOpen {
-            common: CfdStateCommon {
-                transition_timestamp: SystemTime::now(),
-            },
+            common: CfdStateCommon::default(),
             dlc: dlc.clone(),
             attestation: None,
         };
@@ -444,9 +442,7 @@ impl Actor {
         let mut conn = self.db.acquire().await?;
         let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
         cfd.state = CfdState::Open {
-            common: CfdStateCommon {
-                transition_timestamp: SystemTime::now(),
-            },
+            common: CfdStateCommon::default(),
             dlc: dlc.clone(),
             attestation: None,
             collaborative_close: None,
@@ -568,9 +564,7 @@ impl Actor {
 
         // 3. Insert that we are in contract setup and refresh our own feed
         cfd.state = CfdState::ContractSetup {
-            common: CfdStateCommon {
-                transition_timestamp: SystemTime::now(),
-            },
+            common: CfdStateCommon::default(),
         };
 
         append_cfd_state(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;
@@ -656,9 +650,7 @@ impl Actor {
     ) -> Result<()> {
         // Update order in db
         cfd.state = CfdState::Rejected {
-            common: CfdStateCommon {
-                transition_timestamp: SystemTime::now(),
-            },
+            common: CfdStateCommon::default(),
         };
 
         append_cfd_state(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -563,9 +563,7 @@ impl Actor {
             .with_context(|| format!("Announcement {} not found", cfd.order.oracle_event_id))?;
 
         // 3. Insert that we are in contract setup and refresh our own feed
-        cfd.state = CfdState::ContractSetup {
-            common: CfdStateCommon::default(),
-        };
+        cfd.state = CfdState::contract_setup();
 
         append_cfd_state(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;
 
@@ -649,10 +647,7 @@ impl Actor {
         mut conn: PoolConnection<Sqlite>,
     ) -> Result<()> {
         // Update order in db
-        cfd.state = CfdState::Rejected {
-            common: CfdStateCommon::default(),
-        };
-
+        cfd.state = CfdState::rejected();
         append_cfd_state(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;
 
         self.takers

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -168,6 +168,14 @@ pub struct CfdStateCommon {
     pub transition_timestamp: SystemTime,
 }
 
+impl Default for CfdStateCommon {
+    fn default() -> Self {
+        Self {
+            transition_timestamp: SystemTime::now(),
+        }
+    }
+}
+
 // Note: De-/Serialize with type tag to make handling on UI easier
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -293,6 +293,60 @@ pub enum CfdState {
     },
 }
 
+impl CfdState {
+    pub fn outgoing_order_request() -> Self {
+        Self::OutgoingOrderRequest {
+            common: CfdStateCommon::default(),
+        }
+    }
+
+    pub fn accepted() -> Self {
+        Self::Accepted {
+            common: CfdStateCommon::default(),
+        }
+    }
+
+    pub fn rejected() -> Self {
+        Self::Rejected {
+            common: CfdStateCommon::default(),
+        }
+    }
+
+    pub fn contract_setup() -> Self {
+        Self::ContractSetup {
+            common: CfdStateCommon::default(),
+        }
+    }
+
+    pub fn closed(payout: Payout) -> Self {
+        Self::Closed {
+            common: CfdStateCommon::default(),
+            payout,
+        }
+    }
+
+    pub fn must_refund(dlc: Dlc) -> Self {
+        Self::MustRefund {
+            common: CfdStateCommon::default(),
+            dlc,
+        }
+    }
+
+    pub fn refunded(dlc: Dlc) -> Self {
+        Self::Refunded {
+            common: CfdStateCommon::default(),
+            dlc,
+        }
+    }
+
+    pub fn setup_failed(info: String) -> Self {
+        Self::SetupFailed {
+            common: CfdStateCommon::default(),
+            info,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Payout {
     CollaborativeClose(CollaborativeSettlement),
@@ -718,12 +772,7 @@ impl Cfd {
                 monitor::Event::CloseFinality(_) => {
                     let collaborative_close = self.collaborative_close().context("No collaborative close after reaching collaborative close finality")?;
 
-                    CfdState::Closed {
-                        common: CfdStateCommon {
-                            transition_timestamp: SystemTime::now(),
-                        },
-                        payout: Payout::CollaborativeClose(collaborative_close)
-                    }
+                    CfdState::closed(Payout::CollaborativeClose(collaborative_close))
 
                 },
                 monitor::Event::CetTimelockExpired(_) => match self.state.clone() {
@@ -788,36 +837,21 @@ impl Cfd {
                         )
                     };
 
-                    MustRefund {
-                        common: CfdStateCommon {
-                            transition_timestamp: SystemTime::now(),
-                        },
-                        dlc,
-                    }
+                    CfdState::must_refund(dlc)
                 }
                 monitor::Event::RefundFinality(_) => {
                     let dlc = self
                         .dlc()
                         .context("No dlc available when reaching refund finality")?;
 
-                    Refunded {
-                        common: CfdStateCommon {
-                            transition_timestamp: SystemTime::now(),
-                        },
-                        dlc,
-                    }
+                    CfdState::refunded(dlc)
                 }
                 monitor::Event::CetFinality(_) => {
                     let attestation = self
                         .attestation()
                         .context("No attestation available when reaching CET finality")?;
 
-                    CfdState::Closed {
-                        common: CfdStateCommon {
-                            transition_timestamp: SystemTime::now(),
-                        },
-                        payout: Payout::Cet(attestation)
-                    }
+                    CfdState::closed(Payout::Cet(attestation))
                 }
                 monitor::Event::RevokedTransactionFound(_) => {
                     todo!("Punish bad counterparty")

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -149,11 +149,7 @@ impl Actor {
         let cfd = Cfd::new(
             current_order.clone(),
             quantity,
-            CfdState::OutgoingOrderRequest {
-                common: CfdStateCommon {
-                    transition_timestamp: SystemTime::now(),
-                },
-            },
+            CfdState::outgoing_order_request(),
         );
 
         insert_cfd(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;
@@ -269,9 +265,7 @@ impl Actor {
 
         let mut conn = self.db.acquire().await?;
         let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
-        cfd.state = CfdState::ContractSetup {
-            common: CfdStateCommon::default(),
-        };
+        cfd.state = CfdState::contract_setup();
 
         append_cfd_state(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;
 
@@ -320,9 +314,7 @@ impl Actor {
 
         let mut conn = self.db.acquire().await?;
         let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
-        cfd.state = CfdState::Rejected {
-            common: CfdStateCommon::default(),
-        };
+        cfd.state = CfdState::rejected();
 
         append_cfd_state(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;
 

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -270,9 +270,7 @@ impl Actor {
         let mut conn = self.db.acquire().await?;
         let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
         cfd.state = CfdState::ContractSetup {
-            common: CfdStateCommon {
-                transition_timestamp: SystemTime::now(),
-            },
+            common: CfdStateCommon::default(),
         };
 
         append_cfd_state(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;
@@ -323,9 +321,7 @@ impl Actor {
         let mut conn = self.db.acquire().await?;
         let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
         cfd.state = CfdState::Rejected {
-            common: CfdStateCommon {
-                transition_timestamp: SystemTime::now(),
-            },
+            common: CfdStateCommon::default(),
         };
 
         append_cfd_state(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;
@@ -477,9 +473,7 @@ impl Actor {
         let mut conn = self.db.acquire().await?;
         let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
         cfd.state = CfdState::PendingOpen {
-            common: CfdStateCommon {
-                transition_timestamp: SystemTime::now(),
-            },
+            common: CfdStateCommon::default(),
             dlc: dlc.clone(),
             attestation: None,
         };
@@ -520,9 +514,7 @@ impl Actor {
         let mut conn = self.db.acquire().await?;
         let mut cfd = load_cfd_by_order_id(order_id, &mut conn).await?;
         cfd.state = CfdState::Open {
-            common: CfdStateCommon {
-                transition_timestamp: SystemTime::now(),
-            },
+            common: CfdStateCommon::default(),
             dlc: dlc.clone(),
             attestation: None,
             collaborative_close: None,


### PR DESCRIPTION
- Extend DB test suite
- Directly return `PoolConnection`
- Don't use Default for test instance
- Take `Cfd` by reference if we don't need to consume it
- Use pretty assertions
- Make DB tests more readable by reducing boilerplate
- Refactor `insert_new_cfd_state_by_order_id` to `append_cfd_state`
- Reduce boilerplate in constructing `CfdStateCommon`
- Make it less verbose to construct simple states
- Add test for a variety of state updates
- Run tests against in-memory DB
