### PR TITLE
Use the same actor systems in production and testing

### DIFF
--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -11,14 +11,12 @@ async fn taker_receives_order_from_maker_on_publication() {
     let _guard = init_tracing();
     let (mut maker, mut taker) = start_both().await;
 
-    assert!(is_next_none(&mut taker.order_feed).await);
+    assert!(is_next_none(taker.order_feed()).await);
 
     maker.publish_order(dummy_new_order()).await;
 
-    let (published, received) = tokio::join!(
-        next_some(&mut maker.order_feed),
-        next_some(&mut taker.order_feed)
-    );
+    let (published, received) =
+        tokio::join!(next_some(maker.order_feed()), next_some(taker.order_feed()));
 
     assert_is_same_order(&published, &received);
 }
@@ -29,15 +27,15 @@ async fn taker_takes_order_and_maker_rejects() {
     let (mut maker, mut taker) = start_both().await;
 
     // TODO: Why is this needed? For the cfd stream it is not needed
-    is_next_none(&mut taker.order_feed).await;
+    is_next_none(taker.order_feed()).await;
 
     maker.publish_order(dummy_new_order()).await;
 
-    let (_, received) = next_order(&mut maker.order_feed, &mut taker.order_feed).await;
+    let (_, received) = next_order(maker.order_feed(), taker.order_feed()).await;
 
     taker.take_order(received.clone(), Usd::new(dec!(10))).await;
 
-    let (taker_cfd, maker_cfd) = next_cfd(&mut taker.cfd_feed, &mut maker.cfd_feed).await;
+    let (taker_cfd, maker_cfd) = next_cfd(taker.cfd_feed(), maker.cfd_feed()).await;
     assert_is_same_order(&taker_cfd.order, &received);
     assert_is_same_order(&maker_cfd.order, &received);
     assert!(matches!(
@@ -51,7 +49,7 @@ async fn taker_takes_order_and_maker_rejects() {
 
     maker.reject_take_request(received.clone()).await;
 
-    let (taker_cfd, maker_cfd) = next_cfd(&mut taker.cfd_feed, &mut maker.cfd_feed).await;
+    let (taker_cfd, maker_cfd) = next_cfd(taker.cfd_feed(), maker.cfd_feed()).await;
     // TODO: More elaborate Cfd assertions
     assert_is_same_order(&taker_cfd.order, &received);
     assert_is_same_order(&maker_cfd.order, &received);
@@ -64,14 +62,14 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
     let _guard = init_tracing();
     let (mut maker, mut taker) = start_both().await;
 
-    is_next_none(&mut taker.order_feed).await;
+    is_next_none(taker.order_feed()).await;
 
     maker.publish_order(dummy_new_order()).await;
 
-    let (_, received) = next_order(&mut maker.order_feed, &mut taker.order_feed).await;
+    let (_, received) = next_order(maker.order_feed(), taker.order_feed()).await;
 
     taker.take_order(received.clone(), Usd::new(dec!(5))).await;
-    let (_, _) = next_cfd(&mut taker.cfd_feed, &mut maker.cfd_feed).await;
+    let (_, _) = next_cfd(taker.cfd_feed(), maker.cfd_feed()).await;
 
     maker.mocks.mock_oracle_annoucement().await;
     taker.mocks.mock_oracle_annoucement().await;
@@ -81,7 +79,7 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
 
     maker.accept_take_request(received.clone()).await;
 
-    let (taker_cfd, maker_cfd) = next_cfd(&mut taker.cfd_feed, &mut maker.cfd_feed).await;
+    let (taker_cfd, maker_cfd) = next_cfd(taker.cfd_feed(), maker.cfd_feed()).await;
     // TODO: More elaborate Cfd assertions
     assert_eq!(taker_cfd.order.id, received.id);
     assert_eq!(maker_cfd.order.id, received.id);
@@ -91,7 +89,7 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
     maker.mocks.mock_wallet_sign_and_broadcast().await;
     taker.mocks.mock_wallet_sign_and_broadcast().await;
 
-    let (taker_cfd, maker_cfd) = next_cfd(&mut taker.cfd_feed, &mut maker.cfd_feed).await;
+    let (taker_cfd, maker_cfd) = next_cfd(taker.cfd_feed(), maker.cfd_feed()).await;
     // TODO: More elaborate Cfd assertions
     assert_eq!(taker_cfd.order.id, received.id);
     assert_eq!(maker_cfd.order.id, received.id);


### PR DESCRIPTION
Removes the need to manually align test harness whenever actor systems get
expanded.

Soon actor systems will be storing remote handles as well, and they will not be
public.