### PR TITLE
Remove all usages of `#[allow(dead_code)]`

### DIFF
--- a/daemon/src/bitmex_price_feed.rs
+++ b/daemon/src/bitmex_price_feed.rs
@@ -68,12 +68,10 @@ impl Quote {
         }))
     }
 
-    #[allow(dead_code)] // Not used by all binaries.
     pub fn for_maker(&self) -> Usd {
         self.ask
     }
 
-    #[allow(dead_code)] // Not used by all binaries.
     pub fn for_taker(&self) -> Usd {
         // TODO: verify whether this is correct
         self.mid_range().unwrap()

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -188,7 +188,6 @@ pub async fn append_cfd_state(cfd: &Cfd, conn: &mut PoolConnection<Sqlite>) -> a
     Ok(())
 }
 
-#[allow(dead_code)]
 async fn load_cfd_id_by_order_uuid(
     order_uuid: OrderId,
     conn: &mut PoolConnection<Sqlite>,
@@ -210,7 +209,6 @@ async fn load_cfd_id_by_order_uuid(
     Ok(cfd_id)
 }
 
-#[allow(dead_code)]
 async fn load_latest_cfd_state(
     cfd_id: i64,
     conn: &mut PoolConnection<Sqlite>,

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -124,7 +124,6 @@ pub struct Order {
     pub oracle_event_id: BitMexPriceEventId,
 }
 
-#[allow(dead_code)] // Only one binary and the tests use this.
 impl Order {
     pub const TERM: Duration = Duration::hours(24);
 
@@ -581,7 +580,6 @@ pub struct RollOverProposal {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Variants (for now) used by different binaries.
 pub enum SettlementKind {
     Incoming,
     Outgoing,
@@ -684,7 +682,6 @@ impl Cfd {
         }
     }
 
-    #[allow(dead_code)]
     pub fn refund_timelock_in_blocks(&self) -> u32 {
         (self.order.term * Cfd::REFUND_THRESHOLD).as_blocks().ceil() as u32
     }
@@ -701,10 +698,8 @@ impl Cfd {
     /// The downside is that if the oracle disappears: the users would only notice at the end
     /// of the cfd term. In this case the users has to wait for another `1.5` times of the
     /// term to get his funds back.
-    #[allow(dead_code)]
     const REFUND_THRESHOLD: f32 = 1.5;
 
-    #[allow(dead_code)]
     pub const CET_TIMELOCK: u32 = 12;
 
     pub fn handle(&mut self, event: CfdStateChangeEvent) -> Result<Option<CfdState>> {
@@ -1292,7 +1287,6 @@ pub struct NotReadyYet {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Not all variants are used by all binaries.
 pub enum CfdStateChangeEvent {
     // TODO: group other events by actors into enums and add them here so we can bundle all
     // transitions into cfd.transition_to(...)
@@ -1718,7 +1712,6 @@ impl Dlc {
         Ok((tx, sig))
     }
 
-    #[allow(dead_code)] // Used only by the maker.
     pub fn finalize_spend_transaction(
         &self,
         (close_tx, own_sig): (Transaction, Signature),

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -257,7 +257,6 @@ impl xtra::Handler<NewAttestationFetched> for Actor {
     }
 }
 
-#[allow(dead_code)]
 pub fn next_announcement_after(timestamp: OffsetDateTime) -> Result<BitMexPriceEventId> {
     let adjusted = ceil_to_next_hour(timestamp)?;
 

--- a/daemon/src/seed.rs
+++ b/daemon/src/seed.rs
@@ -63,7 +63,6 @@ impl Seed {
         Ok(ext_priv_key)
     }
 
-    #[allow(dead_code)] // Not used by all binaries.
     pub fn derive_auth_password<P: From<[u8; 32]>>(&self) -> P {
         let mut password = [0u8; 32];
 


### PR DESCRIPTION
This is a legacy from not having a library crate.
