### PR TITLE
Rename `MustRefund` Cfd state to `PendingRefund`

### DIFF
--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -88,7 +88,7 @@ where
 
     if let CfdState::OpenCommitted { .. } = cfd.state {
         try_cet_publication(&mut cfd, conn, wallet, update_sender).await?;
-    } else if let CfdState::MustRefund { .. } = cfd.state {
+    } else if let CfdState::PendingRefund { .. } = cfd.state {
         let signed_refund_tx = cfd.refund_tx()?;
         let txid = wallet
             .send(wallet::TryBroadcastTransaction {

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -132,7 +132,7 @@ impl Actor<bdk::electrum_client::Client> {
                     actor.monitor_commit_refund_timelock(&params, cfd.order.id);
                     actor.monitor_refund_finality(&params,cfd.order.id);
                 }
-                CfdState::MustRefund { dlc, .. } => {
+                CfdState::PendingRefund { dlc, .. } => {
                     let params = MonitorParams::from_dlc_and_timelocks(dlc.clone(), cfd.refund_timelock_in_blocks());
                     actor.cfds.insert(cfd.order.id, params.clone());
 

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -86,7 +86,7 @@ impl Actor {
 
                 // Final states
                 | CfdState::Closed { .. }
-                | CfdState::MustRefund { .. }
+                | CfdState::PendingRefund { .. }
                 | CfdState::Refunded { .. }
                 | CfdState::SetupFailed { .. } => ()
             }

--- a/daemon/src/to_sse_event.rs
+++ b/daemon/src/to_sse_event.rs
@@ -208,7 +208,7 @@ pub enum CfdState {
     IncomingRollOverProposal,
     OutgoingRollOverProposal,
     Closed,
-    MustRefund,
+    PendingRefund,
     Refunded,
     SetupFailed,
 }
@@ -405,7 +405,7 @@ fn to_cfd_state(
             model::cfd::CfdState::PendingOpen { .. } => CfdState::PendingOpen,
             model::cfd::CfdState::Open { .. } => CfdState::Open,
             model::cfd::CfdState::OpenCommitted { .. } => CfdState::OpenCommitted,
-            model::cfd::CfdState::MustRefund { .. } => CfdState::MustRefund,
+            model::cfd::CfdState::PendingRefund { .. } => CfdState::PendingRefund,
             model::cfd::CfdState::Refunded { .. } => CfdState::Refunded,
             model::cfd::CfdState::SetupFailed { .. } => CfdState::SetupFailed,
             model::cfd::CfdState::PendingCommit { .. } => CfdState::PendingCommit,
@@ -454,7 +454,7 @@ fn to_tx_url_list(state: model::cfd::CfdState, network: Network) -> Vec<TxUrl> {
         } => {
             vec![tx_ub.collaborative_close(collaborative_close.tx.txid())]
         }
-        MustRefund { dlc, .. } => vec![tx_ub.lock(&dlc), tx_ub.commit(&dlc), tx_ub.refund(&dlc)],
+        PendingRefund { dlc, .. } => vec![tx_ub.lock(&dlc), tx_ub.commit(&dlc), tx_ub.refund(&dlc)],
         Refunded { dlc, .. } => vec![tx_ub.refund(&dlc)],
         OutgoingOrderRequest { .. }
         | IncomingOrderRequest { .. }
@@ -538,8 +538,8 @@ mod tests {
         assert_eq!(json, "\"Open\"");
         let json = serde_json::to_string(&CfdState::OpenCommitted).unwrap();
         assert_eq!(json, "\"OpenCommitted\"");
-        let json = serde_json::to_string(&CfdState::MustRefund).unwrap();
-        assert_eq!(json, "\"MustRefund\"");
+        let json = serde_json::to_string(&CfdState::PendingRefund).unwrap();
+        assert_eq!(json, "\"PendingRefund\"");
         let json = serde_json::to_string(&CfdState::Refunded).unwrap();
         assert_eq!(json, "\"Refunded\"");
         let json = serde_json::to_string(&CfdState::SetupFailed).unwrap();

--- a/frontend/src/components/Types.tsx
+++ b/frontend/src/components/Types.tsx
@@ -95,7 +95,7 @@ export class State {
                 return "Rollover Proposed";
             case StateKey.OUTGOING_ROLL_OVER_PROPOSAL:
                 return "Rollover Proposed";
-            case StateKey.MUST_REFUND:
+            case StateKey.PENDING_REFUND:
                 return "Refunding";
             case StateKey.REFUNDED:
                 return "Refunded";
@@ -124,7 +124,7 @@ export class State {
 
             case StateKey.PENDING_COMMIT:
             case StateKey.OPEN_COMMITTED:
-            case StateKey.MUST_REFUND:
+            case StateKey.PENDING_REFUND:
             case StateKey.PENDING_CET:
             case StateKey.PENDING_CLOSE:
                 return orange;
@@ -158,7 +158,7 @@ export class State {
             case StateKey.OPEN:
             case StateKey.PENDING_COMMIT:
             case StateKey.OPEN_COMMITTED:
-            case StateKey.MUST_REFUND:
+            case StateKey.PENDING_REFUND:
             case StateKey.OUTGOING_SETTLEMENT_PROPOSAL:
             case StateKey.OUTGOING_ROLL_OVER_PROPOSAL:
             case StateKey.PENDING_CET:
@@ -208,7 +208,7 @@ const enum StateKey {
     INCOMING_SETTLEMENT_PROPOSAL = "IncomingSettlementProposal",
     OUTGOING_ROLL_OVER_PROPOSAL = "OutgoingRollOverProposal",
     INCOMING_ROLL_OVER_PROPOSAL = "IncomingRollOverProposal",
-    MUST_REFUND = "MustRefund",
+    PENDING_REFUND = "PendingRefund",
     REFUNDED = "Refunded",
     SETUP_FAILED = "SetupFailed",
     CLOSED = "Closed",


### PR DESCRIPTION
For consistency with PendingClose, PendingCommit, PendingCet - it's analogous to
them, but applies to refund transaction.