### PR TITLE
Nanoseconds begone!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time 0.1.43",
  "winapi 0.3.9",
 ]
@@ -521,6 +522,7 @@ dependencies = [
  "bdk",
  "bytes",
  "cfd_protocol",
+ "chrono",
  "clap",
  "futures",
  "hex",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -10,6 +10,7 @@ atty = "0.2"
 bdk = { version = "0.12", default-features = false, features = ["sqlite", "electrum"] }
 bytes = "1"
 cfd_protocol = { path = "../cfd_protocol" }
+chrono = { version = "0.4", features = ["serde"] }
 clap = "3.0.0-beta.4"
 futures = { version = "0.3", default-features = false }
 hex = "0.4"

--- a/daemon/migrations/20211025050345_rename_term_to_settlement_time_interval.sql
+++ b/daemon/migrations/20211025050345_rename_term_to_settlement_time_interval.sql
@@ -2,4 +2,7 @@ alter table orders
 rename column term_seconds to settlement_time_interval_seconds;
 
 alter table orders
-rename column term_nanoseconds to settlement_time_interval_nanoseconds;
+drop column creation_timestamp_nanoseconds;
+
+alter table orders
+drop column term_nanoseconds;

--- a/daemon/sqlx-data.json
+++ b/daemon/sqlx-data.json
@@ -1,7 +1,7 @@
 {
   "db": "SQLite",
-  "07b8db7d3a709a7f06a20251d5b7251c2a3428ec73c6710a83048d6c8e974958": {
-    "query": "\n        select\n            uuid as \"uuid: crate::model::cfd::OrderId\",\n            trading_pair as \"trading_pair: crate::model::TradingPair\",\n            position as \"position: crate::model::Position\",\n            initial_price,\n            min_quantity,\n            max_quantity,\n            leverage as \"leverage: crate::model::Leverage\",\n            liquidation_price,\n            creation_timestamp_seconds as \"ts_secs: i64\",\n            creation_timestamp_nanoseconds as \"ts_nanos: i32\",\n            settlement_time_interval_seconds as \"settlement_time_interval_secs: i64\",\n            settlement_time_interval_nanoseconds as \"settlement_time_interval_nanos: i32\",\n            origin as \"origin: crate::model::cfd::Origin\",\n            oracle_event_id\n\n        from orders\n        where uuid = $1\n        ",
+  "04399897350d026ee0830ccaba3638f8aa8f4ef9694d59286f32b9e2449a99fa": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.uuid = $1\n        ",
     "describe": {
       "columns": [
         {
@@ -45,139 +45,33 @@
           "type_info": "Text"
         },
         {
-          "name": "ts_secs: i64",
+          "name": "ts_secs: crate::model::Timestamp",
           "ordinal": 8,
           "type_info": "Int64"
         },
         {
-          "name": "ts_nanos: i32",
+          "name": "settlement_time_interval_secs: i64",
           "ordinal": 9,
           "type_info": "Int64"
         },
         {
-          "name": "settlement_time_interval_secs: i64",
-          "ordinal": 10,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_nanos: i32",
-          "ordinal": 11,
-          "type_info": "Int64"
-        },
-        {
           "name": "origin: crate::model::cfd::Origin",
-          "ordinal": 12,
+          "ordinal": 10,
           "type_info": "Text"
         },
         {
           "name": "oracle_event_id",
-          "ordinal": 13,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "1ea6916f2e25bdd8f4761f0810178ed3b5e52817e6440b54d2bf4e13fb786405": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                creation_timestamp_nanoseconds as ts_nanos,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                settlement_time_interval_nanoseconds as settlement_time_interval_nanos,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: i64\",\n            ord.ts_nanos as \"ts_nanos: i32\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.settlement_time_interval_nanos as \"settlement_time_interval_nanos: i32\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.uuid = $1\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "uuid: crate::model::cfd::OrderId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "trading_pair: crate::model::TradingPair",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "position: crate::model::Position",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "initial_price",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "min_quantity",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "max_quantity",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "leverage: crate::model::Leverage",
-          "ordinal": 6,
-          "type_info": "Int64"
-        },
-        {
-          "name": "liquidation_price",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "ts_secs: i64",
-          "ordinal": 8,
-          "type_info": "Int64"
-        },
-        {
-          "name": "ts_nanos: i32",
-          "ordinal": 9,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_secs: i64",
-          "ordinal": 10,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_nanos: i32",
           "ordinal": 11,
-          "type_info": "Int64"
-        },
-        {
-          "name": "origin: crate::model::cfd::Origin",
-          "ordinal": 12,
-          "type_info": "Text"
-        },
-        {
-          "name": "oracle_event_id",
-          "ordinal": 13,
           "type_info": "Text"
         },
         {
           "name": "quantity_usd",
-          "ordinal": 14,
+          "ordinal": 12,
           "type_info": "Text"
         },
         {
           "name": "state",
-          "ordinal": 15,
+          "ordinal": 13,
           "type_info": "Text"
         }
       ],
@@ -185,8 +79,6 @@
         "Right": 1
       },
       "nullable": [
-        false,
-        false,
         false,
         false,
         false,
@@ -222,8 +114,8 @@
       ]
     }
   },
-  "571575003ef3ad8ad627213f11c9080c25a29bb665077ada9047630acfe4465c": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                creation_timestamp_nanoseconds as ts_nanos,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                settlement_time_interval_nanoseconds as settlement_time_interval_nanos,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: i64\",\n            ord.ts_nanos as \"ts_nanos: i32\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.settlement_time_interval_nanos as \"settlement_time_interval_nanos: i32\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.oracle_event_id = $1\n        ",
+  "22aae04782d6d9d6fa025e7606e3dcce91bfb9aca4aef9089a9ff9407c9f2715": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n        ",
     "describe": {
       "columns": [
         {
@@ -267,43 +159,119 @@
           "type_info": "Text"
         },
         {
-          "name": "ts_secs: i64",
+          "name": "ts_secs: crate::model::Timestamp",
           "ordinal": 8,
           "type_info": "Int64"
         },
         {
-          "name": "ts_nanos: i32",
+          "name": "settlement_time_interval_secs: i64",
           "ordinal": 9,
           "type_info": "Int64"
         },
         {
-          "name": "settlement_time_interval_secs: i64",
-          "ordinal": 10,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_nanos: i32",
-          "ordinal": 11,
-          "type_info": "Int64"
-        },
-        {
           "name": "origin: crate::model::cfd::Origin",
-          "ordinal": 12,
+          "ordinal": 10,
           "type_info": "Text"
         },
         {
           "name": "oracle_event_id",
-          "ordinal": 13,
+          "ordinal": 11,
           "type_info": "Text"
         },
         {
           "name": "quantity_usd",
-          "ordinal": 14,
+          "ordinal": 12,
           "type_info": "Text"
         },
         {
           "name": "state",
-          "ordinal": 15,
+          "ordinal": 13,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 0
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "4bb5424ebcd683a149f15df5560fdea6727174f4cd6e0709e526ac3a690e2e5e": {
+    "query": "\n        select\n            uuid as \"uuid: crate::model::cfd::OrderId\",\n            trading_pair as \"trading_pair: crate::model::TradingPair\",\n            position as \"position: crate::model::Position\",\n            initial_price,\n            min_quantity,\n            max_quantity,\n            leverage as \"leverage: crate::model::Leverage\",\n            liquidation_price,\n            creation_timestamp_seconds as \"ts_secs: crate::model::Timestamp\",\n            settlement_time_interval_seconds as \"settlement_time_interval_secs: i64\",\n            origin as \"origin: crate::model::cfd::Origin\",\n            oracle_event_id\n\n        from orders\n        where uuid = $1\n        ",
+    "describe": {
+      "columns": [
+        {
+          "name": "uuid: crate::model::cfd::OrderId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "trading_pair: crate::model::TradingPair",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: crate::model::Position",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "min_quantity",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "max_quantity",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "leverage: crate::model::Leverage",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "liquidation_price",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "ts_secs: crate::model::Timestamp",
+          "ordinal": 8,
+          "type_info": "Int64"
+        },
+        {
+          "name": "settlement_time_interval_secs: i64",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "origin: crate::model::cfd::Origin",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "oracle_event_id",
+          "ordinal": 11,
           "type_info": "Text"
         }
       ],
@@ -313,6 +281,98 @@
       "nullable": [
         false,
         false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "6dbd14a613a982521b4cc9179fd6f6b0298c0a4475508536379e9b82c9f2d0a0": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.oracle_event_id = $1\n        ",
+    "describe": {
+      "columns": [
+        {
+          "name": "uuid: crate::model::cfd::OrderId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "trading_pair: crate::model::TradingPair",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: crate::model::Position",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "min_quantity",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "max_quantity",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "leverage: crate::model::Leverage",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "liquidation_price",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "ts_secs: crate::model::Timestamp",
+          "ordinal": 8,
+          "type_info": "Int64"
+        },
+        {
+          "name": "settlement_time_interval_secs: i64",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "origin: crate::model::cfd::Origin",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "oracle_event_id",
+          "ordinal": 11,
+          "type_info": "Text"
+        },
+        {
+          "name": "quantity_usd",
+          "ordinal": 12,
+          "type_info": "Text"
+        },
+        {
+          "name": "state",
+          "ordinal": 13,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": [
         false,
         false,
         false,
@@ -345,114 +405,6 @@
       },
       "nullable": [
         true
-      ]
-    }
-  },
-  "b5a6bcafbfa745d147c30410e0acf8ee6c7733cc3e550a2db0c7860737c756dd": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                creation_timestamp_nanoseconds as ts_nanos,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                settlement_time_interval_nanoseconds as settlement_time_interval_nanos,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: i64\",\n            ord.ts_nanos as \"ts_nanos: i32\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.settlement_time_interval_nanos as \"settlement_time_interval_nanos: i32\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "uuid: crate::model::cfd::OrderId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "trading_pair: crate::model::TradingPair",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "position: crate::model::Position",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "initial_price",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "min_quantity",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "max_quantity",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "leverage: crate::model::Leverage",
-          "ordinal": 6,
-          "type_info": "Int64"
-        },
-        {
-          "name": "liquidation_price",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "ts_secs: i64",
-          "ordinal": 8,
-          "type_info": "Int64"
-        },
-        {
-          "name": "ts_nanos: i32",
-          "ordinal": 9,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_secs: i64",
-          "ordinal": 10,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_nanos: i32",
-          "ordinal": 11,
-          "type_info": "Int64"
-        },
-        {
-          "name": "origin: crate::model::cfd::Origin",
-          "ordinal": 12,
-          "type_info": "Text"
-        },
-        {
-          "name": "oracle_event_id",
-          "ordinal": 13,
-          "type_info": "Text"
-        },
-        {
-          "name": "quantity_usd",
-          "ordinal": 14,
-          "type_info": "Text"
-        },
-        {
-          "name": "state",
-          "ordinal": 15,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 0
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
       ]
     }
   }

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -5,7 +5,7 @@ use crate::model::cfd::{
     OrderId, Origin, Role, RollOverProposal, SettlementKind, SettlementProposal, UpdateCfdProposal,
     UpdateCfdProposals,
 };
-use crate::model::{BitMexPriceEventId, Price, Usd};
+use crate::model::{BitMexPriceEventId, Price, Timestamp, Usd};
 use crate::monitor::{self, MonitorParams};
 use crate::wire::{MakerToTaker, RollOverMsg, SetupMsg};
 use crate::{log_error, oracle, setup_contract, wallet, wire};
@@ -15,7 +15,6 @@ use bdk::bitcoin::secp256k1::schnorrsig;
 use futures::channel::mpsc;
 use futures::{future, SinkExt};
 use std::collections::HashMap;
-use std::time::SystemTime;
 use tokio::sync::watch;
 use xtra::prelude::*;
 use xtra::KeepRunning;
@@ -357,7 +356,7 @@ where
 
         let proposal = RollOverProposal {
             order_id,
-            timestamp: SystemTime::now(),
+            timestamp: Timestamp::now()?,
         };
 
         self.current_pending_proposals.insert(
@@ -634,7 +633,7 @@ where
                 tx.clone(),
                 dlc.script_pubkey_for(cfd.role()),
                 proposal.price,
-            ),
+            )?,
         ))?;
         append_cfd_state(&cfd, &mut conn, &self.cfd_feed_actor_inbox).await?;
 

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -1,4 +1,4 @@
-use crate::model::WalletInfo;
+use crate::model::{Timestamp, WalletInfo};
 use anyhow::{Context, Result};
 use bdk::bitcoin::consensus::encode::serialize_hex;
 use bdk::bitcoin::util::bip32::ExtendedPrivKey;
@@ -11,7 +11,6 @@ use cfd_protocol::{PartyParams, WalletExt};
 use rocket::serde::json::Value;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::SystemTime;
 use tokio::sync::Mutex;
 use xtra_productivity::xtra_productivity;
 
@@ -64,7 +63,7 @@ impl Actor {
         let wallet_info = WalletInfo {
             balance: Amount::from_sat(balance),
             address,
-            last_updated_at: SystemTime::now(),
+            last_updated_at: Timestamp::now()?,
         };
 
         Ok(wallet_info)

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -1,5 +1,5 @@
 use crate::model::cfd::{Order, OrderId};
-use crate::model::{BitMexPriceEventId, Price, Usd};
+use crate::model::{BitMexPriceEventId, Price, Timestamp, Usd};
 use anyhow::{bail, Result};
 use bdk::bitcoin::secp256k1::Signature;
 use bdk::bitcoin::util::psbt::PartiallySignedTransaction;
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::RangeInclusive;
-use std::time::SystemTime;
 use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -26,7 +25,7 @@ pub enum TakerToMaker {
     },
     ProposeSettlement {
         order_id: OrderId,
-        timestamp: SystemTime,
+        timestamp: Timestamp,
         #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
         taker: Amount,
         #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
@@ -39,7 +38,7 @@ pub enum TakerToMaker {
     },
     ProposeRollOver {
         order_id: OrderId,
-        timestamp: SystemTime,
+        timestamp: Timestamp,
     },
     Protocol(SetupMsg),
     RollOverProtocol(RollOverMsg),

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -5,7 +5,7 @@ use cfd_protocol::secp256k1_zkp::{schnorrsig, Secp256k1};
 use cfd_protocol::PartyParams;
 use daemon::maker_cfd::CfdAction;
 use daemon::model::cfd::{Cfd, CfdState, Order};
-use daemon::model::{Price, Usd, WalletInfo};
+use daemon::model::{Price, Timestamp, Usd, WalletInfo};
 use daemon::tokio_ext::FutureExt;
 use daemon::{
     connection, db, maker_cfd, maker_inc_connections, monitor, oracle, taker_cfd, wallet,
@@ -16,7 +16,7 @@ use sqlx::SqlitePool;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::task::Poll;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 use tokio::sync::watch;
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::filter::LevelFilter;
@@ -233,7 +233,7 @@ impl Wallet {
         Ok(WalletInfo {
             balance: bdk::bitcoin::Amount::ONE_BTC,
             address,
-            last_updated_at: SystemTime::now(),
+            last_updated_at: Timestamp::now()?,
         })
     }
     async fn handle(&mut self, _msg: wallet::Sign) -> Result<PartiallySignedTransaction> {


### PR DESCRIPTION
Created new Timestamp struct that only uses seconds (as i64 in order to play nice with both `sqlx` and `chrono`) and removed use of `SytemTime::now()` throughout in the process.

This PR addresses #352 but also had the effect of doing a better job of addressing #434, making #435 pointless.