### PR TITLE
Roll-out usage of a mocking framework in actor tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,8 @@ dependencies = [
  "hex",
  "hkdf",
  "itertools",
+ "mockall",
+ "mockall_derive",
  "nalgebra",
  "ndarray",
  "ndarray_einsum_beta",
@@ -635,6 +637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +662,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "either"
@@ -742,6 +756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "flume"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +791,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -1366,6 +1395,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab571328afa78ae322493cacca3efac6a0f2e0a67305b4df31fd439ef129ac0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "multer"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1492,12 @@ dependencies = [
  "minimal-lexical",
  "version_check",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
@@ -1674,6 +1736,35 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "predicates"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -2837,6 +2928,12 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
 name = "textwrap"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -53,6 +53,8 @@ name = "maker"
 path = "src/maker.rs"
 
 [dev-dependencies]
+mockall = "0.10.2"
+mockall_derive = "0.10.2"
 pretty_assertions = "1"
 serde_test = "1"
 time = { version = "0.3", features = ["std"] }

--- a/daemon/tests/harness/mocks/mod.rs
+++ b/daemon/tests/harness/mocks/mod.rs
@@ -1,3 +1,57 @@
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, MutexGuard};
+
+use self::monitor::MonitorActor;
+use self::oracle::OracleActor;
+use self::wallet::WalletActor;
+
 pub mod monitor;
 pub mod oracle;
 pub mod wallet;
+
+#[derive(Clone)]
+pub struct Mocks {
+    pub wallet: Arc<Mutex<wallet::MockWallet>>,
+    pub monitor: Arc<Mutex<monitor::MockMonitor>>,
+    pub oracle: Arc<Mutex<oracle::MockOracle>>,
+}
+
+impl Mocks {
+    pub async fn wallet(&mut self) -> MutexGuard<'_, wallet::MockWallet> {
+        self.wallet.lock().await
+    }
+
+    #[allow(dead_code)] // will be used soon
+    pub async fn monitor(&mut self) -> MutexGuard<'_, monitor::MockMonitor> {
+        self.monitor.lock().await
+    }
+
+    pub async fn oracle(&mut self) -> MutexGuard<'_, oracle::MockOracle> {
+        self.oracle.lock().await
+    }
+}
+
+impl Default for Mocks {
+    fn default() -> Self {
+        Self {
+            oracle: Arc::new(Mutex::new(oracle::MockOracle::new())),
+            monitor: Arc::new(Mutex::new(monitor::MockMonitor::new())),
+            wallet: Arc::new(Mutex::new(wallet::MockWallet::new())),
+        }
+    }
+}
+
+/// Creates actors with embedded mock handlers
+pub fn create_actors(mocks: &Mocks) -> (OracleActor, MonitorActor, WalletActor) {
+    let oracle = OracleActor {
+        mock: mocks.oracle.clone(),
+    };
+    let monitor = MonitorActor {
+        mock: mocks.monitor.clone(),
+    };
+    let wallet = WalletActor {
+        mock: mocks.wallet.clone(),
+    };
+    (oracle, monitor, wallet)
+}

--- a/daemon/tests/harness/mocks/monitor.rs
+++ b/daemon/tests/harness/mocks/monitor.rs
@@ -1,29 +1,53 @@
+use std::sync::Arc;
+
 use daemon::{monitor, oracle};
+use mockall::*;
+use tokio::sync::Mutex;
 use xtra_productivity::xtra_productivity;
 
-/// Test Stub simulating the Monitor actor
-pub struct Monitor;
-impl xtra::Actor for Monitor {}
+/// Test Stub simulating the Monitor actor.
+/// Serves as an entrypoint for injected mock handlers.
+pub struct MonitorActor {
+    pub mock: Arc<Mutex<dyn Monitor + Send>>,
+}
+
+impl xtra::Actor for MonitorActor {}
+impl Monitor for MonitorActor {}
 
 #[xtra_productivity(message_impl = false)]
