### PR TITLE
Consume both feeds in test

### DIFF
--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -25,8 +25,10 @@ async fn taker_receives_order_from_maker_on_publication() {
 
     assert!(is_next_none(&mut taker.order_feed).await);
 
+    maker.publish_order(new_dummy_order());
+
     let (published, received) = tokio::join!(
-        maker.publish_order(new_dummy_order()),
+        next_some(&mut maker.order_feed),
         next_some(&mut taker.order_feed)
     );
 
@@ -153,7 +155,7 @@ impl Wallet {
 struct Maker {
     cfd_actor_addr:
         xtra::Address<maker_cfd::Actor<Oracle, Monitor, maker_inc_connections::Actor, Wallet>>,
-    order_feed_receiver: watch::Receiver<Option<Order>>,
+    order_feed: watch::Receiver<Option<Order>>,
     #[allow(dead_code)] // we need to keep the xtra::Address for refcounting
     inc_conn_addr: xtra::Address<maker_inc_connections::Actor>,
     address: SocketAddr,
@@ -199,17 +201,14 @@ impl Maker {
 
         Self {
             cfd_actor_addr: maker.cfd_actor_addr,
-            order_feed_receiver: maker.order_feed_receiver,
+            order_feed: maker.order_feed_receiver,
             inc_conn_addr: maker.inc_conn_addr,
             address,
         }
     }
 
-    async fn publish_order(&mut self, new_order_params: maker_cfd::NewOrder) -> Order {
-        self.cfd_actor_addr.send(new_order_params).await.unwrap();
-        let next_order = self.order_feed_receiver.borrow().clone().unwrap();
-
-        next_order
+    fn publish_order(&mut self, new_order_params: maker_cfd::NewOrder) {
+        self.cfd_actor_addr.do_send(new_order_params).unwrap();
     }
 }
 

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -157,8 +157,8 @@ struct Maker {
         xtra::Address<maker_cfd::Actor<Oracle, Monitor, maker_inc_connections::Actor, Wallet>>,
     order_feed: watch::Receiver<Option<Order>>,
     #[allow(dead_code)] // we need to keep the xtra::Address for refcounting
-    inc_conn_addr: xtra::Address<maker_inc_connections::Actor>,
-    address: SocketAddr,
+    inc_conn_actor_addr: xtra::Address<maker_inc_connections::Actor>,
+    listen_addr: SocketAddr,
 }
 
 impl Maker {
@@ -202,8 +202,8 @@ impl Maker {
         Self {
             cfd_actor_addr: maker.cfd_actor_addr,
             order_feed: maker.order_feed_receiver,
-            inc_conn_addr: maker.inc_conn_addr,
-            address,
+            inc_conn_actor_addr: maker.inc_conn_addr,
+            listen_addr: address,
         }
     }
 
@@ -254,7 +254,7 @@ async fn start_both() -> (Maker, Taker) {
     .unwrap();
 
     let maker = Maker::start(oracle_pk).await;
-    let taker = Taker::start(oracle_pk, maker.address).await;
+    let taker = Taker::start(oracle_pk, maker.listen_addr).await;
     (maker, taker)
 }
 


### PR DESCRIPTION
Minor changes on the test we already have. When creating another test I noticed that it reads nicer to just join on both channels. We might even pack the join into the `next` function at some point and return from both - I did not go that far yet. 

Note that this is also closer to what we do in the production code, because we now send the message with `do_send_async` which is what we do there. 