### PR TITLE
Ensure we always know about Order::Term * announcements

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -57,7 +57,6 @@ impl<O, M, T, W> MakerActorSystem<O, M, T, W>
 where
     O: xtra::Handler<oracle::MonitorAttestation>
         + xtra::Handler<oracle::GetAnnouncement>
-        + xtra::Handler<oracle::FetchAnnouncement>
         + xtra::Handler<oracle::Sync>,
     M: xtra::Handler<monitor::StartMonitoring>
         + xtra::Handler<monitor::Sync>
@@ -162,7 +161,6 @@ impl<O, M, W> TakerActorSystem<O, M, W>
 where
     O: xtra::Handler<oracle::MonitorAttestation>
         + xtra::Handler<oracle::GetAnnouncement>
-        + xtra::Handler<oracle::FetchAnnouncement>
         + xtra::Handler<oracle::Sync>,
     M: xtra::Handler<monitor::StartMonitoring>
         + xtra::Handler<monitor::Sync>

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -190,6 +190,7 @@ async fn main() -> Result<()> {
     housekeeping::transition_non_continue_cfds_to_setup_failed(&mut conn).await?;
     housekeeping::rebroadcast_transactions(&mut conn, &wallet).await?;
 
+    let term = time::Duration::hours(opts.term as i64);
     let MakerActorSystem {
         cfd_actor_addr,
         cfd_feed_receiver,
@@ -200,7 +201,7 @@ async fn main() -> Result<()> {
         db.clone(),
         wallet.clone(),
         oracle,
-        |cfds, channel| oracle::Actor::new(cfds, channel),
+        |cfds, channel| oracle::Actor::new(cfds, channel, term),
         {
             |channel, cfds| {
                 let electrum = opts.network.electrum().to_string();

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -629,7 +629,6 @@ where
 
 impl<O, M, T, W> Actor<O, M, T, W>
 where
-    O: xtra::Handler<oracle::FetchAnnouncement>,
     T: xtra::Handler<maker_inc_connections::BroadcastOrder>,
 {
     async fn handle_new_order(
@@ -640,10 +639,6 @@ where
     ) -> Result<()> {
         let oracle_event_id =
             oracle::next_announcement_after(time::OffsetDateTime::now_utc() + self.term)?;
-
-        self.oracle_actor
-            .do_send_async(oracle::FetchAnnouncement(oracle_event_id))
-            .await?;
 
         let order = Order::new(
             price,
@@ -949,7 +944,6 @@ where
 #[async_trait]
 impl<O: 'static, M: 'static, T: 'static, W: 'static> Handler<NewOrder> for Actor<O, M, T, W>
 where
-    O: xtra::Handler<oracle::FetchAnnouncement>,
     T: xtra::Handler<maker_inc_connections::BroadcastOrder>,
 {
     async fn handle(&mut self, msg: NewOrder, _ctx: &mut Context<Self>) {

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -27,6 +27,8 @@ use xtra::Actor;
 
 mod routes_taker;
 
+pub const TERM: time::Duration = time::Duration::hours(24);
+
 #[derive(Clap)]
 struct Opts {
     /// The IP address of the other party (i.e. the maker).
@@ -179,7 +181,7 @@ async fn main() -> Result<()> {
         oracle,
         send_to_maker,
         read_from_maker,
-        |cfds, channel| oracle::Actor::new(cfds, channel),
+        |cfds, channel| oracle::Actor::new(cfds, channel, TERM),
         {
             |channel, cfds| {
                 let electrum = opts.network.electrum().to_string();

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -86,8 +86,6 @@ impl xtra::Actor for Oracle {}
 
 #[xtra_productivity(message_impl = false)]
 impl Oracle {
-    async fn handle_fetch_announcement(&mut self, _msg: oracle::FetchAnnouncement) {}
-
     async fn handle_get_announcement(
         &mut self,
         _msg: oracle::GetAnnouncement,


### PR DESCRIPTION
When looking into https://github.com/comit-network/hermes/issues/360 I realized we forgot to trigger `FetchAnnouncement` when receiving a roll-over request. 
This is fixed with this PR.

I found this a bit cumbersome to have to do this manually. Instead, we should sync regularly and ensure we have attestations for the next 24h. 

This is also related to the discussion @da-kami and @thomaseizinger had in https://github.com/comit-network/hermes/issues/349