### PR TITLE
Move key to the toplevel child hierarchy elem

### DIFF
--- a/frontend/src/components/cfdtables/CfdTable.tsx
+++ b/frontend/src/components/cfdtables/CfdTable.tsx
@@ -180,9 +180,8 @@ export function CfdTable(
                 Header: "Action",
                 accessor: ({ actions, order_id }) => {
                     const actionIcons = actions.map((action) => {
-                        return (<Tooltip label={action}>
+                        return (<Tooltip label={action} key={action}>
                             <IconButton
-                                key={action}
                                 colorScheme={colorSchemaForAction(action)}
                                 aria-label={action}
                                 icon={iconForAction(action)}


### PR DESCRIPTION
Got the complaint that `each child needs to have unique key` (Firefox) because the key was not on the child, but on a nested item.