### PR TITLE
Use `send` instead of `do_send` in actor tests

### DIFF
--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -35,7 +35,7 @@ async fn taker_takes_order_and_maker_rejects() {
 
     let (_, received) = next_order(&mut maker.order_feed, &mut taker.order_feed).await;
 
-    taker.take_order(received.clone(), Usd::new(dec!(10)));
+    taker.take_order(received.clone(), Usd::new(dec!(10))).await;
 
     let (taker_cfd, maker_cfd) = next_cfd(&mut taker.cfd_feed, &mut maker.cfd_feed).await;
     assert_is_same_order(&taker_cfd.order, &received);
@@ -49,7 +49,7 @@ async fn taker_takes_order_and_maker_rejects() {
         CfdState::IncomingOrderRequest { .. }
     ));
 
-    maker.reject_take_request(received.clone());
+    maker.reject_take_request(received.clone()).await;
 
     let (taker_cfd, maker_cfd) = next_cfd(&mut taker.cfd_feed, &mut maker.cfd_feed).await;
     // TODO: More elaborate Cfd assertions
@@ -70,16 +70,18 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
 
     let (_, received) = next_order(&mut maker.order_feed, &mut taker.order_feed).await;
 
-    taker.take_order(received.clone(), Usd::new(dec!(5)));
+    taker.take_order(received.clone(), Usd::new(dec!(5))).await;
     let (_, _) = next_cfd(&mut taker.cfd_feed, &mut maker.cfd_feed).await;
 
     maker.mocks.mock_oracle_annoucement().await;
     taker.mocks.mock_oracle_annoucement().await;
 
-    maker.accept_take_request(received.clone());
+    maker.mocks.mock_monitor_oracle_attestation().await;
 
     maker.mocks.mock_party_params().await;
     taker.mocks.mock_party_params().await;
+
+    maker.accept_take_request(received.clone()).await;
 
     let (taker_cfd, maker_cfd) = next_cfd(&mut taker.cfd_feed, &mut maker.cfd_feed).await;
     // TODO: More elaborate Cfd assertions

--- a/daemon/tests/harness/mocks/mod.rs
+++ b/daemon/tests/harness/mocks/mod.rs
@@ -24,7 +24,6 @@ impl Mocks {
         self.wallet.lock().await
     }
 
-    #[allow(dead_code)] // will be used soon
     pub async fn monitor(&mut self) -> MutexGuard<'_, monitor::MockMonitor> {
         self.monitor.lock().await
     }
@@ -63,6 +62,13 @@ impl Mocks {
             .await
             .expect_build_party_params()
             .returning(|msg| wallet::build_party_params(msg));
+    }
+
+    pub async fn mock_monitor_oracle_attestation(&mut self) {
+        self.monitor()
+            .await
+            .expect_oracle_attestation()
+            .return_const(());
     }
 }
 

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -123,15 +123,19 @@ impl Maker {
             .unwrap();
     }
 
-    pub fn reject_take_request(&self, order: Order) {
+    pub async fn reject_take_request(&self, order: Order) {
         self.cfd_actor_addr
-            .do_send(CfdAction::RejectOrder { order_id: order.id })
+            .send(CfdAction::RejectOrder { order_id: order.id })
+            .await
+            .unwrap()
             .unwrap();
     }
 
-    pub fn accept_take_request(&self, order: Order) {
+    pub async fn accept_take_request(&self, order: Order) {
         self.cfd_actor_addr
-            .do_send(CfdAction::AcceptOrder { order_id: order.id })
+            .send(CfdAction::AcceptOrder { order_id: order.id })
+            .await
+            .unwrap()
             .unwrap();
     }
 }
@@ -193,12 +197,14 @@ impl Taker {
         }
     }
 
-    pub fn take_order(&self, order: Order, quantity: Usd) {
+    pub async fn take_order(&self, order: Order, quantity: Usd) {
         self.cfd_actor_addr
-            .do_send(taker_cfd::TakeOffer {
+            .send(taker_cfd::TakeOffer {
                 order_id: order.id,
                 quantity,
             })
+            .await
+            .unwrap()
             .unwrap();
     }
 }


### PR DESCRIPTION
`do_send` did not inspect any errors, while Cfd actors support returning errors
if an action performed on them failed.

This matches the code used in production in HTTP requests.

Slight changes in the test were required as the test failed
otherwise (particularly, on unhandled monitoring of oracle attestation).