### PR TITLE
Use fork for secp256k1-zkp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-zkp"
 version = "0.4.0"
-source = "git+https://github.com/ElementsProject/rust-secp256k1-zkp#ab7f6d8f5e74fd7bf5348d4fc3593bcc1dd532ad"
+source = "git+https://github.com/klochowicz/rust-secp256k1-zkp?branch=ecdsa-signatures-release-build#37c6afcf3ead55cbc99cbbba459745c43c7197a3"
 dependencies = [
  "rand 0.6.5",
  "secp256k1",
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-zkp-sys"
 version = "0.4.0"
-source = "git+https://github.com/ElementsProject/rust-secp256k1-zkp#ab7f6d8f5e74fd7bf5348d4fc3593bcc1dd532ad"
+source = "git+https://github.com/klochowicz/rust-secp256k1-zkp?branch=ecdsa-signatures-release-build#37c6afcf3ead55cbc99cbbba459745c43c7197a3"
 dependencies = [
  "cc",
  "secp256k1-sys",

--- a/cfd_protocol/Cargo.toml
+++ b/cfd_protocol/Cargo.toml
@@ -9,7 +9,7 @@ bdk = { version = "0.12", default-features = false }
 bit-vec = "0.6"
 itertools = "0.10"
 rand = "0.6"
-secp256k1-zkp = { git = "https://github.com/ElementsProject/rust-secp256k1-zkp", features = ["bitcoin_hashes", "global-context", "serde"] }
+secp256k1-zkp = { git = "https://github.com/klochowicz/rust-secp256k1-zkp", branch = "ecdsa-signatures-release-build", features = ["bitcoin_hashes", "global-context", "serde"] }
 thiserror = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
Because of bug in upstream library where the release build removes the actual computation of adaptor signatures


resolves #348 
