### PR TITLE
Mock common empty handlers at test actor system startup

### DIFF
--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -76,8 +76,6 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
     maker.mocks.mock_oracle_annoucement().await;
     taker.mocks.mock_oracle_annoucement().await;
 
-    maker.mocks.mock_monitor_oracle_attestation().await;
-
     maker.mocks.mock_party_params().await;
     taker.mocks.mock_party_params().await;
 

--- a/daemon/tests/harness/mocks/mod.rs
+++ b/daemon/tests/harness/mocks/mod.rs
@@ -32,6 +32,15 @@ impl Mocks {
         self.oracle.lock().await
     }
 
+    /// Mock message handlers that are not important for the test, but the cfd
+    /// actor still sends messages
+    pub async fn mock_common_empty_handlers(&mut self) {
+        // Sync methods need to be mocked before actors start
+        self.oracle().await.expect_sync().return_const(());
+        self.monitor().await.expect_sync().return_const(());
+        self.mock_monitor_oracle_attestation().await;
+    }
+
     // Helper function setting up a "happy path" wallet mock
     pub async fn mock_wallet_sign_and_broadcast(&mut self) {
         let mut seq = mockall::Sequence::new();

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -55,13 +55,9 @@ impl Maker {
     pub async fn start(oracle_pk: schnorrsig::PublicKey) -> Self {
         let db = in_memory_db().await;
 
-        let mocks = mocks::Mocks::default();
-
+        let mut mocks = mocks::Mocks::default();
         let (oracle, monitor, wallet) = mocks::create_actors(&mocks);
-
-        // Sync method need to be mocked before the actors start
-        mocks.oracle.lock().await.expect_sync().return_const(());
-        mocks.monitor.lock().await.expect_sync().return_const(());
+        mocks.mock_common_empty_handlers().await;
 
         let wallet_addr = wallet.create(None).spawn_global();
 
@@ -168,12 +164,9 @@ impl Taker {
 
         let db = in_memory_db().await;
 
-        let mocks = mocks::Mocks::default();
+        let mut mocks = mocks::Mocks::default();
         let (oracle, monitor, wallet) = mocks::create_actors(&mocks);
-
-        // Sync method need to be mocked before the actors start
-        mocks.oracle.lock().await.expect_sync().return_const(());
-        mocks.monitor.lock().await.expect_sync().return_const(());
+        mocks.mock_common_empty_handlers().await;
 
         let wallet_addr = wallet.create(None).spawn_global();
 


### PR DESCRIPTION
These empty handlers are needed in most tests, otherwise a test can fail if a
message is sent from an actor to a non-existent inbox.

I noticed that the contract setup test failed on the CI recently due to the
monitor oracle attestation msg not being mocked.