### PR TITLE
Add a feature flag to opt-in for long-running integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,8 @@ jobs:
       - name: Setup rust toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@v1.3.0
-      - run: cargo build --bins --tests
-      - run: cargo test --workspace
+      - run: cargo build --features expensive_tests --bins --tests
+      - run: cargo test --workspace --features expensive_tests
       - name: Smoke test ${{ matrix.os }} binary
         shell: bash
         run: |

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -44,6 +44,10 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 xtra = { version = "0.6", features = ["with-tokio-1"] }
 xtra_productivity = { path = "../xtra_productivity" }
 
+[features]
+# Feature flag to enable tests that take longer to compile.
+expensive_tests = []
+
 [[bin]]
 name = "taker"
 path = "src/taker.rs"

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -87,6 +87,7 @@ fn mock_wallet_sign_and_broadcast(wallet: &mut MutexGuard<'_, harness::mocks::wa
 }
 
 #[tokio::test]
+#[cfg_attr(not(feature = "expensive_tests"), ignore)]
 async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
     let _guard = init_tracing();
     let (mut maker, mut taker) = start_both().await;


### PR DESCRIPTION
This allows opting-in for longer-running tests by enabling "expensive_tests"
feature, instead of waiting for a few minutes after starting `cargo test`.

Amend the CI to run all the tests (including expensive ones) on every run.