### PR TITLE
Initialise the `RELEASE_BRANCH` envvar to ensure drafting release PR works

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -11,13 +11,15 @@ jobs:
   draft-new-release:
     name: "Draft a new release"
     runs-on: ubuntu-latest
+    env:
+      RELEASE_BRANCH: release/${{ github.event.inputs.version }}
     steps:
       - uses: actions/checkout@v2.3.5
         with:
           token: ${{ secrets.BOTTY_GITHUB_TOKEN }}
 
       - name: Create release branch
-        run: git checkout -b release/${{ github.event.inputs.version }}
+        run: git checkout -b ${{ env.RELEASE_BRANCH }}
 
       - name: Initialize mandatory git config
         run: |


### PR DESCRIPTION
Thanks to @scratchscratchscratchy for pointing this out!