### PR TITLE
Prefer automatic links in docs

### DIFF
--- a/cfd_protocol/src/interval/digit_decomposition.rs
+++ b/cfd_protocol/src/interval/digit_decomposition.rs
@@ -1,7 +1,7 @@
 //! Utility functions to decompose numeric outcome values
 //!
 //! This code has been lifted from:
-//! https://github.com/p2pderivatives/rust-dlc/blob/chore%2Ffactor-out-dlc-trie/dlc-trie/src/digit_decomposition.rs
+//! <https://github.com/p2pderivatives/rust-dlc/blob/chore%2Ffactor-out-dlc-trie/dlc-trie/src/digit_decomposition.rs>
 
 /// Describes an interval that starts at `prefix || start` and terminates at `prefix || end`.
 struct PrefixInterval {

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -279,7 +279,7 @@ pub struct Announcement {
     /// Identifier for an oracle event.
     ///
     /// Doubles up as the path of the URL for this event i.e.
-    /// https://h00.ooo/{id}.
+    /// <https://h00.ooo/>{id}.
     pub id: BitMexPriceEventId,
     pub expected_outcome_time: OffsetDateTime,
     pub nonce_pks: Vec<schnorrsig::PublicKey>,

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -146,7 +146,7 @@ struct RpcError {
     code: i64,
 }
 
-/// Bitcoin error codes: https://github.com/bitcoin/bitcoin/blob/97d3500601c1d28642347d014a6de1e38f53ae4e/src/rpc/protocol.h#L23
+/// Bitcoin error codes: <https://github.com/bitcoin/bitcoin/blob/97d3500601c1d28642347d014a6de1e38f53ae4e/src/rpc/protocol.h#L23>
 pub enum RpcErrorCode {
     /// Transaction or block was rejected by network rules. Error code -27.
     RpcVerifyAlreadyInChain,


### PR DESCRIPTION
Automatic links (wrapped inside <>) are automatically turned into clickable
links when you generate documentation

Gets rid of the warnings when you run `cargo doc`