### PR TITLE
Taker cleans up order feed

### DIFF
--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -155,6 +155,11 @@ impl<O, M> Actor<O, M> {
 
         insert_cfd(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;
 
+        // Cleanup own order feed, after inserting the cfd.
+        // Due to the 1:1 relationship between order and cfd we can never create another cfd for the
+        // same order id.
+        self.order_feed_actor_inbox.send(None)?;
+
         self.send_to_maker
             .do_send(wire::TakerToMaker::TakeOrder { order_id, quantity })?;
 


### PR DESCRIPTION
fixes https://github.com/comit-network/hermes/issues/399

The first commit was mostly added for ensuring sanity - this should also help us for scenarios where we restart the taker and the maker sends over the same current order as before.  Instead of bailing in `insert` we could handle this in a less intrusive way, because in some scenarios (as the one above) it is actually expected at the moment, so we might not want to treat it as error. For now I kept it simple and just bail (otherwise the insert would fail...) - that should not cause side effects.