### PR TITLE
Use a connection actor for the taker

### DIFF
--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -1,57 +1,174 @@
-use crate::{noise, send_to_socket, taker_cfd, wire};
+use crate::{log_error, noise, send_to_socket, wire};
 use anyhow::Result;
-use futures::{Stream, StreamExt};
+use futures::future::RemoteHandle;
+use futures::{FutureExt, StreamExt};
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
+use tokio::sync::watch;
 use tokio_util::codec::FramedRead;
 use xtra::prelude::MessageChannel;
-use xtra::spawn::TokioGlobalSpawnExt;
-use xtra::Actor as _;
+use xtra::KeepRunning;
+use xtra_productivity::xtra_productivity;
 
-const CONNECTION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+struct ConnectedState {
+    last_heartbeat: SystemTime,
+    _pulse_handle: RemoteHandle<()>,
+}
 
 pub struct Actor {
-    pub send_to_maker: Box<dyn MessageChannel<wire::TakerToMaker>>,
-    pub read_from_maker: Box<dyn Stream<Item = taker_cfd::MakerStreamMessage> + Unpin + Send>,
+    status_sender: watch::Sender<ConnectionStatus>,
+    send_to_maker: Box<dyn MessageChannel<wire::TakerToMaker>>,
+    send_to_maker_ctx: xtra::Context<send_to_socket::Actor<wire::TakerToMaker>>,
+    noise_static_sk: x25519_dalek::StaticSecret,
+    maker_to_taker: Box<dyn MessageChannel<wire::MakerToTaker>>,
+    /// Max duration since the last heartbeat until we die.
+    timeout: Duration,
+    connected_state: Option<ConnectedState>,
+}
+
+pub struct Connect {
+    pub maker_noise_static_pk: x25519_dalek::PublicKey,
+    pub maker_addr: SocketAddr,
+}
+
+pub struct MakerStreamMessage {
+    pub item: Result<wire::MakerToTaker>,
+}
+
+/// Private message to measure the current pulse (i.e. check when we received the last heartbeat).
+struct MeasurePulse;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConnectionStatus {
+    Online,
+    Offline,
 }
 
 impl Actor {
-    pub async fn new(
-        maker_addr: SocketAddr,
-        maker_noise_static_pk: x25519_dalek::PublicKey,
+    pub fn new(
+        status_sender: watch::Sender<ConnectionStatus>,
+        maker_to_taker: Box<dyn MessageChannel<wire::MakerToTaker>>,
         noise_static_sk: x25519_dalek::StaticSecret,
-    ) -> Result<Self> {
-        let (read, write, noise) = loop {
-            let socket = tokio::net::TcpSocket::new_v4().expect("Be able ta create a socket");
-            if let Ok(mut connection) = socket.connect(maker_addr).await {
-                let noise = noise::initiator_handshake(
-                    &mut connection,
-                    &noise_static_sk,
-                    &maker_noise_static_pk,
-                )
-                .await?;
-                let (read, write) = connection.into_split();
-                break (read, write, Arc::new(Mutex::new(noise)));
-            } else {
-                tracing::warn!(
-                    "Could not connect to the maker, retrying in {}s ...",
-                    CONNECTION_RETRY_INTERVAL.as_secs()
-                );
-                tokio::time::sleep(CONNECTION_RETRY_INTERVAL).await;
+        timeout: Duration,
+    ) -> Self {
+        let (send_to_maker_addr, send_to_maker_ctx) = xtra::Context::new(None);
+
+        Self {
+            status_sender,
+            send_to_maker: Box::new(send_to_maker_addr),
+            send_to_maker_ctx,
+            noise_static_sk,
+            maker_to_taker,
+            timeout,
+            connected_state: None,
+        }
+    }
+}
+
+#[xtra_productivity(message_impl = false)]
+impl Actor {
+    async fn handle_taker_to_maker(&mut self, message: wire::TakerToMaker) {
+        log_error!(self.send_to_maker.send(message));
+    }
+}
+
+#[xtra_productivity]
+impl Actor {
+    async fn handle_connect(
+        &mut self,
+        Connect {
+            maker_addr,
+            maker_noise_static_pk,
+        }: Connect,
+        ctx: &mut xtra::Context<Self>,
+    ) -> Result<()> {
+        let (read, write, noise) = {
+            let socket = tokio::net::TcpSocket::new_v4().expect("Be able to create a socket");
+            let mut connection = socket.connect(maker_addr).await?;
+            let noise = noise::initiator_handshake(
+                &mut connection,
+                &self.noise_static_sk,
+                &maker_noise_static_pk,
+            )
+            .await?;
+            let (read, write) = connection.into_split();
+            (read, write, Arc::new(Mutex::new(noise)))
+        };
+
+        let send_to_socket = send_to_socket::Actor::new(write, noise.clone());
+
+        tokio::spawn(self.send_to_maker_ctx.attach(send_to_socket));
+
+        let read = FramedRead::new(read, wire::EncryptedJsonCodec::new(noise))
+            .map(move |item| MakerStreamMessage { item });
+
+        let this = ctx.address().expect("self to be alive");
+        tokio::spawn(this.attach_stream(read));
+
+        let (pulse_future, pulse_remote_handle) = ctx
+            .notify_interval(self.timeout, || MeasurePulse)
+            .expect("we just started")
+            .remote_handle();
+        tokio::spawn(pulse_future);
+
+        self.connected_state = Some(ConnectedState {
+            last_heartbeat: SystemTime::now(),
+            _pulse_handle: pulse_remote_handle,
+        });
+        self.status_sender
+            .send(ConnectionStatus::Online)
+            .expect("receiver to outlive the actor");
+
+        Ok(())
+    }
+
+    async fn handle_wire_message(
+        &mut self,
+        message: MakerStreamMessage,
+        _ctx: &mut xtra::Context<Self>,
+    ) -> KeepRunning {
+        let msg = match message.item {
+            Ok(msg) => msg,
+            Err(e) => {
+                tracing::warn!("Error while receiving message from maker: {:#}", e);
+                return KeepRunning::Yes;
             }
         };
 
-        let send_to_maker = send_to_socket::Actor::new(write, noise.clone())
-            .create(None)
-            .spawn_global();
+        match msg {
+            wire::MakerToTaker::Heartbeat => {
+                tracing::info!("got the heartbeat");
+                self.connected_state
+                    .as_mut()
+                    .expect("wire messages only to arrive in connected state")
+                    .last_heartbeat = SystemTime::now();
+            }
+            other => {
+                // this one should go to the taker cfd actor
+                log_error!(self.maker_to_taker.send(other));
+            }
+        }
+        KeepRunning::Yes
+    }
 
-        let read = FramedRead::new(read, wire::EncryptedJsonCodec::new(noise))
-            .map(move |item| taker_cfd::MakerStreamMessage { item });
+    fn handle_measure_pulse(&mut self, _: MeasurePulse) {
+        let time_since_last_heartbeat = SystemTime::now()
+            .duration_since(
+                self.connected_state
+                    .as_ref()
+                    .expect("only run pulse measurements if connected")
+                    .last_heartbeat,
+            )
+            .expect("now is always later than heartbeat");
 
-        Ok(Self {
-            send_to_maker: Box::new(send_to_maker),
-            read_from_maker: Box::new(read),
-        })
+        if time_since_last_heartbeat > self.timeout {
+            self.status_sender
+                .send(ConnectionStatus::Offline)
+                .expect("watch receiver to outlive the actor");
+            self.connected_state = None;
+        }
     }
 }
+
+impl xtra::Actor for Actor {}

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -64,6 +64,8 @@ impl fmt::Display for TakerToMaker {
 #[serde(tag = "type", content = "payload")]
 #[allow(clippy::large_enum_variant)]
 pub enum MakerToTaker {
+    /// Periodically broadcasted message, indicating maker's presence
+    Heartbeat,
     CurrentOrder(Option<Order>),
     ConfirmOrder(OrderId), // TODO: Include payout curve in "accept" message from maker
     RejectOrder(OrderId),
@@ -82,6 +84,7 @@ pub enum MakerToTaker {
 impl fmt::Display for MakerToTaker {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            MakerToTaker::Heartbeat { .. } => write!(f, "Heartbeat"),
             MakerToTaker::CurrentOrder(_) => write!(f, "CurrentOrder"),
             MakerToTaker::ConfirmOrder(_) => write!(f, "ConfirmOrder"),
             MakerToTaker::RejectOrder(_) => write!(f, "RejectOrder"),


### PR DESCRIPTION
Connection actor takes care of establishing a connection to the maker and is
monitoring its status.

The connection actor:
- listens for periodically sent heartbeat messages from the maker,
- publish the maker status on a watch::channel feed outside TakerActorSystem,
- observe changes on the watch channel and shut down Rocket if maker goes offline

Note: this is a stepping stone resulting in temporary behaviour. Eventually,
     we'd want to support reconnecting to the maker as well as operating the
     taker without the maker being online (with a limited set of actions).