### PR TITLE
Publish docker image improvements

### DIFF
--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -155,7 +155,7 @@ jobs:
       contents: read
       packages: write
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
     steps:
       - name: Checkout tagged commit
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -154,6 +154,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        include:
+          - bin: maker
+          - bin: taker
     env:
       GITHUB_TOKEN: ${{ secrets.ITCHY_GITHUB_TOKEN }}
     steps:
@@ -176,7 +181,7 @@ jobs:
 
       - name: Download release from github
         run: |
-          gh release download ${{ github.event.release.tag_name }} -p '*Linux_x86_64*' -p '*aarch64*' -p '*armv7*'
+          gh release download ${{ github.event.release.tag_name }} -p '${{matrix.bin}}*Linux_x86_64*' -p '${{matrix.bin}}*aarch64*' -p '${{matrix.bin}}*armv7*'
 
       - name: Unpack archives
         run: |
@@ -186,16 +191,13 @@ jobs:
           # when building the image. This variable is either
           # `linux/amd64/`, `linux/arm64/` or `linux/arm/v7`. Hence we need to extract into subfolders.
 
-          7z x maker_${{ github.event.release.tag_name }}_Linux_aarch64.tar -olinux/arm64/
-          7z x taker_${{ github.event.release.tag_name }}_Linux_aarch64.tar -olinux/arm64/
+          7z x ${{matrix.bin}}_${{ github.event.release.tag_name }}_Linux_aarch64.tar -olinux/arm64/
 
-          7z x maker_${{ github.event.release.tag_name }}_Linux_x86_64.tar -olinux/amd64/
-          7z x taker_${{ github.event.release.tag_name }}_Linux_x86_64.tar -olinux/amd64/
+          7z x ${{matrix.bin}}_${{ github.event.release.tag_name }}_Linux_x86_64.tar -olinux/amd64/
 
-          7z x maker_${{ github.event.release.tag_name }}_Linux_armv7.tar -olinux/arm/v7
-          7z x taker_${{ github.event.release.tag_name }}_Linux_armv7.tar -olinux/arm/v7
+          7z x ${{matrix.bin}}_${{ github.event.release.tag_name }}_Linux_armv7.tar -olinux/arm/v7
 
-      - name: Build maker docker image
+      - name: Build docker image for ${{matrix.bin}}
         run: |
           VERSION=${{ github.event.release.tag_name }}
 
@@ -207,23 +209,6 @@ jobs:
               --push \
               --platform linux/amd64,linux/arm64,linux/arm/v7 \
               --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
-              --tag ghcr.io/${{ github.repository }}/maker:${VERSION} \
-              --build-arg BINARY_PATH=maker \
-              .
-
-
-      - name: Build taker docker image
-        run: |
-          VERSION=${{ github.event.release.tag_name }}
-
-          if [ "$VERSION" = "preview" ]; then
-              VERSION=latest
-          fi
-
-          docker buildx build \
-              --push \
-              --platform linux/amd64,linux/arm64,linux/arm/v7 \
-              --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
-              --tag ghcr.io/${{ github.repository }}/taker:${VERSION} \
-              --build-arg BINARY_PATH=taker \
+              --tag ghcr.io/${{ github.repository }}/${{matrix.bin}}:${VERSION} \
+              --build-arg BINARY_PATH=${{matrix.bin}} \
               .

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -197,21 +197,33 @@ jobs:
 
       - name: Build maker docker image
         run: |
+          VERSION=${{ github.event.release.tag_name }}
+
+          if [ "$VERSION" = "preview" ]; then
+              VERSION=latest
+          fi
+
           docker buildx build \
               --push \
               --platform linux/amd64,linux/arm64,linux/arm/v7 \
               --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
-              --tag ghcr.io/${{ github.repository }}/maker:${{ github.event.release.tag_name }} \
+              --tag ghcr.io/${{ github.repository }}/maker:${VERSION} \
               --build-arg BINARY_PATH=maker \
               .
 
 
       - name: Build taker docker image
         run: |
+          VERSION=${{ github.event.release.tag_name }}
+
+          if [ "$VERSION" = "preview" ]; then
+              VERSION=latest
+          fi
+
           docker buildx build \
               --push \
               --platform linux/amd64,linux/arm64,linux/arm/v7 \
               --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
-              --tag ghcr.io/${{ github.repository }}/taker:${{ github.event.release.tag_name }} \
+              --tag ghcr.io/${{ github.repository }}/taker:${VERSION} \
               --build-arg BINARY_PATH=taker \
               .

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.release.target_commitish }}
-          token: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+          token: ${{ secrets.ITCHY_GITHUB_TOKEN }}
 
       - name: Install toolchain from `rust-toolchain.toml`
         run: rustup show
@@ -139,7 +139,7 @@ jobs:
       - name: Upload archive
         uses: actions/upload-release-asset@v1.0.2
         env:
