### PR TITLE
SQL query fix

### DIFF
--- a/daemon/migrations/20211025050345_rename_term_to_settlement_time_interval.sql
+++ b/daemon/migrations/20211025050345_rename_term_to_settlement_time_interval.sql
@@ -1,8 +1,59 @@
-alter table orders
-rename column term_seconds to settlement_time_interval_seconds;
+PRAGMA foreign_keys=off;
 
-alter table orders
-drop column creation_timestamp_nanoseconds;
+create temporary table orders_backup (
+  id,
+  uuid,
+  trading_pair,
+  position,
+  initial_price,
+  min_quantity,
+  max_quantity,
+  leverage,
+  liquidation_price,
+  creation_timestamp_seconds,
+  settlement_time_interval_seconds,
+  origin,
+  oracle_event_id 
+);
 
-alter table orders
-drop column term_nanoseconds;
+insert into orders_backup
+  select
+    id,
+    uuid,
+    trading_pair,
+    position,
+    initial_price,
+    min_quantity,
+    max_quantity,
+    leverage,
+    liquidation_price,
+    creation_timestamp_seconds,
+    term_seconds,
+    origin,
+    oracle_event_id 
+  from orders;
+
+drop table orders;
+
+create table orders (
+  id                                integer primary key autoincrement,
+  uuid                              text unique not null,
+  trading_pair                      text        not null,
+  position                          text        not null,
+  initial_price                     text        not null,
+  min_quantity                      text        not null,
+  max_quantity                      text        not null,
+  leverage                          integer     not null,
+  liquidation_price                 text        not null,
+  creation_timestamp_seconds        integer     not null,
+  settlement_time_interval_seconds  integer     not null,
+  origin                            text        not null,
+  oracle_event_id                   text        not null
+);
+
+insert into orders
+  select *
+  from orders_backup;
+drop table orders_backup;
+
+PRAGMA foreign_keys=on;


### PR DESCRIPTION
Not completely necessary, but the previous ALTER commands only worked
because of being operated in an edge-case. The replacement here accomplishes
exactly the same thing but in a more stable and sqlite-compliant manner,
which makes the downstream workflow clearer at the same time.