### PR TITLE
All the term to be configurable on the maker's commandline

### DIFF
--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -812,6 +812,7 @@ mod tests {
                 Usd::new(dec!(1000)),
                 Origin::Theirs,
                 BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc()),
+                time::Duration::hours(24),
             )
             .unwrap()
         }

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -751,7 +751,7 @@ where
         let dlc = cfd.open_dlc().context("CFD was in wrong state")?;
 
         let oracle_event_id =
-            oracle::next_announcement_after(time::OffsetDateTime::now_utc() + Order::TERM)?;
+            oracle::next_announcement_after(time::OffsetDateTime::now_utc() + cfd.order.term)?;
         let announcement = self
             .oracle_actor
             .send(oracle::GetAnnouncement(oracle_event_id))

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -125,14 +125,13 @@ pub struct Order {
 }
 
 impl Order {
-    pub const TERM: Duration = Duration::hours(24);
-
     pub fn new(
         price: Usd,
         min_quantity: Usd,
         max_quantity: Usd,
         origin: Origin,
         oracle_event_id: BitMexPriceEventId,
+        term: Duration,
     ) -> Result<Self> {
         let leverage = Leverage(2);
         let maintenance_margin_rate = dec!(0.005);
@@ -149,7 +148,7 @@ impl Order {
             liquidation_price,
             position: Position::Sell,
             creation_timestamp: SystemTime::now(),
-            term: Self::TERM,
+            term,
             origin,
             oracle_event_id,
         })

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -340,6 +340,8 @@ where
             anyhow::bail!("An update for order id {} is already in progress", order_id)
         }
 
+        let order = load_order_by_id(order_id, &mut self.db.acquire().await?).await?;
+
         let proposal = RollOverProposal {
             order_id,
             timestamp: SystemTime::now(),
@@ -357,7 +359,7 @@ where
         // we are likely going to need this one
         self.oracle_actor
             .send(oracle::FetchAnnouncement(oracle::next_announcement_after(
-                OffsetDateTime::now_utc() + Order::TERM,
+                OffsetDateTime::now_utc() + order.term,
             )?))
             .await?;
 


### PR DESCRIPTION
- Use the original order's term for rolling over
- Allow term to be configurable on the maker's commandline
