### PR TITLE
Reduce heartbeat interval in test harness

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -47,7 +47,7 @@ pub mod wallet;
 pub mod wallet_sync;
 pub mod wire;
 
-const HEARTBEAT_INTERVAL: std::time::Duration = Duration::from_secs(5);
+pub const HEARTBEAT_INTERVAL: std::time::Duration = Duration::from_secs(5);
 
 pub const N_PAYOUTS: usize = 200;
 
@@ -218,6 +218,7 @@ where
         oracle_constructor: impl FnOnce(Vec<Cfd>, Box<dyn StrongMessageChannel<Attestation>>) -> O,
         monitor_constructor: impl FnOnce(Box<dyn StrongMessageChannel<monitor::Event>>, Vec<Cfd>) -> F,
         n_payouts: usize,
+        maker_heartbeat_interval: Duration,
     ) -> Result<Self>
     where
         F: Future<Output = Result<M>>,
@@ -263,7 +264,7 @@ where
                     maker_online_status_feed_sender,
                     Box::new(cfd_actor_addr.clone()),
                     identity_sk,
-                    HEARTBEAT_INTERVAL * 2,
+                    maker_heartbeat_interval,
                 ))
                 .spawn_with_handle(),
         );

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -9,7 +9,7 @@ use daemon::seed::Seed;
 use daemon::tokio_ext::FutureExt;
 use daemon::{
     bitmex_price_feed, db, housekeeping, logger, maker_cfd, maker_inc_connections, monitor, oracle,
-    wallet, wallet_sync, MakerActorSystem, N_PAYOUTS,
+    wallet, wallet_sync, MakerActorSystem, HEARTBEAT_INTERVAL, N_PAYOUTS,
 };
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::SqlitePool;
@@ -263,7 +263,9 @@ async fn main() -> Result<()> {
                 monitor::Actor::new(electrum, channel, cfds)
             }
         },
-        |channel0, channel1| maker_inc_connections::Actor::new(channel0, channel1, identity_sk),
+        |channel0, channel1| {
+            maker_inc_connections::Actor::new(channel0, channel1, identity_sk, HEARTBEAT_INTERVAL)
+        },
         time::Duration::hours(opts.settlement_time_interval_hours as i64),
         N_PAYOUTS,
     )

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -9,7 +9,7 @@ use daemon::seed::Seed;
 use daemon::tokio_ext::FutureExt;
 use daemon::{
     bitmex_price_feed, connection, db, housekeeping, logger, monitor, oracle, taker_cfd, wallet,
-    wallet_sync, TakerActorSystem, N_PAYOUTS,
+    wallet_sync, TakerActorSystem, HEARTBEAT_INTERVAL, N_PAYOUTS,
 };
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::SqlitePool;
@@ -252,6 +252,7 @@ async fn main() -> Result<()> {
             }
         },
         N_PAYOUTS,
+        HEARTBEAT_INTERVAL * 2,
     )
     .await?;
 

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -1,11 +1,12 @@
 use crate::harness::flow::{is_next_none, next, next_cfd, next_order, next_some};
-use crate::harness::{assert_is_same_order, dummy_new_order, init_tracing, start_both};
+use crate::harness::{
+    assert_is_same_order, dummy_new_order, init_tracing, start_both, HEARTBEAT_INTERVAL_FOR_TEST,
+};
 use daemon::connection::ConnectionStatus;
 use daemon::model::cfd::CfdState;
 use daemon::model::Usd;
 use maia::secp256k1_zkp::schnorrsig;
 use rust_decimal_macros::dec;
-use std::time::Duration;
 use tokio::time::sleep;
 mod harness;
 
@@ -116,8 +117,7 @@ async fn taker_notices_lack_of_maker() {
 
     std::mem::drop(maker);
 
-    // TODO: shorten this sleep by specifying different heartbeat interval for tests
-    sleep(Duration::from_secs(12)).await;
+    sleep(HEARTBEAT_INTERVAL_FOR_TEST * 3).await;
 
     assert_eq!(
         ConnectionStatus::Offline,


### PR DESCRIPTION
As a rule of thumb, taker waits twice the amount of HEARTBEAT_INTERVAL until it
assumes that maker disappeared.