### PR TITLE
Use timestamp data from Bitmex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time 0.1.43",
  "winapi 0.3.9",
 ]
@@ -521,6 +522,7 @@ dependencies = [
  "bdk",
  "bytes",
  "cfd_protocol",
+ "chrono",
  "clap",
  "futures",
  "hex",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -10,6 +10,7 @@ atty = "0.2"
 bdk = { version = "0.12", default-features = false, features = ["sqlite", "electrum"] }
 bytes = "1"
 cfd_protocol = { path = "../cfd_protocol" }
+chrono = { version = "0.4", features = ["serde"] }
 clap = "3.0.0-beta.4"
 futures = { version = "0.3", default-features = false }
 hex = "0.4"

--- a/daemon/src/bitmex_price_feed.rs
+++ b/daemon/src/bitmex_price_feed.rs
@@ -1,10 +1,12 @@
 use crate::model::Price;
-use anyhow::Result;
+use anyhow::{Context, Result};
+use chrono::prelude::*;
 use futures::{StreamExt, TryStreamExt};
 use rust_decimal::Decimal;
 use std::convert::TryFrom;
 use std::future::Future;
 use std::time::SystemTime;
+use time::OffsetDateTime;
 use tokio::sync::watch;
 use tokio_tungstenite::tungstenite;
 
@@ -62,7 +64,7 @@ impl Quote {
         let [quote] = table_message.data;
 
         Ok(Some(Self {
-            timestamp: SystemTime::now(),
+            timestamp: datetime_to_system_time(&quote.timestamp)?,
             bid: Price::new(Decimal::try_from(quote.bid_price)?)?,
             ask: Price::new(Decimal::try_from(quote.ask_price)?)?,
         }))
@@ -80,6 +82,16 @@ impl Quote {
     fn mid_range(&self) -> Price {
         (self.bid + self.ask) / 2
     }
+}
+
+fn datetime_to_system_time(datetime_str: &str) -> Result<SystemTime> {
+    let datetime = DateTime::parse_from_rfc3339(datetime_str)
+        .context("Unable to parse datetime as RFC3339")?;
+    let unix_ts = datetime.timestamp();
+    let offset_dt = OffsetDateTime::from_unix_timestamp(unix_ts)
+        .context("Unable to convert to UNIX timestamp")?;
+
+    Ok(SystemTime::from(offset_dt))
 }
 
 mod wire {
@@ -100,11 +112,14 @@ mod wire {
         pub bid_price: f64,
         pub ask_price: f64,
         pub symbol: String,
+        pub timestamp: String,
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::UNIX_EPOCH;
+
     use super::*;
     use rust_decimal_macros::dec;
 
@@ -113,8 +128,14 @@ mod tests {
         let message = tungstenite::Message::Text(r#"{"table":"quoteBin1m","action":"insert","data":[{"timestamp":"2021-09-21T02:40:00.000Z","symbol":"XBTUSD","bidSize":50200,"bidPrice":42640.5,"askPrice":42641,"askSize":363600}]}"#.to_owned());
 
         let quote = Quote::from_message(message).unwrap().unwrap();
+        let quote_ts_seconds = quote
+            .timestamp
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
 
         assert_eq!(quote.bid, Price::new(dec!(42640.5)).unwrap());
         assert_eq!(quote.ask, Price::new(dec!(42641)).unwrap());
+        assert_eq!(quote_ts_seconds, 1632192000);
     }
 }


### PR DESCRIPTION
Addresses #434. Quote data includes a `timestamp` column and this PR allows us to consume it.