### PR TITLE
Generate seed automatically if no seed is present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           sleep 10s # Wait for maker to start\
 
           # The maker-id is generated from the makers seed found in daemon/util/testnet_seeds/maker_seed
-          target/debug/taker --data-dir=/tmp/taker --generate-seed --maker-id 10d4ba2ac3f7a22da4009d813ff1bc3f404dfe2cc93a32bedf1512aa9951c95e testnet &
+          target/debug/taker --data-dir=/tmp/taker --maker-id 10d4ba2ac3f7a22da4009d813ff1bc3f404dfe2cc93a32bedf1512aa9951c95e testnet &
           sleep 10s # Wait for taker to start
 
           curl --fail http://localhost:8000/api/alive

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -44,10 +44,6 @@ struct Opts {
     #[clap(long)]
     data_dir: Option<PathBuf>,
 
-    /// Generate a seed file within the data directory.
-    #[clap(long)]
-    generate_seed: bool,
-
     /// If enabled logs will be in json format
     #[clap(short, long)]
     json: bool,
@@ -160,7 +156,7 @@ async fn main() -> Result<()> {
         tokio::fs::create_dir_all(&data_dir).await?;
     }
 
-    let seed = Seed::initialize(&data_dir.join("maker_seed"), opts.generate_seed).await?;
+    let seed = Seed::initialize(&data_dir.join("maker_seed")).await?;
 
     let bitcoin_network = opts.network.bitcoin_network();
     let ext_priv_key = seed.derive_extended_priv_key(bitcoin_network)?;

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -43,10 +43,6 @@ struct Opts {
     #[clap(long)]
     data_dir: Option<PathBuf>,
 
-    /// Generate a seed file within the data directory.
-    #[clap(long)]
-    generate_seed: bool,
-
     /// If enabled logs will be in json format
     #[clap(short, long)]
     json: bool,
@@ -159,7 +155,7 @@ async fn main() -> Result<()> {
         tokio::fs::create_dir_all(&data_dir).await?;
     }
 
-    let seed = Seed::initialize(&data_dir.join("taker_seed"), opts.generate_seed).await?;
+    let seed = Seed::initialize(&data_dir.join("taker_seed")).await?;
 
     let bitcoin_network = opts.network.bitcoin_network();
     let ext_priv_key = seed.derive_extended_priv_key(bitcoin_network)?;


### PR DESCRIPTION
Smooth out user experience by automatically generating a new seed if there
is none present (and by writing that fact in the log file).

Fixes #505 