### PR TITLE
Refactor database queries, take #2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,6 +2615,7 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
+ "uuid",
  "webpki",
  "webpki-roots 0.21.1",
  "whoami",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1"
 serde_plain = "1"
 serde_with = { version = "1", features = ["macros"] }
 sha2 = "0.9"
-sqlx = { version = "0.5", features = ["offline"] }
+sqlx = { version = "0.5", features = ["offline", "sqlite", "uuid"] }
 thiserror = "1"
 time = { version = "0.3", features = ["serde"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }

--- a/daemon/migrations/20210903050345_create_cfd_and_order_tables.sql
+++ b/daemon/migrations/20210903050345_create_cfd_and_order_tables.sql
@@ -1,19 +1,21 @@
 -- todo: Decimal is had to deserialize as number so we use text
 create table if not exists orders
 (
-    id                 integer primary key autoincrement,
-    uuid               text unique not null,
-    trading_pair       text        not null,
-    position           text        not null,
-    initial_price      text        not null,
-    min_quantity       text        not null,
-    max_quantity       text        not null,
-    leverage           integer     not null,
-    liquidation_price  text        not null,
-    creation_timestamp text        not null,
-    term               text        not null,
-    origin             text        not null,
-    oracle_event_id    text        not null
+    id                              integer primary key autoincrement,
+    uuid                            text unique not null,
+    trading_pair                    text        not null,
+    position                        text        not null,
+    initial_price                   text        not null,
+    min_quantity                    text        not null,
+    max_quantity                    text        not null,
+    leverage                        integer     not null,
+    liquidation_price               text        not null,
+    creation_timestamp_seconds      integer     not null,
+    creation_timestamp_nanoseconds  integer     not null,
+    term_seconds                    integer     not null,
+    term_nanoseconds                integer     not null,
+    origin                          text        not null,
+    oracle_event_id                 text        not null
 );
 
 create unique index if not exists orders_uuid

--- a/daemon/sqlx-data.json
+++ b/daemon/sqlx-data.json
@@ -1,7 +1,7 @@
 {
   "db": "SQLite",
-  "50abbb297394739ec9d85917f8c32aa8bcfa0bfe140b24e9eeda4ce8d30d4f8d": {
-    "query": "\n        select\n            state\n        from cfd_states\n        where cfd_id = ?\n        order by id desc\n        limit 1;\n        ",
+  "221a6283db798bacaba99e7e85130f9a8bbea1299d8cb99d272b1d478dc19775": {
+    "query": "\n        select\n            state\n        from cfd_states\n        where cfd_id = $1\n        order by id desc\n        limit 1;\n        ",
     "describe": {
       "columns": [
         {
@@ -18,78 +18,88 @@
       ]
     }
   },
-  "63c8fd1a1512b55c19feea463dbb6a0fdf98a325801ba8677e2a33fd3ee1ebb9": {
-    "query": "\n        select\n            orders.uuid as order_id,\n            orders.initial_price as price,\n            orders.min_quantity as min_quantity,\n            orders.max_quantity as max_quantity,\n            orders.leverage as leverage,\n            orders.trading_pair as trading_pair,\n            orders.position as position,\n            orders.origin as origin,\n            orders.liquidation_price as liquidation_price,\n            orders.creation_timestamp as creation_timestamp,\n            orders.term as term,\n            orders.oracle_event_id,\n            cfds.quantity_usd as quantity_usd,\n            cfd_states.state as state\n        from cfds as cfds\n        inner join orders as orders on cfds.order_id = orders.id\n        inner join cfd_states as cfd_states on cfd_states.cfd_id = cfds.id\n        where cfd_states.state in (\n            select\n              state\n              from cfd_states\n            where cfd_id = cfds.id\n            order by id desc\n            limit 1\n        )\n        ",
+  "2687e30ae7feb70b443b0de40712a0233c47afbd429da580df72c08286ce7008": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                creation_timestamp_nanoseconds as ts_nanos,\n                term_seconds as term_secs,\n                term_nanoseconds as term_nanos,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: i64\",\n            ord.ts_nanos as \"ts_nanos: i32\",\n            ord.term_secs as \"term_secs: i64\",\n            ord.term_nanos as \"term_nanos: i32\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n        ",
     "describe": {
       "columns": [
         {
-          "name": "order_id",
+          "name": "uuid: crate::model::cfd::OrderId",
           "ordinal": 0,
           "type_info": "Text"
         },
         {
-          "name": "price",
+          "name": "trading_pair: crate::model::TradingPair",
           "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "name": "min_quantity",
+          "name": "position: crate::model::Position",
           "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "name": "max_quantity",
+          "name": "initial_price",
           "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "name": "leverage",
+          "name": "min_quantity",
           "ordinal": 4,
-          "type_info": "Int64"
+          "type_info": "Text"
         },
         {
-          "name": "trading_pair",
+          "name": "max_quantity",
           "ordinal": 5,
           "type_info": "Text"
         },
         {
-          "name": "position",
+          "name": "leverage: crate::model::Leverage",
           "ordinal": 6,
-          "type_info": "Text"
+          "type_info": "Int64"
         },
         {
-          "name": "origin",
+          "name": "liquidation_price",
           "ordinal": 7,
           "type_info": "Text"
         },
         {
-          "name": "liquidation_price",
+          "name": "ts_secs: i64",
           "ordinal": 8,
-          "type_info": "Text"
+          "type_info": "Int64"
         },
         {
-          "name": "creation_timestamp",
+          "name": "ts_nanos: i32",
           "ordinal": 9,
-          "type_info": "Text"
+          "type_info": "Int64"
         },
         {
-          "name": "term",
+          "name": "term_secs: i64",
           "ordinal": 10,
-          "type_info": "Text"
+          "type_info": "Int64"
         },
         {
-          "name": "oracle_event_id",
+          "name": "term_nanos: i32",
           "ordinal": 11,
-          "type_info": "Text"
+          "type_info": "Int64"
         },
         {
-          "name": "quantity_usd",
+          "name": "origin: crate::model::cfd::Origin",
           "ordinal": 12,
           "type_info": "Text"
         },
         {
-          "name": "state",
+          "name": "oracle_event_id",
           "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "quantity_usd",
+          "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "state",
+          "ordinal": 15,
           "type_info": "Text"
         }
       ],
@@ -110,12 +120,122 @@
         false,
         false,
         false,
+        false,
+        false,
         false
       ]
     }
   },
-  "8e7571250da58b12f5884f17656e5966957c7798ea029c701a4fc43fd613f015": {
-    "query": "\n        select\n            id\n        from cfds\n        where order_uuid = ?;\n        ",
+  "296b741deaf0219b2f2d2f2a65128839796e68f1edf4d8f6488d7f7dceb63923": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                creation_timestamp_nanoseconds as ts_nanos,\n                term_seconds as term_secs,\n                term_nanoseconds as term_nanos,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: i64\",\n            ord.ts_nanos as \"ts_nanos: i32\",\n            ord.term_secs as \"term_secs: i64\",\n            ord.term_nanos as \"term_nanos: i32\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.oracle_event_id = $1\n        ",
+    "describe": {
+      "columns": [
+        {
+          "name": "uuid: crate::model::cfd::OrderId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "trading_pair: crate::model::TradingPair",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: crate::model::Position",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "min_quantity",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "max_quantity",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "leverage: crate::model::Leverage",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "liquidation_price",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "ts_secs: i64",
+          "ordinal": 8,
+          "type_info": "Int64"
+        },
+        {
+          "name": "ts_nanos: i32",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "term_secs: i64",
+          "ordinal": 10,
+          "type_info": "Int64"
+        },
+        {
+          "name": "term_nanos: i32",
+          "ordinal": 11,
+          "type_info": "Int64"
+        },
+        {
+          "name": "origin: crate::model::cfd::Origin",
+          "ordinal": 12,
+          "type_info": "Text"
+        },
+        {
+          "name": "oracle_event_id",
+          "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "quantity_usd",
+          "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "state",
+          "ordinal": 15,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "8cbe349911b35d8e79763d64b4f5813b4bd98f12e0bba5ada84d2cae8b08ef4f": {
+    "query": "\n        select\n            id\n        from cfds\n        where order_uuid = $1;\n        ",
     "describe": {
       "columns": [
         {
@@ -132,285 +252,88 @@
       ]
     }
   },
-  "a464a1feb12abadff8bfd5b2b3b7362f3846869c0702944b21737eff8f420be5": {
-    "query": "\n        insert into cfd_states (\n            cfd_id,\n            state\n        ) values (?, ?);\n        ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 2
-      },
-      "nullable": []
-    }
-  },
-  "a59cf0824b5e4191c94c229086ce464d1b8084f65a6fafb165d27ce6df5b815b": {
-    "query": "\n            insert into orders (\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp,\n                term,\n                origin,\n                oracle_event_id\n            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 12
-      },
-      "nullable": []
-    }
-  },
-  "e0d3fe192c419be4fa65199d1e024ce8794e19a847be53038b7a8a33afb36bd2": {
-    "query": "\n        select\n            orders.uuid as order_id,\n            orders.initial_price as price,\n            orders.min_quantity as min_quantity,\n            orders.max_quantity as max_quantity,\n            orders.leverage as leverage,\n            orders.trading_pair as trading_pair,\n            orders.position as position,\n            orders.origin as origin,\n            orders.liquidation_price as liquidation_price,\n            orders.creation_timestamp as creation_timestamp,\n            orders.term as term,\n            orders.oracle_event_id,\n            cfds.quantity_usd as quantity_usd,\n            cfd_states.state as state\n        from cfds as cfds\n        inner join orders as orders on cfds.order_id = orders.id\n        inner join cfd_states as cfd_states on cfd_states.cfd_id = cfds.id\n        where cfd_states.state in (\n            select\n              state\n              from cfd_states\n            where cfd_id = cfds.id\n            order by id desc\n            limit 1\n        )\n        and orders.uuid = ?\n        ",
+  "b1499d56ef5b4218d49f7e8179b03f9f9f8551a4826e93850608828faca1eeab": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                creation_timestamp_nanoseconds as ts_nanos,\n                term_seconds as term_secs,\n                term_nanoseconds as term_nanos,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: i64\",\n            ord.ts_nanos as \"ts_nanos: i32\",\n            ord.term_secs as \"term_secs: i64\",\n            ord.term_nanos as \"term_nanos: i32\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.uuid = $1\n        ",
     "describe": {
       "columns": [
         {
-          "name": "order_id",
+          "name": "uuid: crate::model::cfd::OrderId",
           "ordinal": 0,
           "type_info": "Text"
         },
         {
-          "name": "price",
+          "name": "trading_pair: crate::model::TradingPair",
           "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "name": "min_quantity",
+          "name": "position: crate::model::Position",
           "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "max_quantity",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "leverage",
-          "ordinal": 4,
-          "type_info": "Int64"
-        },
-        {
-          "name": "trading_pair",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "position",
-          "ordinal": 6,
-          "type_info": "Text"
-        },
-        {
-          "name": "origin",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "liquidation_price",
-          "ordinal": 8,
-          "type_info": "Text"
-        },
-        {
-          "name": "creation_timestamp",
-          "ordinal": 9,
-          "type_info": "Text"
-        },
-        {
-          "name": "term",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "oracle_event_id",
-          "ordinal": 11,
-          "type_info": "Text"
-        },
-        {
-          "name": "quantity_usd",
-          "ordinal": 12,
-          "type_info": "Text"
-        },
-        {
-          "name": "state",
-          "ordinal": 13,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "e45a49eb1fb4cbddc046712d9e2df2db0c18c618f0fae2133e51d82eda6bec36": {
-    "query": "\n        select\n            orders.uuid as order_id,\n            orders.initial_price as price,\n            orders.min_quantity as min_quantity,\n            orders.max_quantity as max_quantity,\n            orders.leverage as leverage,\n            orders.trading_pair as trading_pair,\n            orders.position as position,\n            orders.origin as origin,\n            orders.liquidation_price as liquidation_price,\n            orders.creation_timestamp as creation_timestamp,\n            orders.term as term,\n            orders.oracle_event_id,\n            cfds.quantity_usd as quantity_usd,\n            cfd_states.state as state\n        from cfds as cfds\n        inner join orders as orders on cfds.order_id = orders.id\n        inner join cfd_states as cfd_states on cfd_states.cfd_id = cfds.id\n        where cfd_states.state in (\n            select\n              state\n              from cfd_states\n            where cfd_id = cfds.id\n            order by id desc\n            limit 1\n        )\n        and orders.oracle_event_id = ?\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "order_id",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "price",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "min_quantity",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "max_quantity",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "leverage",
-          "ordinal": 4,
-          "type_info": "Int64"
-        },
-        {
-          "name": "trading_pair",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "position",
-          "ordinal": 6,
-          "type_info": "Text"
-        },
-        {
-          "name": "origin",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "liquidation_price",
-          "ordinal": 8,
-          "type_info": "Text"
-        },
-        {
-          "name": "creation_timestamp",
-          "ordinal": 9,
-          "type_info": "Text"
-        },
-        {
-          "name": "term",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "oracle_event_id",
-          "ordinal": 11,
-          "type_info": "Text"
-        },
-        {
-          "name": "quantity_usd",
-          "ordinal": 12,
-          "type_info": "Text"
-        },
-        {
-          "name": "state",
-          "ordinal": 13,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "f3dce76f316212c91cb3402b0cef00f1c9adbef8519c54e9bdbd373aab946209": {
-    "query": "\n        select * from orders where uuid = ?;\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "uuid",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "trading_pair",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "position",
-          "ordinal": 3,
           "type_info": "Text"
         },
         {
           "name": "initial_price",
-          "ordinal": 4,
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
           "name": "min_quantity",
-          "ordinal": 5,
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
           "name": "max_quantity",
-          "ordinal": 6,
+          "ordinal": 5,
           "type_info": "Text"
         },
         {
-          "name": "leverage",
-          "ordinal": 7,
+          "name": "leverage: crate::model::Leverage",
+          "ordinal": 6,
           "type_info": "Int64"
         },
         {
           "name": "liquidation_price",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "ts_secs: i64",
           "ordinal": 8,
-          "type_info": "Text"
+          "type_info": "Int64"
         },
         {
-          "name": "creation_timestamp",
+          "name": "ts_nanos: i32",
           "ordinal": 9,
-          "type_info": "Text"
+          "type_info": "Int64"
         },
         {
-          "name": "term",
+          "name": "term_secs: i64",
           "ordinal": 10,
-          "type_info": "Text"
+          "type_info": "Int64"
         },
         {
-          "name": "origin",
+          "name": "term_nanos: i32",
           "ordinal": 11,
+          "type_info": "Int64"
+        },
+        {
+          "name": "origin: crate::model::cfd::Origin",
+          "ordinal": 12,
           "type_info": "Text"
         },
         {
           "name": "oracle_event_id",
-          "ordinal": 12,
+          "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "quantity_usd",
+          "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "state",
+          "ordinal": 15,
           "type_info": "Text"
         }
       ],
@@ -418,7 +341,10 @@
         "Right": 1
       },
       "nullable": [
-        true,
+        false,
+        false,
+        false,
+        false,
         false,
         false,
         false,
@@ -434,24 +360,100 @@
       ]
     }
   },
-  "fac3d990211ef9e5fa8bcd6e1d6e0c8a81652b98fb11f2686affd1593fba75fd": {
-    "query": "\n            insert into cfd_states (\n                cfd_id,\n                state\n            ) values (?, ?);\n            ",
+  "b708b7116aa14093e0e21ab8f87e52928a70649a62250902054ef6526f1d6f66": {
+    "query": "\n        select\n            uuid as \"uuid: crate::model::cfd::OrderId\",\n            trading_pair as \"trading_pair: crate::model::TradingPair\",\n            position as \"position: crate::model::Position\",\n            initial_price,\n            min_quantity,\n            max_quantity,\n            leverage as \"leverage: crate::model::Leverage\",\n            liquidation_price,\n            creation_timestamp_seconds as \"ts_secs: i64\",\n            creation_timestamp_nanoseconds as \"ts_nanos: i32\",\n            term_seconds as \"term_secs: i64\",\n            term_nanoseconds as \"term_nanos: i32\",\n            origin as \"origin: crate::model::cfd::Origin\",\n            oracle_event_id\n\n        from orders\n        where uuid = $1\n        ",
     "describe": {
-      "columns": [],
+      "columns": [
+        {
+          "name": "uuid: crate::model::cfd::OrderId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "trading_pair: crate::model::TradingPair",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: crate::model::Position",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "min_quantity",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "max_quantity",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "leverage: crate::model::Leverage",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "liquidation_price",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "ts_secs: i64",
+          "ordinal": 8,
+          "type_info": "Int64"
+        },
+        {
+          "name": "ts_nanos: i32",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "term_secs: i64",
+          "ordinal": 10,
+          "type_info": "Int64"
+        },
+        {
+          "name": "term_nanos: i32",
+          "ordinal": 11,
+          "type_info": "Int64"
+        },
+        {
+          "name": "origin: crate::model::cfd::Origin",
+          "ordinal": 12,
+          "type_info": "Text"
+        },
+        {
+          "name": "oracle_event_id",
+          "ordinal": 13,
+          "type_info": "Text"
+        }
+      ],
       "parameters": {
-        "Right": 2
+        "Right": 1
       },
-      "nullable": []
-    }
-  },
-  "fad32c267100e26f4fba80e4feb5ff45ee29c3a67bd378f6627b1f13ee45c573": {
-    "query": "\n            insert into cfds (\n                order_id,\n                order_uuid,\n                quantity_usd\n            ) values (?, ?, ?);\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 3
-      },
-      "nullable": []
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
     }
   }
 }

--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -72,15 +72,16 @@ impl From<Decimal> for Percent {
     }
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, sqlx::Type)]
+#[sqlx(transparent)]
 pub struct Leverage(pub u8);
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::Type)]
 pub enum TradingPair {
     BtcUsd,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::Type)]
 pub enum Position {
     Buy,
     Sell,

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -19,7 +19,8 @@ use std::time::SystemTime;
 use time::Duration;
 use uuid::Uuid;
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, sqlx::Type)]
+#[sqlx(transparent)]
 pub struct OrderId(Uuid);
 
 impl Default for OrderId {
@@ -45,7 +46,7 @@ impl<'v> FromParam<'v> for OrderId {
 
 // TODO: Could potentially remove this and use the Role in the Order instead
 /// Origin of the order
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, sqlx::Type)]
 pub enum Origin {
     Ours,
     Theirs,


### PR DESCRIPTION
Fix up SQL queries

This PR does a few things:
* cleans up the SQL to make the queries clearer in terms of intent, as well as eliminating the use of an extra transaction in some write queries.
* adds some additional testing
* (mostly) eliminates the use of `serde_json::to_string()`, making the data columns behave in a more sane manner