### PR TITLE
Maker actor system

### DIFF
--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -70,8 +70,8 @@ pub struct Actor {
 
 impl Actor {
     pub fn new(
-        new_taker_channel: &impl MessageChannel<NewTakerOnline>,
-        taker_msg_channel: &impl MessageChannel<FromTaker>,
+        new_taker_channel: Box<dyn MessageChannel<NewTakerOnline>>,
+        taker_msg_channel: Box<dyn MessageChannel<FromTaker>>,
     ) -> Self {
         Self {
             write_connections: HashMap::new(),

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -50,11 +50,11 @@ pub struct Actor<C = bdk::electrum_client::Client> {
 
 impl Actor<bdk::electrum_client::Client> {
     pub async fn new(
-        electrum_rpc_url: &str,
-        event_channel: impl StrongMessageChannel<Event> + 'static,
+        electrum_rpc_url: String,
+        event_channel: Box<dyn StrongMessageChannel<Event>>,
         cfds: Vec<Cfd>,
     ) -> Result<Self> {
-        let client = bdk::electrum_client::Client::new(electrum_rpc_url)
+        let client = bdk::electrum_client::Client::new(&electrum_rpc_url)
             .context("Failed to initialize Electrum RPC client")?;
 
         // Initially fetch the latest block for storing the height.
@@ -65,7 +65,7 @@ impl Actor<bdk::electrum_client::Client> {
 
         let mut actor = Self {
             cfds: HashMap::new(),
-            event_channel: Box::new(event_channel),
+            event_channel,
             client,
             latest_block_height: BlockHeight::try_from(latest_block)?,
             current_status: BTreeMap::default(),

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -67,7 +67,7 @@ struct NewAttestationFetched {
 impl Actor {
     pub fn new(
         cfds: Vec<Cfd>,
-        attestation_channel: impl StrongMessageChannel<Attestation> + 'static,
+        attestation_channel: Box<dyn StrongMessageChannel<Attestation>>,
     ) -> Self {
         let mut pending_attestations = HashSet::new();
 
@@ -101,7 +101,7 @@ impl Actor {
             announcements: HashMap::new(),
             pending_announcements: HashSet::new(),
             pending_attestations,
-            attestation_channel: Box::new(attestation_channel),
+            attestation_channel,
         }
     }
 }

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -240,8 +240,8 @@ async fn main() -> Result<()> {
                 tokio::spawn(
                     monitor_actor_context.run(
                         monitor::Actor::new(
-                            opts.network.electrum(),
-                            cfd_actor_inbox.clone(),
+                            opts.network.electrum().to_string(),
+                            Box::new(cfd_actor_inbox.clone()),
                             cfds.clone(),
                         )
                         .await
@@ -258,7 +258,7 @@ async fn main() -> Result<()> {
                     .create(None)
                     .spawn_global();
 
-                tokio::spawn(oracle_actor_context.run(oracle::Actor::new(cfds, actor)));
+                tokio::spawn(oracle_actor_context.run(oracle::Actor::new(cfds, Box::new(actor))));
 
                 oracle_actor_address
                     .do_send_async(oracle::Sync)


### PR DESCRIPTION
How does this attempt at an actor system look? 

- The constructor just hooks everything up in the same way that `main` currently does. I think we want this to be consistent between tests and production. 
- The closures allow us to build whatever actors we want so long as they respect the contract expressed in the trait bounds. Maybe this is clunky. This could be leveraged to, for example, construct a `monitor::Actor` stand-in which immediately finds any transactions we subscribe to.
- I assume both the `wallet` and `db` arguments can be previously initialised for the purpose of testing, like we've done in the past.