### PR TITLE
Configurable log levels on both taker and maker

### DIFF
--- a/daemon/src/fan_out.rs
+++ b/daemon/src/fan_out.rs
@@ -23,7 +23,11 @@ where
     async fn handle(&mut self, message: M, _: &mut xtra::Context<Self>) {
         for receiver in &self.receivers {
             // Not sure why here is no `do_send_async` ...
-            let _ = receiver.do_send(message.clone());
+            if receiver.do_send(message.clone()).is_err() {
+                tracing::error!(
+                    "Fan out actor was unable to send to other actor - we should never see this."
+                )
+            }
         }
     }
 }

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -48,6 +48,10 @@ struct Opts {
     #[clap(short, long)]
     json: bool,
 
+    /// Configure the log level, e.g.: one of Error, Warn, Info, Debug, Trace
+    #[clap(short, long, default_value = "Debug")]
+    log_level: LevelFilter,
+
     /// The time interval until potential settlement of each CFD in hours
     #[clap(long, default_value = "24")]
     settlement_time_interval_hours: u8,
@@ -142,7 +146,7 @@ impl Network {
 async fn main() -> Result<()> {
     let opts = Opts::parse();
 
-    logger::init(LevelFilter::DEBUG, opts.json).context("initialize logger")?;
+    logger::init(opts.log_level, opts.json).context("initialize logger")?;
     tracing::info!("Running version: {}", env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"));
 
     let data_dir = opts

--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -151,7 +151,8 @@ impl Actor {
     async fn handle_broadcast_order(&mut self, msg: BroadcastOrder) -> Result<()> {
         let order = msg.0;
 
-        for conn in self.write_connections.values() {
+        for (taker_id, conn) in self.write_connections.clone() {
+            tracing::trace!(%taker_id, "sending new order for broadcast to connection: {:?}", order);
             conn.do_send_async(wire::MakerToTaker::CurrentOrder(order.clone()))
                 .await?;
         }

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -112,7 +112,6 @@ impl Actor {
             ));
 
             if self.announcements.get(&event_id).is_some() {
-                tracing::trace!("Announcement already known: {}", event_id,);
                 continue;
             }
             let this = ctx.address().expect("self to be alive");

--- a/daemon/src/send_to_socket.rs
+++ b/daemon/src/send_to_socket.rs
@@ -33,6 +33,8 @@ where
     async fn handle(&mut self, message: T, ctx: &mut xtra::Context<Self>) {
         let message_name = message.to_string(); // send consumes the message, avoid a clone just in case it errors by getting the name here
 
+        tracing::trace!(%message_name, "send to socket message");
+
         if let Err(e) = self.write.send(message).await {
             tracing::error!("Failed to write message {} to socket: {}", message_name, e);
             ctx.stop();

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -47,6 +47,10 @@ struct Opts {
     #[clap(short, long)]
     json: bool,
 
+    /// Configure the log level, e.g.: one of Error, Warn, Info, Debug, Trace
+    #[clap(short, long, default_value = "Debug")]
+    log_level: LevelFilter,
+
     #[clap(subcommand)]
     network: Network,
 }
@@ -141,7 +145,7 @@ impl Network {
 async fn main() -> Result<()> {
     let opts = Opts::parse();
 
-    logger::init(LevelFilter::DEBUG, opts.json).context("initialize logger")?;
+    logger::init(opts.log_level, opts.json).context("initialize logger")?;
     tracing::info!("Running version: {}", env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"));
 
     let data_dir = opts

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -300,6 +300,7 @@ where
 
 impl<O, M, W> Actor<O, M, W> {
     async fn handle_new_order(&mut self, order: Option<Order>) -> Result<()> {
+        tracing::trace!("new order {:?}", order);
         match order {
             Some(mut order) => {
                 order.origin = Origin::Theirs;
@@ -736,6 +737,8 @@ where
                 return KeepRunning::Yes;
             }
         };
+
+        tracing::trace!("message from maker: {:?}", msg);
 
         match msg {
             wire::MakerToTaker::CurrentOrder(current_order) => {


### PR DESCRIPTION
Add configurable log levels on taker and maker and start tracing connection related information to track down a problem where the taker does not receive orders but there are not connection errors on both sides.

https://github.com/itchysats/itchysats/issues/550