### PR TITLE
Rename Buy and Sell to Long and Short

### DIFF
--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -441,8 +441,8 @@ pub enum TradingPair {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::Type)]
 pub enum Position {
-    Buy,
-    Sell,
+    Long,
+    Short,
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/daemon/src/routes_taker.rs
+++ b/daemon/src/routes_taker.rs
@@ -1,5 +1,5 @@
 use bdk::bitcoin::{Amount, Network};
-use daemon::model::cfd::{calculate_buy_margin, Cfd, Order, OrderId, Role, UpdateCfdProposals};
+use daemon::model::cfd::{calculate_long_margin, Cfd, Order, OrderId, Role, UpdateCfdProposals};
 use daemon::model::{Leverage, Price, Usd, WalletInfo};
 use daemon::routes::EmbeddedFileExt;
 use daemon::to_sse_event::{CfdAction, CfdsWithAuxData, ToSseEvent};
@@ -178,7 +178,7 @@ pub struct MarginResponse {
 pub fn margin_calc(
     margin_request: Json<MarginRequest>,
 ) -> Result<status::Accepted<Json<MarginResponse>>, status::BadRequest<String>> {
-    let margin = calculate_buy_margin(
+    let margin = calculate_long_margin(
         margin_request.price,
         margin_request.quantity,
         margin_request.leverage,

--- a/docs/asset/mvp_sequence_diagram.puml
+++ b/docs/asset/mvp_sequence_diagram.puml
@@ -34,7 +34,7 @@ UserApp -> User: Buy position open
 end group
 Seller -> SellerApp: Republish new sell-order
 group DLC settlement
-User -> UserApp: Close buy position
+User -> UserApp: Close long position
 UserApp -> Oracle: request attestation
 Oracle --> UserApp: attested price
 UserApp -> Bitcoin: CET according to price

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,14 +14,14 @@ The Minimal Viable Product's goal is to showcase that non-custidial CFD trading 
 
 ### In scope
 
-For the MVP there is only one Maker that takes the selling side and creates sell orders.
+For the MVP there is only one Maker that takes the short side and creates orders.
 The maker does not do any automation.
 The maker dictates the price.
 
 A user is always in the role of a taker.
 The user has a simple user interface and can take the maker's order there.
-The taker can specify a quantity, the leverage is fixed to `x5`.
-For the MVP the leverage is fixed to `x5` for both sell and buy orders.
+The taker can specify a quantity, the leverage is fixed to `x2`.
+For the MVP the leverage is fixed to `x1` for the maker.
 The oracle is needed for attestation of prices at a certain point in time.
 The oracle is to be run by a separate party that is neither the taker nor the maker.
 
@@ -38,11 +38,11 @@ Constraints:
 - Software Setup
   - Taker
     - Local running daemon that exposes API + web-interface for UI
-    - Can take a sell order (represents the buy side)
+    - Can take an order (represents the long side)
       - Specify quantity
       - (fixed leverage of `x5`)
   - Maker
-    - Can create a sell order (represents the sell side)
+    - Can create an order (represents the short side)
     - Sell order publication is done manually
     - Take requests are accepted manually
   - ♻️ Oracle

--- a/frontend/src/TakerApp.tsx
+++ b/frontend/src/TakerApp.tsx
@@ -206,7 +206,7 @@ export default function App() {
                                     makeNewOrderRequest(payload);
                                 }}
                             >
-                                BUY
+                                BUY LONG
                             </Button>
                         </GridItem>
                     </Grid>

--- a/frontend/src/components/Types.tsx
+++ b/frontend/src/components/Types.tsx
@@ -16,17 +16,17 @@ export class Position {
 
     public getColorScheme(): string {
         switch (this.key) {
-            case PositionKey.BUY:
+            case PositionKey.LONG:
                 return "green";
-            case PositionKey.SELL:
+            case PositionKey.SHORT:
                 return "blue";
         }
     }
 }
 
 enum PositionKey {
-    BUY = "Buy",
-    SELL = "Sell",
+    LONG = "Long",
+    SHORT = "Short",
 }
 
 export interface Cfd {


### PR DESCRIPTION
Addresses #373. Change made for consistency of language and removes some ambiguity in the business logic as a side-effect.