### PR TITLE
Fix price type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 .pnp.*
 
 # Artifacts from running the daemons
-/*.sqlite*
+*.sqlite*
 /maker_seed
 /taker_seed
 /mainnet

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -6,7 +6,7 @@ use crate::model::cfd::{
     OrderId, Origin, Role, RollOverProposal, SettlementKind, SettlementProposal, UpdateCfdProposal,
     UpdateCfdProposals,
 };
-use crate::model::{TakerId, Usd};
+use crate::model::{Price, TakerId, Usd};
 use crate::monitor::MonitorParams;
 use crate::{log_error, maker_inc_connections, monitor, oracle, setup_contract, wallet, wire};
 use anyhow::{Context as _, Result};
@@ -34,7 +34,7 @@ pub enum CfdAction {
 }
 
 pub struct NewOrder {
-    pub price: Usd,
+    pub price: Price,
     pub min_quantity: Usd,
     pub max_quantity: Usd,
 }
@@ -633,7 +633,7 @@ where
 {
     async fn handle_new_order(
         &mut self,
-        price: Usd,
+        price: Price,
         min_quantity: Usd,
         max_quantity: Usd,
     ) -> Result<()> {

--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use bdk::bitcoin::Network;
 use daemon::auth::Authenticated;
 use daemon::model::cfd::{Cfd, Order, OrderId, Role, UpdateCfdProposals};
-use daemon::model::{Usd, WalletInfo};
+use daemon::model::{Price, Usd, WalletInfo};
 use daemon::routes::EmbeddedFileExt;
 use daemon::to_sse_event::{CfdAction, CfdsWithAuxData, ToSseEvent};
 use daemon::{bitmex_price_feed, maker_cfd};
@@ -101,7 +101,7 @@ pub async fn maker_feed(
 // TODO: Use Rocket form?
 #[derive(Debug, Clone, Deserialize)]
 pub struct CfdNewOrderRequest {
-    pub price: Usd,
+    pub price: Price,
     // TODO: [post-MVP] Representation of the contract size; at the moment the contract size is
     // always 1 USD
     pub min_quantity: Usd,

--- a/daemon/src/routes_taker.rs
+++ b/daemon/src/routes_taker.rs
@@ -1,6 +1,6 @@
 use bdk::bitcoin::{Amount, Network};
 use daemon::model::cfd::{calculate_buy_margin, Cfd, Order, OrderId, Role, UpdateCfdProposals};
-use daemon::model::{Leverage, Usd, WalletInfo};
+use daemon::model::{Leverage, Price, Usd, WalletInfo};
 use daemon::routes::EmbeddedFileExt;
 use daemon::to_sse_event::{CfdAction, CfdsWithAuxData, ToSseEvent};
 use daemon::{bitmex_price_feed, taker_cfd};
@@ -160,7 +160,7 @@ pub fn get_health_check() {}
 
 #[derive(Debug, Clone, Copy, Deserialize)]
 pub struct MarginRequest {
-    pub price: Usd,
+    pub price: Price,
     pub quantity: Usd,
     pub leverage: Leverage,
 }
@@ -182,8 +182,7 @@ pub fn margin_calc(
         margin_request.price,
         margin_request.quantity,
         margin_request.leverage,
-    )
-    .map_err(|e| status::BadRequest(Some(e.to_string())))?;
+    );
 
     Ok(status::Accepted(Some(Json(MarginResponse { margin }))))
 }

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -5,7 +5,7 @@ use crate::model::cfd::{
     OrderId, Origin, Role, RollOverProposal, SettlementKind, SettlementProposal, UpdateCfdProposal,
     UpdateCfdProposals,
 };
-use crate::model::{BitMexPriceEventId, Usd};
+use crate::model::{BitMexPriceEventId, Price, Usd};
 use crate::monitor::{self, MonitorParams};
 use crate::wire::{MakerToTaker, RollOverMsg, SetupMsg};
 use crate::{log_error, oracle, setup_contract, wallet, wire};
@@ -28,7 +28,7 @@ pub struct TakeOffer {
 pub enum CfdAction {
     ProposeSettlement {
         order_id: OrderId,
-        current_price: Usd,
+        current_price: Price,
     },
     ProposeRollOver {
         order_id: OrderId,
@@ -193,7 +193,7 @@ where
     async fn handle_propose_settlement(
         &mut self,
         order_id: OrderId,
-        current_price: Usd,
+        current_price: Price,
     ) -> Result<()> {
         let mut conn = self.db.acquire().await?;
         let cfd = load_cfd_by_order_id(order_id, &mut conn).await?;

--- a/daemon/src/to_sse_event.rs
+++ b/daemon/src/to_sse_event.rs
@@ -1,7 +1,7 @@
 use crate::model::cfd::{
     Dlc, OrderId, Payout, Role, SettlementKind, UpdateCfdProposal, UpdateCfdProposals,
 };
-use crate::model::{Leverage, Position, TradingPair, Usd};
+use crate::model::{Leverage, Position, Price, TradingPair, Usd};
 use crate::{bitmex_price_feed, model};
 use bdk::bitcoin::{Amount, Network, SignedAmount, Txid};
 use rocket::request::FromParam;
@@ -16,12 +16,12 @@ use tokio::sync::watch;
 #[derive(Debug, Clone, Serialize)]
 pub struct Cfd {
     pub order_id: OrderId,
-    pub initial_price: Usd,
+    pub initial_price: Price,
 
     pub leverage: Leverage,
     pub trading_pair: TradingPair,
     pub position: Position,
-    pub liquidation_price: Usd,
+    pub liquidation_price: Price,
 
     pub quantity_usd: Usd,
 
@@ -163,13 +163,13 @@ pub struct CfdOrder {
     pub trading_pair: TradingPair,
     pub position: Position,
 
-    pub price: Usd,
+    pub price: Price,
 
     pub min_quantity: Usd,
     pub max_quantity: Usd,
 
     pub leverage: Leverage,
-    pub liquidation_price: Usd,
+    pub liquidation_price: Price,
 
     pub creation_timestamp: u64,
     pub term_in_secs: u64,
@@ -184,7 +184,7 @@ pub trait ToSseEvent {
 /// by UI
 pub struct CfdsWithAuxData {
     pub cfds: Vec<model::cfd::Cfd>,
-    pub current_price: Usd,
+    pub current_price: Price,
     pub pending_proposals: UpdateCfdProposals,
     pub network: Network,
 }
@@ -419,8 +419,8 @@ fn to_tx_url_list(state: model::cfd::CfdState, network: Network) -> Vec<TxUrl> {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Quote {
-    bid: Usd,
-    ask: Usd,
+    bid: Price,
+    ask: Price,
     last_updated_at: u64,
 }
 

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -1,5 +1,5 @@
 use crate::model::cfd::{Order, OrderId};
-use crate::model::{BitMexPriceEventId, Usd};
+use crate::model::{BitMexPriceEventId, Price, Usd};
 use anyhow::{bail, Result};
 use bdk::bitcoin::secp256k1::Signature;
 use bdk::bitcoin::util::psbt::PartiallySignedTransaction;
@@ -31,7 +31,7 @@ pub enum TakerToMaker {
         taker: Amount,
         #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
         maker: Amount,
-        price: Usd,
+        price: Price,
     },
     InitiateSettlement {
         order_id: OrderId,

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -4,7 +4,7 @@ use bdk::bitcoin::{ecdsa, Txid};
 use cfd_protocol::secp256k1_zkp::{schnorrsig, Secp256k1};
 use cfd_protocol::PartyParams;
 use daemon::model::cfd::Order;
-use daemon::model::{Usd, WalletInfo};
+use daemon::model::{Price, Usd, WalletInfo};
 use daemon::{connection, db, logger, maker_cfd, maker_inc_connections, monitor, oracle, wallet};
 use rand::thread_rng;
 use rust_decimal_macros::dec;
@@ -36,7 +36,7 @@ async fn taker_receives_order_from_maker_on_publication() {
 
 fn new_dummy_order() -> maker_cfd::NewOrder {
     maker_cfd::NewOrder {
-        price: Usd::new(dec!(50_000)),
+        price: Price::new(dec!(50_000)).expect("unexpected failure"),
         min_quantity: Usd::new(dec!(10)),
         max_quantity: Usd::new(dec!(100)),
     }


### PR DESCRIPTION
Replacement of structs with public data to ones with private data

Addresses #357 and #365. Although not a very large change, this PR ends up touching rather a lot of code.

* Converted types `Usd`, `Leverage` and `Percent` to something that is appropriate to this application
* Created new types `Price` and `InversePrice` to use for BTC/USD exchange rate with appropriate algebraic ops implemented as well.
* Added new positive tests
* The function `daemon::model::calculate_profit()` has been changed substantially as the updated types make the existing workflow needlessly complex
* Some tests (mostly in `cfd.rs` required updating) in order to make use of the new types.
* Minor edit to `.gitignore` to avoid accidental pushing of DB to repository--should have been it's own item, added here to fix a problem that arose during this work.

NOTE:
* There may be an excess of algebraic ops implemented, some pruning may be appropriate.