-          GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ITCHY_GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./${{ steps.create-archive-name.outputs.archive }}
@@ -155,7 +155,7 @@ jobs:
       contents: read
       packages: write
     env:
-      GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.ITCHY_GITHUB_TOKEN }}
     steps:
       - name: Checkout tagged commit
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Create release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ITCHY_GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.extract-version.outputs.version }}
           release_name: ${{ steps.extract-version.outputs.version }}

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -19,15 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
         with:
-          token: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+          token: ${{ secrets.ITCHY_GITHUB_TOKEN }}
 
       - name: Create release branch
         run: git checkout -b ${{ env.RELEASE_BRANCH }}
 
       - name: Initialize mandatory git config
         run: |
-          git config user.name "${{ secrets.BOTTY_NAME }}"
-          git config user.email ${{ secrets.BOTTY_EMAIL }}
+          git config user.name "${{ secrets.ITCHY_NAME }}"
+          git config user.email ${{ secrets.ITCHY_EMAIL }}
 
       - name: Bump version in Cargo.toml
         uses: thomaseizinger/set-crate-version@1.0.0
@@ -66,4 +66,4 @@ jobs:
         env:
           # Using a bot account is important to trigger subsequent workflows.
           # See https://devopsdirective.com/posts/2020/07/stupid-github-actions/#2----recursive-action.
-          GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ITCHY_GITHUB_TOKEN }}

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Create preview release
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.ITCHY_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2.4.0
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -58,22 +58,34 @@ jobs:
 
       - name: Build maker docker image
         run: |
+          VERSION=${{ github.event.inputs.release_tag }}
+
+          if [ "$VERSION" = "preview" ]; then
+              VERSION=latest
+          fi
+
           docker buildx build \
               --push \
               --platform linux/amd64,linux/arm64,linux/arm/v7 \
               --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
-              --tag ghcr.io/${{ github.repository }}/maker:${{ github.event.inputs.release_tag }} \
+              --tag ghcr.io/${{ github.repository }}/maker:${VERSION} \
               --build-arg BINARY_PATH=maker \
               .
 
 
       - name: Build taker docker image
         run: |
+          VERSION=${{ github.event.release.tag_name }}
+
+          if [ "$VERSION" = "preview" ]; then
+              VERSION=latest
+          fi
+
           docker buildx build \
               --push \
               --platform linux/amd64,linux/arm64,linux/arm/v7 \
               --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
-              --tag ghcr.io/${{ github.repository }}/taker:${{ github.event.inputs.release_tag }} \
+              --tag ghcr.io/${{ github.repository }}/taker:${VERSION} \
               --build-arg BINARY_PATH=taker \
               .
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       packages: write
     env:
-      GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.ITCHY_GITHUB_TOKEN }}
     steps:
       - name: Checkout tagged commit
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       packages: write
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
     steps:
       - name: Checkout tagged commit
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -20,7 +20,8 @@ jobs:
     steps:
       - name: Checkout tagged commit
         uses: actions/checkout@v2.4.0
