### PR TITLE
Make `taker_cfd::Actor` generic over other actor addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "xtra"
 version = "0.6.0"
-source = "git+https://github.com/Restioson/xtra#7ae9140dbc30127aaa5f701078b72ac143babeb4"
+source = "git+https://github.com/luckysori/xtra?rev=19684c196f71ec762e595906cc88c6142b82092e#19684c196f71ec762e595906cc88c6142b82092e"
 dependencies = [
  "async-trait",
  "barrage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ resolver = "2"
 
 [patch.crates-io]
 rocket = { git = "https://github.com/SergioBenitez/Rocket" } # Need to patch rocket dependency of `rocket_basicauth` until there is an official release.
-xtra = { git = "https://github.com/Restioson/xtra" } # Need to patch xtra dependency until there is an official release as it contains useful PRs from us.
+xtra = { git = "https://github.com/luckysori/xtra", rev = "19684c196f71ec762e595906cc88c6142b82092e" } # Need to patch xtra dependency until there is an official release as it contains useful PRs from us.

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -221,7 +221,7 @@ async fn main() -> Result<()> {
                     cfd_feed_sender,
                     order_feed_sender,
                     update_cfd_feed_sender,
-                    send_to_maker,
+                    Box::new(send_to_maker),
                     monitor_actor_address.clone(),
                     oracle_actor_address.clone(),
                 )


### PR DESCRIPTION
Equivalent to what we did to `maker_cfd::Actor` in #339.