### PR TITLE
Sync with Olivia every 5 seconds

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -257,7 +257,7 @@ async fn main() -> Result<()> {
 
                 tokio::spawn(
                     oracle_actor_context
-                        .notify_interval(Duration::from_secs(60), || oracle::Sync)
+                        .notify_interval(Duration::from_secs(5), || oracle::Sync)
                         .unwrap(),
                 );
                 let actor = fan_out::Actor::new(&[&cfd_maker_actor_inbox, &monitor_actor_address])

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -224,13 +224,20 @@ impl xtra::Handler<GetAnnouncement> for Actor {
         msg: GetAnnouncement,
         _ctx: &mut xtra::Context<Self>,
     ) -> Option<Announcement> {
-        self.announcements
-            .get_key_value(&msg.0)
-            .map(|(id, (time, nonce_pks))| Announcement {
-                id: *id,
-                expected_outcome_time: *time,
-                nonce_pks: nonce_pks.clone(),
-            })
+        let announcement =
+            self.announcements
+                .get_key_value(&msg.0)
+                .map(|(id, (time, nonce_pks))| Announcement {
+                    id: *id,
+                    expected_outcome_time: *time,
+                    nonce_pks: nonce_pks.clone(),
+                });
+
+        if announcement.is_none() {
+            self.pending_announcements.insert(msg.0);
+        }
+
+        announcement
     }
 }
 

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -251,7 +251,7 @@ async fn main() -> Result<()> {
                 tokio::spawn(wallet_sync::new(wallet, wallet_feed_sender));
                 tokio::spawn(
                     oracle_actor_context
-                        .notify_interval(Duration::from_secs(60), || oracle::Sync)
+                        .notify_interval(Duration::from_secs(5), || oracle::Sync)
                         .unwrap(),
                 );
                 let actor = fan_out::Actor::new(&[&cfd_actor_inbox, &monitor_actor_address])


### PR DESCRIPTION
We are only making requests to Olivia that are absolutely necessary,
i.e. only fetch attestations when they are likely ready and only
fetch attestations that we definitely need.

As a result, we can trigger the sync much more frequent.

Fixes #349.