-      # TODO: checkout the tag and not master
+        with:
+          ref: ${{ github.event.inputs.release_tag }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -3,7 +3,7 @@ name: "Release docker images from release"
 on:
   workflow_dispatch:
     inputs:
-      realease_tag:
+      release_tag:
         description: 'The release tag to build containers for (preview or x.y.z)'
         required: true
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Download release
         run: |
-          gh release download ${{ github.event.inputs.realease_tag }} -p '*Linux_x86_64*' -p '*aarch64*' -p '*armv7*'
+          gh release download ${{ github.event.inputs.release_tag }} -p '*Linux_x86_64*' -p '*aarch64*' -p '*armv7*'
 
       - name: Unpack archives
         run: |
@@ -46,14 +46,14 @@ jobs:
           # when building the image. This variable is either
           # `linux/amd64/`, `linux/arm64/` or `linux/arm/v7`. Hence we need to extract into subfolders.
 
-          7z x maker_${{ github.event.inputs.realease_tag }}_Linux_aarch64.tar -olinux/arm64/
-          7z x taker_${{ github.event.inputs.realease_tag }}_Linux_aarch64.tar -olinux/arm64/
+          7z x maker_${{ github.event.inputs.release_tag }}_Linux_aarch64.tar -olinux/arm64/
+          7z x taker_${{ github.event.inputs.release_tag }}_Linux_aarch64.tar -olinux/arm64/
 
-          7z x maker_${{ github.event.inputs.realease_tag }}_Linux_x86_64.tar -olinux/amd64/
-          7z x taker_${{ github.event.inputs.realease_tag }}_Linux_x86_64.tar -olinux/amd64/
+          7z x maker_${{ github.event.inputs.release_tag }}_Linux_x86_64.tar -olinux/amd64/
+          7z x taker_${{ github.event.inputs.release_tag }}_Linux_x86_64.tar -olinux/amd64/
 
-          7z x maker_${{ github.event.inputs.realease_tag }}_Linux_armv7.tar -olinux/arm/v7
-          7z x taker_${{ github.event.inputs.realease_tag }}_Linux_armv7.tar -olinux/arm/v7
+          7z x maker_${{ github.event.inputs.release_tag }}_Linux_armv7.tar -olinux/arm/v7
+          7z x taker_${{ github.event.inputs.release_tag }}_Linux_armv7.tar -olinux/arm/v7
 
       - name: Build maker docker image
         run: |
@@ -61,7 +61,7 @@ jobs:
               --push \
               --platform linux/amd64,linux/arm64,linux/arm/v7 \
               --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
-              --tag ghcr.io/${{ github.repository }}/maker:${{ github.event.inputs.realease_tag }} \
+              --tag ghcr.io/${{ github.repository }}/maker:${{ github.event.inputs.release_tag }} \
               --build-arg BINARY_PATH=maker \
               .
 
@@ -72,7 +72,7 @@ jobs:
               --push \
               --platform linux/amd64,linux/arm64,linux/arm/v7 \
               --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
-              --tag ghcr.io/${{ github.repository }}/taker:${{ github.event.inputs.realease_tag }} \
+              --tag ghcr.io/${{ github.repository }}/taker:${{ github.event.inputs.release_tag }} \
               --build-arg BINARY_PATH=taker \
               .
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -15,6 +15,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+         bin: [maker,taker]
     env:
       GITHUB_TOKEN: ${{ secrets.ITCHY_GITHUB_TOKEN }}
     steps:
@@ -37,7 +40,7 @@ jobs:
 
       - name: Download release
         run: |
-          gh release download ${{ github.event.inputs.release_tag }} -p '*Linux_x86_64*' -p '*aarch64*' -p '*armv7*'
+          gh release download ${{ github.event.inputs.release_tag }} -p '${{matrix.bin}}*Linux_x86_64*' -p '${{matrix.bin}}*aarch64*' -p '${{matrix.bin}}*armv7*'
 
       - name: Unpack archives
         run: |
@@ -47,16 +50,13 @@ jobs:
           # when building the image. This variable is either
           # `linux/amd64/`, `linux/arm64/` or `linux/arm/v7`. Hence we need to extract into subfolders.
 
-          7z x maker_${{ github.event.inputs.release_tag }}_Linux_aarch64.tar -olinux/arm64/
-          7z x taker_${{ github.event.inputs.release_tag }}_Linux_aarch64.tar -olinux/arm64/
+          7z x ${{matrix.bin}}_${{ github.event.inputs.release_tag }}_Linux_aarch64.tar -olinux/arm64/
 
-          7z x maker_${{ github.event.inputs.release_tag }}_Linux_x86_64.tar -olinux/amd64/
-          7z x taker_${{ github.event.inputs.release_tag }}_Linux_x86_64.tar -olinux/amd64/
+          7z x ${{matrix.bin}}_${{ github.event.inputs.release_tag }}_Linux_x86_64.tar -olinux/amd64/
 
-          7z x maker_${{ github.event.inputs.release_tag }}_Linux_armv7.tar -olinux/arm/v7
-          7z x taker_${{ github.event.inputs.release_tag }}_Linux_armv7.tar -olinux/arm/v7
+          7z x ${{matrix.bin}}_${{ github.event.inputs.release_tag }}_Linux_armv7.tar -olinux/arm/v7
 
-      - name: Build maker docker image
+      - name: Build docker image for ${{matrix.bin}}
         run: |
           VERSION=${{ github.event.inputs.release_tag }}
 
@@ -68,25 +68,6 @@ jobs:
               --push \
               --platform linux/amd64,linux/arm64,linux/arm/v7 \
               --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
-              --tag ghcr.io/${{ github.repository }}/maker:${VERSION} \
-              --build-arg BINARY_PATH=maker \
+              --tag ghcr.io/${{ github.repository }}/${{matrix.bin}}:${VERSION} \
+              --build-arg BINARY_PATH=${{matrix.bin}} \
               .
-
-
-      - name: Build taker docker image
-        run: |
-          VERSION=${{ github.event.release.tag_name }}
-
-          if [ "$VERSION" = "preview" ]; then
-              VERSION=latest
-          fi
-
-          docker buildx build \
-              --push \
-              --platform linux/amd64,linux/arm64,linux/arm/v7 \
-              --label "org.opencontainers.image.source https://github.com/${{ github.repository }}" \
-              --tag ghcr.io/${{ github.repository }}/taker:${VERSION} \
-              --build-arg BINARY_PATH=taker \
-              .
-
-


### PR DESCRIPTION
Note: the only thing we need from the checkout is the dockerfile. The rest does not matter. 
Nevertheless, when manually releasing docker images by release tag, we should check out that particular release tag to ensure we are using the correct dockerfile