-impl Monitor {
-    async fn handle(&mut self, _msg: monitor::Sync) {}
-
-    async fn handle(&mut self, _msg: monitor::StartMonitoring) {
-        todo!("stub this if needed")
+impl MonitorActor {
+    async fn handle(&mut self, msg: monitor::Sync) {
+        self.mock.lock().await.sync(msg)
     }
 
-    async fn handle(&mut self, _msg: monitor::CollaborativeSettlement) {
-        todo!("stub this if needed")
+    async fn handle(&mut self, msg: monitor::StartMonitoring) {
+        self.mock.lock().await.start_monitoring(msg)
     }
 
-    async fn handle(&mut self, _msg: oracle::Attestation) {
-        todo!("stub this if needed")
+    async fn handle(&mut self, msg: monitor::CollaborativeSettlement) {
+        self.mock.lock().await.collaborative_settlement(msg)
+    }
+
+    async fn handle(&mut self, msg: oracle::Attestation) {
+        self.mock.lock().await.oracle_attestation(msg)
     }
 }
 
-impl Default for Monitor {
-    fn default() -> Self {
-        Monitor
+#[automock]
+pub trait Monitor {
+    fn sync(&mut self, _msg: monitor::Sync) {
+        unreachable!("mockall will reimplement this method")
+    }
+
+    fn start_monitoring(&mut self, _msg: monitor::StartMonitoring) {
+        unreachable!("mockall will reimplement this method")
+    }
+
+    fn collaborative_settlement(&mut self, _msg: monitor::CollaborativeSettlement) {
+        unreachable!("mockall will reimplement this method")
+    }
+
+    fn oracle_attestation(&mut self, _msg: oracle::Attestation) {
+        unreachable!("mockall will reimplement this method")
     }
 }

--- a/daemon/tests/harness/mocks/oracle.rs
+++ b/daemon/tests/harness/mocks/oracle.rs
@@ -1,45 +1,57 @@
+use crate::harness::cfd_protocol::OliviaData;
 use daemon::model::BitMexPriceEventId;
 use daemon::oracle;
+use mockall::*;
+use std::sync::Arc;
 use time::OffsetDateTime;
+use tokio::sync::Mutex;
 use xtra_productivity::xtra_productivity;
 
-pub struct Oracle {
-    announcement: Option<oracle::Announcement>,
+/// Test Stub simulating the Oracle actor.
+/// Serves as an entrypoint for injected mock handlers.
+pub struct OracleActor {
+    pub mock: Arc<Mutex<dyn Oracle + Send>>,
 }
 
-impl Oracle {
-    pub fn with_dummy_announcement(
-        mut self,
-        dummy_announcement: cfd_protocol::Announcement,
-    ) -> Self {
-        self.announcement = Some(oracle::Announcement {
-            id: BitMexPriceEventId::new(OffsetDateTime::UNIX_EPOCH, 0),
-            expected_outcome_time: OffsetDateTime::now_utc(),
-            nonce_pks: dummy_announcement.nonce_pks,
-        });
-
-        self
-    }
-}
-
-impl xtra::Actor for Oracle {}
+impl xtra::Actor for OracleActor {}
+impl Oracle for OracleActor {}
 
 #[xtra_productivity(message_impl = false)]
-impl Oracle {
-    async fn handle_get_announcement(
-        &mut self,
-        _msg: oracle::GetAnnouncement,
-    ) -> Option<oracle::Announcement> {
-        self.announcement.clone()
+impl OracleActor {
+    async fn handle(&mut self, msg: oracle::GetAnnouncement) -> Option<oracle::Announcement> {
+        self.mock.lock().await.get_announcement(msg)
     }
 
-    async fn handle(&mut self, _msg: oracle::MonitorAttestation) {}
+    async fn handle(&mut self, msg: oracle::MonitorAttestation) {
+        self.mock.lock().await.monitor_attestation(msg)
+    }
 
-    async fn handle(&mut self, _msg: oracle::Sync) {}
+    async fn handle(&mut self, msg: oracle::Sync) {
+        self.mock.lock().await.sync(msg)
+    }
 }
 
-impl Default for Oracle {
-    fn default() -> Self {
-        Oracle { announcement: None }
+#[automock]
+pub trait Oracle {
+    fn get_announcement(&mut self, _msg: oracle::GetAnnouncement) -> Option<oracle::Announcement> {
+        unreachable!("mockall will reimplement this method")
+    }
+
+    fn monitor_attestation(&mut self, _msg: oracle::MonitorAttestation) {
+        unreachable!("mockall will reimplement this method")
+    }
+
+    fn sync(&mut self, _msg: oracle::Sync) {
+        unreachable!("mockall will reimplement this method")
+    }
+}
+
+pub fn dummy_announcement() -> oracle::Announcement {
+    let announcement = OliviaData::example_0().announcement();
+
+    oracle::Announcement {
+        id: BitMexPriceEventId::new(OffsetDateTime::UNIX_EPOCH, 0),
+        expected_outcome_time: OffsetDateTime::now_utc(),
+        nonce_pks: announcement.nonce_pks,
     }
 }


### PR DESCRIPTION
Mockall is a mocking framework that removes the need for writing more actors,
making tests easier to write.

Summary:
- add one more layer of indirection (a trait per actor type: Wallet, Oracle, Monitor)
- Mocks implementing the actor traits (with default stubbed implementations if no extra
  behaviour needed)
- references to the mocks are being passed into the tests (via Arc<Mutex>>), allowing
  for dynamically changing the behaviour and adding assertions. This also
    aids readability, as the mock setup can be collocated with a particular
    test, if the test needs something extra