### PR TITLE
Don't fail for loops

### DIFF
--- a/daemon/src/housekeeping.rs
+++ b/daemon/src/housekeeping.rs
@@ -1,10 +1,10 @@
 use crate::db::{append_cfd_state, load_all_cfds};
 use crate::model::cfd::{Cfd, CfdState};
+use crate::try_continue;
 use crate::wallet::Wallet;
 use anyhow::Result;
 use sqlx::pool::PoolConnection;
 use sqlx::Sqlite;
-
 pub async fn transition_non_continue_cfds_to_setup_failed(
     conn: &mut PoolConnection<Sqlite>,
 ) -> Result<()> {
@@ -29,29 +29,28 @@ pub async fn rebroadcast_transactions(
     let cfds = load_all_cfds(conn).await?;
 
     for dlc in cfds.iter().filter_map(|cfd| Cfd::pending_open_dlc(cfd)) {
-        let txid = wallet.try_broadcast_transaction(dlc.lock.0.clone()).await?;
-
+        let txid = try_continue!(wallet.try_broadcast_transaction(dlc.lock.0.clone()).await);
         tracing::info!("Lock transaction published with txid {}", txid);
     }
 
     for cfd in cfds.iter().filter(|cfd| Cfd::is_must_refund(cfd)) {
         let signed_refund_tx = cfd.refund_tx()?;
-        let txid = wallet.try_broadcast_transaction(signed_refund_tx).await?;
+        let txid = try_continue!(wallet.try_broadcast_transaction(signed_refund_tx).await);
 
         tracing::info!("Refund transaction published on chain: {}", txid);
     }
 
     for cfd in cfds.iter().filter(|cfd| Cfd::is_pending_commit(cfd)) {
         let signed_commit_tx = cfd.commit_tx()?;
-        let txid = wallet.try_broadcast_transaction(signed_commit_tx).await?;
+        let txid = try_continue!(wallet.try_broadcast_transaction(signed_commit_tx).await);
 
         tracing::info!("Commit transaction published on chain: {}", txid);
     }
 
     for cfd in cfds.iter().filter(|cfd| Cfd::is_pending_cet(cfd)) {
-        // Double question-mark OK because if we are in PendingCet we must have been Ready before
+        // Double question mark OK because if we are in PendingCet we must have been Ready before
         let signed_cet = cfd.cet()??;
-        let txid = wallet.try_broadcast_transaction(signed_cet).await?;
+        let txid = try_continue!(wallet.try_broadcast_transaction(signed_cet).await);
 
         tracing::info!("CET published on chain: {}", txid);
     }

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -22,6 +22,7 @@ pub mod setup_contract;
 pub mod taker_cfd;
 pub mod to_sse_event;
 pub mod tokio_ext;
+pub mod try_continue;
 pub mod wallet;
 pub mod wallet_sync;
 pub mod wire;

--- a/daemon/src/try_continue.rs
+++ b/daemon/src/try_continue.rs
@@ -1,0 +1,13 @@
+/// Wrapper for errors in loop that logs error and continues
+#[macro_export]
+macro_rules! try_continue {
+    ($result:expr) => {
+        match $result {
+            Ok(value) => value,
+            Err(e) => {
+                tracing::error!("{:#}", e);
+                continue;
+            }
+        }
+    };
+}


### PR DESCRIPTION
We should not fail for loops where we loop over cfds to process state updates based on information we learned / restart. 
We use a macro to wrap all fallible code in the loop to just print an error and continue. 

Note: I went over the codebase in search of other for loops, maybe someone else can do another grep :)