### PR TITLE
Another auto rollover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3826,7 +3826,6 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "pollster",
- "tokio",
 ]
 
 [[package]]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,5 @@
 disallowed-methods = [
   "xtra::Address::do_send_async", # discards the return value, possibly swallowing an error
   "xtra::Address::do_send", # discards the return value, possibly swallowing an error
+  "xtra::message_channel::MessageChannel::do_send", # discards the return value, possibly swallowing an error
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,5 @@
 disallowed-methods = [
+  "tokio::spawn", # tasks can outlive the actor system, prefer spawn_with_handle()
   "xtra::Address::do_send_async", # discards the return value, possibly swallowing an error
   "xtra::Address::do_send", # discards the return value, possibly swallowing an error
   "xtra::message_channel::MessageChannel::do_send", # discards the return value, possibly swallowing an error

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -45,7 +45,7 @@ tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log", "json"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 x25519-dalek = { version = "1.1" }
-xtra = { version = "0.6", features = ["with-tokio-1"] }
+xtra = { version = "0.6" }
 xtra_productivity = { version = "0.1.0" }
 
 [[bin]]

--- a/daemon/clippy.toml
+++ b/daemon/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+  "tokio::spawn", # tasks can outlive the actor system, prefer spawn_with_handle()
+]

--- a/daemon/clippy.toml
+++ b/daemon/clippy.toml
@@ -1,3 +1,0 @@
-disallowed-methods = [
-  "tokio::spawn", # tasks can outlive the actor system, prefer spawn_with_handle()
-]

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -39,7 +39,7 @@ pub async fn insert_order(order: &Order, conn: &mut PoolConnection<Sqlite>) -> a
     .bind(order.leverage.get())
     .bind(&order.liquidation_price.to_string())
     .bind(&order.creation_timestamp.seconds())
-    .bind(&order.settlement_time_interval_hours.whole_seconds())
+    .bind(&order.settlement_interval.whole_seconds())
     .bind(&order.origin)
     .bind(&order.oracle_event_id.to_string())
     .execute(conn)
@@ -90,7 +90,7 @@ pub async fn load_order_by_id(
         leverage: row.leverage,
         liquidation_price: row.liquidation_price.parse()?,
         creation_timestamp: row.ts_secs,
-        settlement_time_interval_hours: Duration::new(row.settlement_time_interval_secs, 0),
+        settlement_interval: Duration::new(row.settlement_time_interval_secs, 0),
         origin: row.origin,
         oracle_event_id: row.oracle_event_id.parse()?,
     })
@@ -300,7 +300,7 @@ pub async fn load_cfd_by_order_id(
         leverage: row.leverage,
         liquidation_price: row.liquidation_price.parse()?,
         creation_timestamp: row.ts_secs,
-        settlement_time_interval_hours: Duration::new(row.settlement_time_interval_secs, 0),
+        settlement_interval: Duration::new(row.settlement_time_interval_secs, 0),
         origin: row.origin,
         oracle_event_id: row.oracle_event_id.parse()?,
     };
@@ -398,7 +398,7 @@ pub async fn load_all_cfds(conn: &mut PoolConnection<Sqlite>) -> anyhow::Result<
                 leverage: row.leverage,
                 liquidation_price: row.liquidation_price.parse()?,
                 creation_timestamp: row.ts_secs,
-                settlement_time_interval_hours: Duration::new(row.settlement_time_interval_secs, 0),
+                settlement_interval: Duration::new(row.settlement_time_interval_secs, 0),
                 origin: row.origin,
                 oracle_event_id: row.oracle_event_id.parse()?,
             };
@@ -504,7 +504,7 @@ pub async fn load_cfds_by_oracle_event_id(
                 leverage: row.leverage,
                 liquidation_price: row.liquidation_price.parse()?,
                 creation_timestamp: row.ts_secs,
-                settlement_time_interval_hours: Duration::new(row.settlement_time_interval_secs, 0),
+                settlement_interval: Duration::new(row.settlement_time_interval_secs, 0),
                 origin: row.origin,
                 oracle_event_id: row.oracle_event_id.parse()?,
             };

--- a/daemon/src/fan_out.rs
+++ b/daemon/src/fan_out.rs
@@ -22,11 +22,10 @@ where
 {
     async fn handle(&mut self, message: M, _: &mut xtra::Context<Self>) {
         for receiver in &self.receivers {
-            // Not sure why here is no `do_send_async` ...
             if receiver.send(message.clone()).await.is_err() {
-                tracing::error!(
-                    "Fan out actor was unable to send to other actor - we should never see this."
-                )
+                // Should ideally remove from list but that is unnecessarily hard with Rust
+                // iterators
+                tracing::error!("Actor disconnected, cannot send message");
             }
         }
     }

--- a/daemon/src/fan_out.rs
+++ b/daemon/src/fan_out.rs
@@ -23,7 +23,7 @@ where
     async fn handle(&mut self, message: M, _: &mut xtra::Context<Self>) {
         for receiver in &self.receivers {
             // Not sure why here is no `do_send_async` ...
-            if receiver.do_send(message.clone()).is_err() {
+            if receiver.send(message.clone()).await.is_err() {
                 tracing::error!(
                     "Fan out actor was unable to send to other actor - we should never see this."
                 )

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -313,9 +313,7 @@ where
 
         tasks.add(oracle_ctx.run(oracle_constructor(cfds, Box::new(fan_out_actor))));
 
-        cfd_actor_addr
-            .do_send_async(taker_cfd::AutoRollover)
-            .await?;
+        cfd_actor_addr.send(taker_cfd::AutoRollover).await?;
 
         tracing::debug!("Taker actor system ready");
 

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -52,6 +52,8 @@ pub const HEARTBEAT_INTERVAL: std::time::Duration = Duration::from_secs(5);
 
 pub const N_PAYOUTS: usize = 200;
 
+pub const SETTLEMENT_INTERVAL: time::Duration = time::Duration::hours(24);
+
 /// Struct controlling the lifetime of the async tasks,
 /// such as running actors and periodic notifications.
 /// If it gets dropped, all tasks are cancelled.
@@ -109,7 +111,7 @@ where
             Box<dyn MessageChannel<NewTakerOnline>>,
             Box<dyn MessageChannel<FromTaker>>,
         ) -> T,
-        settlement_time_interval_hours: time::Duration,
+        settlement_interval: time::Duration,
         n_payouts: usize,
     ) -> Result<Self>
     where
@@ -133,7 +135,7 @@ where
         let (cfd_actor_addr, cfd_actor_fut) = maker_cfd::Actor::new(
             db,
             wallet_addr,
-            settlement_time_interval_hours,
+            settlement_interval,
             oracle_pk,
             cfd_feed_sender,
             order_feed_sender,

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -313,8 +313,6 @@ where
 
         tasks.add(oracle_ctx.run(oracle_constructor(cfds, Box::new(fan_out_actor))));
 
-        cfd_actor_addr.send(taker_cfd::AutoRollover).await?;
-
         tracing::debug!("Taker actor system ready");
 
         Ok(Self {

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
 #![warn(clippy::disallowed_method)]
-
 use crate::db::load_all_cfds;
 use crate::maker_cfd::{FromTaker, NewTakerOnline};
 use crate::model::cfd::{Cfd, Order, UpdateCfdProposals};

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -52,6 +52,16 @@ pub const HEARTBEAT_INTERVAL: std::time::Duration = Duration::from_secs(5);
 
 pub const N_PAYOUTS: usize = 200;
 
+/// The interval until the cfd gets settled, i.e. the attestation happens
+///
+/// This variable defines at what point in time the oracle event id will be chose to settle the cfd.
+/// Hence, this constant defines how long a cfd is open (until it gets either settled or rolled
+/// over).
+///
+/// Multiple code parts align on this constant:
+/// - How the oracle event id is chosen when creating an order (maker)
+/// - The sliding window of cached oracle announcements (maker, taker)
+/// - The auto-rollover time-window (taker)
 pub const SETTLEMENT_INTERVAL: time::Duration = time::Duration::hours(24);
 
 /// Struct controlling the lifetime of the async tasks,

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -255,11 +255,20 @@ where
 
         let (monitor_addr, mut monitor_ctx) = xtra::Context::new(None);
         let (oracle_addr, mut oracle_ctx) = xtra::Context::new(None);
+        let (cfd_actor_addr, mut cfd_context) = xtra::Context::new(None);
+        let (connection_actor_addr, connection_actor_ctx) = xtra::Context::new(None);
 
         let mut tasks = Tasks::default();
 
-        let (connection_actor_addr, connection_actor_ctx) = xtra::Context::new(None);
-        let (cfd_actor_addr, cfd_actor_fut) = taker_cfd::Actor::new(
+        // Trigger auto-rollover every 5 minutes, the actor decides if an actual proposal is to be
+        // sent out
+        tasks.add(
+            cfd_context
+                .notify_interval(Duration::from_secs(60 * 5), || taker_cfd::AutoRollover)
+                .map_err(|e| anyhow::anyhow!(e))?,
+        );
+
+        tasks.add(cfd_context.run(taker_cfd::Actor::new(
             db,
             wallet_addr,
             oracle_pk,
@@ -270,11 +279,7 @@ where
             monitor_addr.clone(),
             oracle_addr,
             n_payouts,
-        )
-        .create(None)
-        .run();
-
-        tasks.add(cfd_actor_fut);
+        )));
 
         tasks.add(connection_actor_ctx.run(connection::Actor::new(
             maker_online_status_feed_sender,
@@ -307,6 +312,10 @@ where
         tasks.add(fan_out_actor_fut);
 
         tasks.add(oracle_ctx.run(oracle_constructor(cfds, Box::new(fan_out_actor))));
+
+        cfd_actor_addr
+            .do_send_async(taker_cfd::AutoRollover)
+            .await?;
 
         tracing::debug!("Taker actor system ready");
 

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -62,7 +62,7 @@ pub struct FromTaker {
 pub struct Actor<O, M, T, W> {
     db: sqlx::SqlitePool,
     wallet: Address<W>,
-    settlement_time_interval_hours: Duration,
+    settlement_interval: Duration,
     oracle_pk: schnorrsig::PublicKey,
     cfd_feed_actor_inbox: watch::Sender<Vec<Cfd>>,
     order_feed_sender: watch::Sender<Option<Order>>,
@@ -102,7 +102,7 @@ impl<O, M, T, W> Actor<O, M, T, W> {
     pub fn new(
         db: sqlx::SqlitePool,
         wallet: Address<W>,
-        settlement_time_interval_hours: Duration,
+        settlement_interval: Duration,
         oracle_pk: schnorrsig::PublicKey,
         cfd_feed_actor_inbox: watch::Sender<Vec<Cfd>>,
         order_feed_sender: watch::Sender<Option<Order>>,
@@ -115,7 +115,7 @@ impl<O, M, T, W> Actor<O, M, T, W> {
         Self {
             db,
             wallet,
-            settlement_time_interval_hours,
+            settlement_interval,
             oracle_pk,
             cfd_feed_actor_inbox,
             order_feed_sender,
@@ -747,7 +747,7 @@ where
         let dlc = cfd.open_dlc().context("CFD was in wrong state")?;
 
         let oracle_event_id = oracle::next_announcement_after(
-            time::OffsetDateTime::now_utc() + cfd.order.settlement_time_interval_hours,
+            time::OffsetDateTime::now_utc() + cfd.order.settlement_interval,
         )?;
         let announcement = self
             .oracle_actor
@@ -959,7 +959,7 @@ where
         } = msg;
 
         let oracle_event_id = oracle::next_announcement_after(
-            time::OffsetDateTime::now_utc() + self.settlement_time_interval_hours,
+            time::OffsetDateTime::now_utc() + self.settlement_interval,
         )?;
 
         let order = Order::new(
@@ -968,7 +968,7 @@ where
             max_quantity,
             Origin::Ours,
             oracle_event_id,
-            self.settlement_time_interval_hours,
+            self.settlement_interval,
         )?;
 
         // 1. Save to DB

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -115,7 +115,7 @@ pub struct Order {
     pub creation_timestamp: Timestamp,
 
     /// The duration that will be used for calculating the settlement timestamp
-    pub settlement_time_interval_hours: Duration,
+    pub settlement_interval: Duration,
 
     pub origin: Origin,
 
@@ -132,7 +132,7 @@ impl Order {
         max_quantity: Usd,
         origin: Origin,
         oracle_event_id: BitMexPriceEventId,
-        settlement_time_interval_hours: Duration,
+        settlement_interval: Duration,
     ) -> Result<Self> {
         let leverage = Leverage::new(2)?;
         let liquidation_price = calculate_long_liquidation_price(leverage, price);
@@ -147,7 +147,7 @@ impl Order {
             liquidation_price,
             position: Position::Short,
             creation_timestamp: Timestamp::now()?,
-            settlement_time_interval_hours,
+            settlement_interval,
             origin,
             oracle_event_id,
         })
@@ -671,7 +671,7 @@ impl Cfd {
     }
 
     pub fn refund_timelock_in_blocks(&self) -> u32 {
-        (self.order.settlement_time_interval_hours * Cfd::REFUND_THRESHOLD)
+        (self.order.settlement_interval * Cfd::REFUND_THRESHOLD)
             .as_blocks()
             .ceil() as u32
     }
@@ -680,20 +680,20 @@ impl Cfd {
         self.order.oracle_event_id.timestamp()
     }
 
-    /// A factor to be added to the CFD order settlement_time_interval_hours for calculating the
+    /// A factor to be added to the CFD order settlement_interval for calculating the
     /// refund timelock.
     ///
     /// The refund timelock is important in case the oracle disappears or never publishes a
     /// signature. Ideally, both users collaboratively settle in the refund scenario. This
     /// factor is important if the users do not settle collaboratively.
-    /// `1.5` times the settlement_time_interval_hours as defined in CFD order should be safe in the
+    /// `1.5` times the settlement_interval as defined in CFD order should be safe in the
     /// extreme case where a user publishes the commit transaction right after the contract was
     /// initialized. In this case, the oracle still has `1.0 *
-    /// cfdorder.settlement_time_interval_hours` time to attest and no one can publish the refund
+    /// cfdorder.settlement_interval` time to attest and no one can publish the refund
     /// transaction.
     /// The downside is that if the oracle disappears: the users would only notice at the end
-    /// of the cfd settlement_time_interval_hours. In this case the users has to wait for another
-    /// `1.5` times of the settlement_time_interval_hours to get his funds back.
+    /// of the cfd settlement_interval. In this case the users has to wait for another
+    /// `1.5` times of the settlement_interval to get his funds back.
     const REFUND_THRESHOLD: f32 = 1.5;
 
     pub const CET_TIMELOCK: u32 = 12;

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -2,7 +2,7 @@ use crate::model::{
     BitMexPriceEventId, InversePrice, Leverage, Percent, Position, Price, TakerId, Timestamp,
     TradingPair, Usd,
 };
-use crate::{monitor, oracle, payout_curve};
+use crate::{monitor, oracle, payout_curve, SETTLEMENT_INTERVAL};
 use anyhow::{bail, Context, Result};
 use bdk::bitcoin::secp256k1::{SecretKey, Signature};
 use bdk::bitcoin::{Address, Amount, PublicKey, Script, SignedAmount, Transaction, Txid};
@@ -1277,27 +1277,35 @@ impl Cfd {
 
     /// Only cfds in state `Open` that have not received an attestation and are within 23 hours
     /// until expiry are eligible for rollover
-    pub fn rollover_proposal(&self) -> Option<RollOverProposal> {
-        let now = OffsetDateTime::now_utc();
-        let remaining_till_expiry = self.expiry_timestamp() - now;
-        let rollover_window = Duration::hours(1);
+    pub fn rollover_proposal(&self, now: OffsetDateTime) -> Option<RollOverProposal> {
+        // already expired
+        if now > self.expiry_timestamp() {
+            return None;
+        }
 
-        if matches!(
+        let time_until_expiry = self.expiry_timestamp() - now;
+
+        // was just rolled over
+        if time_until_expiry > SETTLEMENT_INTERVAL - Duration::HOUR {
+            return None;
+        }
+
+        // state does not match
+        // only state open with no attestation is acceptable for rollover
+        if !matches!(
             self.state.clone(),
             CfdState::Open {
                 attestation: None,
                 ..
             }
-        ) && remaining_till_expiry > rollover_window
-            && remaining_till_expiry > Duration::ZERO
-        {
-            Some(RollOverProposal {
-                order_id: self.order.id,
-                timestamp: Timestamp::now().expect("the timestamp not to fail"),
-            })
-        } else {
-            None
+        ) {
+            return None;
         }
+
+        Some(RollOverProposal {
+            order_id: self.order.id,
+            timestamp: Timestamp::now().expect("the timestamp not to fail"),
+        })
     }
 }
 
@@ -1623,6 +1631,7 @@ mod tests {
     use rust_decimal_macros::dec;
     use std::collections::BTreeMap;
     use std::str::FromStr;
+    use time::macros::datetime;
 
     #[test]
     fn given_default_values_then_expected_liquidation_price() {
@@ -1871,55 +1880,109 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn given_cfd_rollover_window_lower_bound_then_rollover_proposal() {
-        let now = OffsetDateTime::now_utc();
-        let cfd = Cfd::dummy_open().with_event_id(BitMexPriceEventId::with_20_digits(
-            now + Duration::hours(1) + Duration::seconds(1),
-        ));
+    async fn given_cfd_expires_now_then_rollover_proposal() {
+        // --|----|-------------------------------------------------|--> time
+        //   ct   1h                                                24h
+        // --|----|<--------------------rollover------------------->|--
+        //                                                          now
 
-        assert!(cfd.rollover_proposal().is_some());
+        let cfd = Cfd::dummy_open().with_event_id(BitMexPriceEventId::with_20_digits(
+            datetime!(2021-11-19 10:00:00).assume_utc(),
+        ));
+        let rollover_proposal = cfd.rollover_proposal(datetime!(2021-11-19 10:00:00).assume_utc());
+
+        assert!(rollover_proposal.is_some());
     }
 
     #[tokio::test]
-    async fn given_cfd_rollover_window_upper_bound_then_rollover_proposal() {
-        let now = OffsetDateTime::now_utc();
-        let cfd = Cfd::dummy_open().with_event_id(BitMexPriceEventId::with_20_digits(
-            now + Duration::hours(23) + Duration::seconds(59),
-        ));
+    async fn given_cfd_expires_within_23hours_then_rollover_proposal() {
+        // --|----|-------------------------------------------------|--> time
+        //   ct   1h                                                24h
+        // --|----|<--------------------rollover------------------->|--
+        //        now
 
-        assert!(cfd.rollover_proposal().is_some());
+        let cfd = Cfd::dummy_open().with_event_id(BitMexPriceEventId::with_20_digits(
+            datetime!(2021-11-19 10:00:00).assume_utc(),
+        ));
+        let rollover_proposal = cfd.rollover_proposal(datetime!(2021-11-18 11:00:00).assume_utc());
+
+        assert!(rollover_proposal.is_some());
     }
 
     #[tokio::test]
     async fn given_cfd_past_expiry_time_then_no_rollover_proposal() {
-        let now = OffsetDateTime::now_utc();
-        let cfd = Cfd::dummy_open().with_event_id(BitMexPriceEventId::with_20_digits(
-            now - Duration::seconds(1),
-        ));
+        // --|----|-------------------------------------------------|--> time
+        //   ct   1h                                                24h
+        // --|----|<--------------------rollover------------------->|--
+        //                                                           now
 
-        assert!(cfd.rollover_proposal().is_none())
+        let cfd = Cfd::dummy_open().with_event_id(BitMexPriceEventId::with_20_digits(
+            datetime!(2021-11-19 10:00:00).assume_utc(),
+        ));
+        let rollover_proposal = cfd.rollover_proposal(datetime!(2021-11-19 10:00:01).assume_utc());
+
+        assert!(rollover_proposal.is_none());
     }
 
     #[tokio::test]
     async fn given_cfd_was_just_renewed_then_no_rollover_proposal() {
-        let now = OffsetDateTime::now_utc();
-        let cfd = Cfd::dummy_open().with_event_id(BitMexPriceEventId::with_20_digits(
-            now + Duration::hours(1) - Duration::seconds(1),
-        ));
+        // --|----|-------------------------------------------------|--> time
+        //   ct   1h                                                24h
+        // --|----|<--------------------rollover------------------->|--
+        //    now
 
-        assert!(cfd.rollover_proposal().is_none())
+        let cfd = Cfd::dummy_open().with_event_id(BitMexPriceEventId::with_20_digits(
+            datetime!(2021-11-19 10:00:00).assume_utc(),
+        ));
+        let rollover_proposal = cfd.rollover_proposal(datetime!(2021-11-18 10:00:01).assume_utc());
+
+        assert!(rollover_proposal.is_none());
+    }
+
+    #[tokio::test]
+    async fn given_cfd_out_of_bounds_expiry_then_no_rollover_proposal() {
+        // --|----|-------------------------------------------------|--> time
+        //   ct   1h                                                24h
+        // --|----|<--------------------rollover------------------->|--
+        //  now
+
+        let cfd = Cfd::dummy_open().with_event_id(BitMexPriceEventId::with_20_digits(
+            datetime!(2021-11-19 10:00:00).assume_utc(),
+        ));
+        let rollover_proposal = cfd.rollover_proposal(datetime!(2021-11-18 09:59:59).assume_utc());
+
+        assert!(rollover_proposal.is_none());
+    }
+
+    #[tokio::test]
+    async fn given_cfd_was_renewed_less_than_1h_ago_then_no_rollover_proposal() {
+        // --|----|-------------------------------------------------|--> time
+        //   ct   1h                                                24h
+        // --|----|<--------------------rollover------------------->|--
+        //       now
+
+        let cfd = Cfd::dummy_open().with_event_id(BitMexPriceEventId::with_20_digits(
+            datetime!(2021-11-19 10:00:00).assume_utc(),
+        ));
+        let rollover_proposal = cfd.rollover_proposal(datetime!(2021-11-18 10:59:59).assume_utc());
+
+        assert!(rollover_proposal.is_none());
     }
 
     #[tokio::test]
     async fn given_cfd_has_attestation_then_no_rollover_proposal() {
         let cfd = Cfd::dummy_open_with_attestation();
-        assert!(cfd.rollover_proposal().is_none())
+        assert!(cfd
+            .rollover_proposal(datetime!(2021-11-19 10:00:00).assume_utc())
+            .is_none())
     }
 
     #[tokio::test]
     async fn given_cfd_not_in_open_then_no_rollover_proposal() {
         let cfd = Cfd::dummy_not_open();
-        assert!(cfd.rollover_proposal().is_none())
+        assert!(cfd
+            .rollover_proposal(datetime!(2021-11-19 10:00:00).assume_utc())
+            .is_none())
     }
 
     impl Cfd {

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -1416,6 +1416,181 @@ fn calculate_profit(
     Ok((profit, Percent(percent)))
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Cet {
+    pub tx: Transaction,
+    pub adaptor_sig: EcdsaAdaptorSignature,
+
+    // TODO: Range + number of digits (usize) could be represented as Digits similar to what we do
+    // in the protocol lib
+    pub range: RangeInclusive<u64>,
+    pub n_bits: usize,
+}
+
+/// Contains all data we've assembled about the CFD through the setup protocol.
+///
+/// All contained signatures are the signatures of THE OTHER PARTY.
+/// To use any of these transactions, we need to re-sign them with the correct secret key.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Dlc {
+    pub identity: SecretKey,
+    pub identity_counterparty: PublicKey,
+    pub revocation: SecretKey,
+    pub revocation_pk_counterparty: PublicKey,
+    pub publish: SecretKey,
+    pub publish_pk_counterparty: PublicKey,
+    pub maker_address: Address,
+    pub taker_address: Address,
+
+    /// The fully signed lock transaction ready to be published on chain
+    pub lock: (Transaction, Descriptor<PublicKey>),
+    pub commit: (Transaction, EcdsaAdaptorSignature, Descriptor<PublicKey>),
+    pub cets: HashMap<BitMexPriceEventId, Vec<Cet>>,
+    pub refund: (Transaction, Signature),
+
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    pub maker_lock_amount: Amount,
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    pub taker_lock_amount: Amount,
+
+    pub revoked_commit: Vec<RevokedCommit>,
+}
+
+impl Dlc {
+    /// Create a close transaction based on the current contract and a settlement proposals
+    pub fn close_transaction(
+        &self,
+        proposal: &crate::model::cfd::SettlementProposal,
+    ) -> Result<(Transaction, Signature)> {
+        let (lock_tx, lock_desc) = &self.lock;
+        let (lock_outpoint, lock_amount) = {
+            let outpoint = lock_tx
+                .outpoint(&lock_desc.script_pubkey())
+                .expect("lock script to be in lock tx");
+            let amount = Amount::from_sat(lock_tx.output[outpoint.vout as usize].value);
+
+            (outpoint, amount)
+        };
+        let (tx, sighash) = maia::close_transaction(
+            lock_desc,
+            lock_outpoint,
+            lock_amount,
+            (&self.maker_address, proposal.maker),
+            (&self.taker_address, proposal.taker),
+        )
+        .context("Unable to collaborative close transaction")?;
+
+        let sig = SECP256K1.sign(&sighash, &self.identity);
+
+        Ok((tx, sig))
+    }
+
+    pub fn finalize_spend_transaction(
+        &self,
+        (close_tx, own_sig): (Transaction, Signature),
+        counterparty_sig: Signature,
+    ) -> Result<Transaction> {
+        let own_pk = PublicKey::new(secp256k1_zkp::PublicKey::from_secret_key(
+            SECP256K1,
+            &self.identity,
+        ));
+
+        let (_, lock_desc) = &self.lock;
+        let spend_tx = maia::finalize_spend_transaction(
+            close_tx,
+            lock_desc,
+            (own_pk, own_sig),
+            (self.identity_counterparty, counterparty_sig),
+        )?;
+
+        Ok(spend_tx)
+    }
+
+    pub fn refund_amount(&self, role: Role) -> Amount {
+        let our_script_pubkey = match role {
+            Role::Taker => self.taker_address.script_pubkey(),
+            Role::Maker => self.maker_address.script_pubkey(),
+        };
+
+        self.refund
+            .0
+            .output
+            .iter()
+            .find(|output| output.script_pubkey == our_script_pubkey)
+            .map(|output| Amount::from_sat(output.value))
+            .unwrap_or_default()
+    }
+
+    pub fn script_pubkey_for(&self, role: Role) -> Script {
+        match role {
+            Role::Maker => self.maker_address.script_pubkey(),
+            Role::Taker => self.taker_address.script_pubkey(),
+        }
+    }
+}
+
+/// Information which we need to remember in order to construct a
+/// punishment transaction in case the counterparty publishes a
+/// revoked commit transaction.
+///
+/// It also includes the information needed to monitor for the
+/// publication of the revoked commit transaction.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RevokedCommit {
+    // To build punish transaction
+    pub encsig_ours: EcdsaAdaptorSignature,
+    pub revocation_sk_theirs: SecretKey,
+    pub publication_pk_theirs: PublicKey,
+    // To monitor revoked commit transaction
+    pub txid: Txid,
+    pub script_pubkey: Script,
+}
+
+/// Used when transactions (e.g. collaborative close) are recorded as a part of
+/// CfdState in the cases when we can't solely rely on state transition
+/// timestamp as it could have occured for different reasons (like a new
+/// attestation in Open state)
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct CollaborativeSettlement {
+    pub tx: Transaction,
+    pub timestamp: Timestamp,
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    payout: Amount,
+    price: Price,
+}
+
+impl CollaborativeSettlement {
+    pub fn new(tx: Transaction, own_script_pubkey: Script, price: Price) -> Result<Self> {
+        // Falls back to Amount::ZERO in case we don't find an output that matches out script pubkey
+        // The assumption is, that this can happen for cases where we were liuqidated
+        let payout = match tx
+            .output
+            .iter()
+            .find(|output| output.script_pubkey == own_script_pubkey)
+            .map(|output| Amount::from_sat(output.value))
+        {
+            Some(payout) => payout,
+            None => {
+                tracing::error!(
+                    "Collaborative settlement with a zero amount, this should really not happen!"
+                );
+                Amount::ZERO
+            }
+        };
+
+        Ok(Self {
+            tx,
+            timestamp: Timestamp::now().context("Unable to get current time")?,
+            payout,
+            price,
+        })
+    }
+
+    pub fn payout(&self) -> Amount {
+        self.payout
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1665,180 +1840,5 @@ mod tests {
         let deserialized = serde_json::from_str(&serde_json::to_string(&id).unwrap()).unwrap();
 
         assert_eq!(id, deserialized);
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Cet {
-    pub tx: Transaction,
-    pub adaptor_sig: EcdsaAdaptorSignature,
-
-    // TODO: Range + number of digits (usize) could be represented as Digits similar to what we do
-    // in the protocol lib
-    pub range: RangeInclusive<u64>,
-    pub n_bits: usize,
-}
-
-/// Contains all data we've assembled about the CFD through the setup protocol.
-///
-/// All contained signatures are the signatures of THE OTHER PARTY.
-/// To use any of these transactions, we need to re-sign them with the correct secret key.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Dlc {
-    pub identity: SecretKey,
-    pub identity_counterparty: PublicKey,
-    pub revocation: SecretKey,
-    pub revocation_pk_counterparty: PublicKey,
-    pub publish: SecretKey,
-    pub publish_pk_counterparty: PublicKey,
-    pub maker_address: Address,
-    pub taker_address: Address,
-
-    /// The fully signed lock transaction ready to be published on chain
-    pub lock: (Transaction, Descriptor<PublicKey>),
-    pub commit: (Transaction, EcdsaAdaptorSignature, Descriptor<PublicKey>),
-    pub cets: HashMap<BitMexPriceEventId, Vec<Cet>>,
-    pub refund: (Transaction, Signature),
-
-    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
-    pub maker_lock_amount: Amount,
-    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
-    pub taker_lock_amount: Amount,
-
-    pub revoked_commit: Vec<RevokedCommit>,
-}
-
-impl Dlc {
-    /// Create a close transaction based on the current contract and a settlement proposals
-    pub fn close_transaction(
-        &self,
-        proposal: &crate::model::cfd::SettlementProposal,
-    ) -> Result<(Transaction, Signature)> {
-        let (lock_tx, lock_desc) = &self.lock;
-        let (lock_outpoint, lock_amount) = {
-            let outpoint = lock_tx
-                .outpoint(&lock_desc.script_pubkey())
-                .expect("lock script to be in lock tx");
-            let amount = Amount::from_sat(lock_tx.output[outpoint.vout as usize].value);
-
-            (outpoint, amount)
-        };
-        let (tx, sighash) = maia::close_transaction(
-            lock_desc,
-            lock_outpoint,
-            lock_amount,
-            (&self.maker_address, proposal.maker),
-            (&self.taker_address, proposal.taker),
-        )
-        .context("Unable to collaborative close transaction")?;
-
-        let sig = SECP256K1.sign(&sighash, &self.identity);
-
-        Ok((tx, sig))
-    }
-
-    pub fn finalize_spend_transaction(
-        &self,
-        (close_tx, own_sig): (Transaction, Signature),
-        counterparty_sig: Signature,
-    ) -> Result<Transaction> {
-        let own_pk = PublicKey::new(secp256k1_zkp::PublicKey::from_secret_key(
-            SECP256K1,
-            &self.identity,
-        ));
-
-        let (_, lock_desc) = &self.lock;
-        let spend_tx = maia::finalize_spend_transaction(
-            close_tx,
-            lock_desc,
-            (own_pk, own_sig),
-            (self.identity_counterparty, counterparty_sig),
-        )?;
-
-        Ok(spend_tx)
-    }
-
-    pub fn refund_amount(&self, role: Role) -> Amount {
-        let our_script_pubkey = match role {
-            Role::Taker => self.taker_address.script_pubkey(),
-            Role::Maker => self.maker_address.script_pubkey(),
-        };
-
-        self.refund
-            .0
-            .output
-            .iter()
-            .find(|output| output.script_pubkey == our_script_pubkey)
-            .map(|output| Amount::from_sat(output.value))
-            .unwrap_or_default()
-    }
-
-    pub fn script_pubkey_for(&self, role: Role) -> Script {
-        match role {
-            Role::Maker => self.maker_address.script_pubkey(),
-            Role::Taker => self.taker_address.script_pubkey(),
-        }
-    }
-}
-
-/// Information which we need to remember in order to construct a
-/// punishment transaction in case the counterparty publishes a
-/// revoked commit transaction.
-///
-/// It also includes the information needed to monitor for the
-/// publication of the revoked commit transaction.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct RevokedCommit {
-    // To build punish transaction
-    pub encsig_ours: EcdsaAdaptorSignature,
-    pub revocation_sk_theirs: SecretKey,
-    pub publication_pk_theirs: PublicKey,
-    // To monitor revoked commit transaction
-    pub txid: Txid,
-    pub script_pubkey: Script,
-}
-
-/// Used when transactions (e.g. collaborative close) are recorded as a part of
-/// CfdState in the cases when we can't solely rely on state transition
-/// timestamp as it could have occured for different reasons (like a new
-/// attestation in Open state)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct CollaborativeSettlement {
-    pub tx: Transaction,
-    pub timestamp: Timestamp,
-    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
-    payout: Amount,
-    price: Price,
-}
-
-impl CollaborativeSettlement {
-    pub fn new(tx: Transaction, own_script_pubkey: Script, price: Price) -> Result<Self> {
-        // Falls back to Amount::ZERO in case we don't find an output that matches out script pubkey
-        // The assumption is, that this can happen for cases where we were liuqidated
-        let payout = match tx
-            .output
-            .iter()
-            .find(|output| output.script_pubkey == own_script_pubkey)
-            .map(|output| Amount::from_sat(output.value))
-        {
-            Some(payout) => payout,
-            None => {
-                tracing::error!(
-                    "Collaborative settlement with a zero amount, this should really not happen!"
-                );
-                Amount::ZERO
-            }
-        };
-
-        Ok(Self {
-            tx,
-            timestamp: Timestamp::now().context("Unable to get current time")?,
-            payout,
-            price,
-        })
-    }
-
-    pub fn payout(&self) -> Amount {
-        self.payout
     }
 }

--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -170,11 +170,6 @@ pub async fn post_cfd_action(
             tracing::error!(msg);
             return Err(HttpApiProblem::new(StatusCode::BAD_REQUEST).detail(msg));
         }
-        CfdAction::RollOver => {
-            let msg = "RollOver proposal can only be triggered by taker";
-            tracing::error!(msg);
-            return Err(HttpApiProblem::new(StatusCode::BAD_REQUEST).detail(msg));
-        }
     };
 
     result

--- a/daemon/src/routes_taker.rs
+++ b/daemon/src/routes_taker.rs
@@ -149,7 +149,6 @@ pub async fn post_cfd_action(
                 current_price,
             })
         }
-        CfdAction::RollOver => cfd_action_channel.send(ProposeRollOver { order_id: id }),
     };
 
     result

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -9,7 +9,7 @@ use daemon::seed::Seed;
 use daemon::tokio_ext::FutureExt;
 use daemon::{
     bitmex_price_feed, connection, db, housekeeping, logger, monitor, oracle, taker_cfd, wallet,
-    wallet_sync, TakerActorSystem, Tasks, HEARTBEAT_INTERVAL, N_PAYOUTS,
+    wallet_sync, TakerActorSystem, Tasks, HEARTBEAT_INTERVAL, N_PAYOUTS, SETTLEMENT_INTERVAL,
 };
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::SqlitePool;
@@ -25,7 +25,6 @@ use xtra::Actor;
 
 mod routes_taker;
 
-pub const ANNOUNCEMENT_LOOKAHEAD: time::Duration = time::Duration::hours(24);
 const CONNECTION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Parser)]
@@ -246,7 +245,7 @@ async fn main() -> Result<()> {
         wallet.clone(),
         oracle,
         identity_sk,
-        |cfds, channel| oracle::Actor::new(cfds, channel, ANNOUNCEMENT_LOOKAHEAD),
+        |cfds, channel| oracle::Actor::new(cfds, channel, SETTLEMENT_INTERVAL),
         {
             |channel, cfds| {
                 let electrum = opts.network.electrum().to_string();

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -290,6 +290,9 @@ async fn main() -> Result<()> {
     let rocket = rocket.ignite().await?;
     let shutdown_handle = rocket.shutdown();
 
+    // has to be done after connection is established, otherwise blocks
+    cfd_actor_addr.send(taker_cfd::AutoRollover).await?;
+
     // shutdown the rocket server maker if goes offline
     tasks.add(async move {
         loop {

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -30,12 +30,13 @@ pub enum CfdAction {
         order_id: OrderId,
         current_price: Price,
     },
-    ProposeRollOver {
-        order_id: OrderId,
-    },
     Commit {
         order_id: OrderId,
     },
+}
+
+pub struct ProposeRollOver {
+    order_id: OrderId,
 }
 
 pub struct CfdSetupCompleted {
@@ -713,7 +714,6 @@ where
                 self.handle_propose_settlement(order_id, current_price)
                     .await
             }
-            ProposeRollOver { order_id } => self.handle_propose_roll_over(order_id).await,
         } {
             tracing::error!("Message handler failed: {:#}", e);
             anyhow::bail!(e)
@@ -816,6 +816,13 @@ where
     }
 }
 
+#[async_trait]
+impl<O: 'static, M: 'static, W: 'static> Handler<ProposeRollOver> for Actor<O, M, W> {
+    async fn handle(&mut self, msg: ProposeRollOver, _ctx: &mut Context<Self>) {
+        log_error!(self.handle_propose_roll_over(msg.order_id))
+    }
+}
+
 impl Message for TakeOffer {
     type Result = Result<()>;
 }
@@ -829,6 +836,10 @@ impl Message for CfdSetupCompleted {
 }
 
 impl Message for CfdRollOverCompleted {
+    type Result = ();
+}
+
+impl Message for ProposeRollOver {
     type Result = ();
 }
 

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -17,6 +17,7 @@ use futures::channel::mpsc;
 use futures::future::RemoteHandle;
 use futures::{future, SinkExt};
 use std::collections::HashMap;
+use time::OffsetDateTime;
 use tokio::sync::watch;
 use xtra::prelude::*;
 
@@ -364,9 +365,10 @@ impl<O: 'static, M: 'static, W: 'static> Actor<O, M, W> {
         // cleanup all pending proposals because auto-rollover will create a new one
         self.current_pending_proposals.clear();
 
+        let now = OffsetDateTime::now_utc();
         let proposals = cfds
             .iter()
-            .filter_map(|cfd| cfd.rollover_proposal())
+            .filter_map(|cfd| cfd.rollover_proposal(now))
             .collect::<Vec<RollOverProposal>>();
 
         let address = ctx

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -332,28 +332,6 @@ impl<O, M, W> Actor<O, M, W> {
         Ok(())
     }
 
-    async fn handle_auto_rollover(&mut self) -> Result<()> {
-        tracing::debug!("Auto rollover");
-
-        let mut conn = self.db.acquire().await?;
-        let cfds = load_all_cfds(&mut conn).await?;
-
-        // cleanup all pending proposals because auto-rollover will create a new one
-        self.current_pending_proposals.clear();
-
-        let proposals = cfds
-            .iter()
-            .filter_map(|cfd| cfd.rollover_proposal())
-            .collect::<Vec<RollOverProposal>>();
-
-        // TODO: Consider send message to ourselves
-        for proposal in proposals {
-            try_continue!(self.handle_propose_roll_over(proposal).await)
-        }
-
-        Ok(())
-    }
-
     async fn handle_propose_roll_over(&mut self, proposal: RollOverProposal) -> Result<()> {
         self.current_pending_proposals.insert(
             proposal.order_id,
@@ -370,6 +348,33 @@ impl<O, M, W> Actor<O, M, W> {
                 timestamp: proposal.timestamp,
             })
             .await?;
+        Ok(())
+    }
+}
+
+impl<O: 'static, M: 'static, W: 'static> Actor<O, M, W> {
+    async fn handle_auto_rollover(&mut self, ctx: &mut Context<Self>) -> Result<()> {
+        tracing::debug!("Auto rollover");
+
+        let mut conn = self.db.acquire().await?;
+        let cfds = load_all_cfds(&mut conn).await?;
+
+        // cleanup all pending proposals because auto-rollover will create a new one
+        self.current_pending_proposals.clear();
+
+        let proposals = cfds
+            .iter()
+            .filter_map(|cfd| cfd.rollover_proposal())
+            .collect::<Vec<RollOverProposal>>();
+
+        let address = ctx
+            .address()
+            .expect("actor to be able to retrieve own address");
+
+        for proposal in proposals {
+            try_continue!(address.send(ProposeRollOver { proposal }).await)
+        }
+
         Ok(())
     }
 }
@@ -840,8 +845,8 @@ impl<O: 'static, M: 'static, W: 'static> Handler<ProposeRollOver> for Actor<O, M
 
 #[async_trait]
 impl<O: 'static, M: 'static, W: 'static> Handler<AutoRollover> for Actor<O, M, W> {
-    async fn handle(&mut self, _msg: AutoRollover, _ctx: &mut Context<Self>) {
-        log_error!(self.handle_auto_rollover())
+    async fn handle(&mut self, _msg: AutoRollover, ctx: &mut Context<Self>) {
+        log_error!(self.handle_auto_rollover(ctx))
     }
 }
 

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -163,7 +163,8 @@ impl<O, M, W> Actor<O, M, W> {
         self.order_feed_actor_inbox.send(None)?;
 
         self.send_to_maker
-            .do_send(wire::TakerToMaker::TakeOrder { order_id, quantity })?;
+            .send(wire::TakerToMaker::TakeOrder { order_id, quantity })
+            .await?;
 
         Ok(())
     }
@@ -217,13 +218,14 @@ where
         self.send_pending_update_proposals()?;
 
         self.send_to_maker
-            .do_send(wire::TakerToMaker::ProposeSettlement {
+            .send(wire::TakerToMaker::ProposeSettlement {
                 order_id: proposal.order_id,
                 timestamp: proposal.timestamp,
                 taker: proposal.taker,
                 maker: proposal.maker,
                 price: proposal.price,
-            })?;
+            })
+            .await?;
         Ok(())
     }
 
@@ -377,10 +379,11 @@ where
         self.send_pending_update_proposals()?;
 
         self.send_to_maker
-            .do_send(wire::TakerToMaker::ProposeRollOver {
+            .send(wire::TakerToMaker::ProposeRollOver {
                 order_id: proposal.order_id,
                 timestamp: proposal.timestamp,
-            })?;
+            })
+            .await?;
         Ok(())
     }
 }
@@ -655,10 +658,11 @@ where
         let (tx, sig_taker) = dlc.close_transaction(proposal)?;
 
         self.send_to_maker
-            .do_send(wire::TakerToMaker::InitiateSettlement {
+            .send(wire::TakerToMaker::InitiateSettlement {
                 order_id,
                 sig_taker,
-            })?;
+            })
+            .await?;
 
         cfd.handle(CfdStateChangeEvent::ProposalSigned(
             CollaborativeSettlement::new(

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -1,15 +1,15 @@
 use crate::cfd_actors::{self, append_cfd_state, insert_cfd_and_send_to_feed};
-use crate::db::{insert_order, load_cfd_by_order_id, load_order_by_id};
+use crate::db::{insert_order, load_all_cfds, load_cfd_by_order_id, load_order_by_id};
 use crate::model::cfd::{
     Cfd, CfdState, CfdStateChangeEvent, CfdStateCommon, CollaborativeSettlement, Dlc, Order,
     OrderId, Origin, Role, RollOverProposal, SettlementKind, SettlementProposal, UpdateCfdProposal,
     UpdateCfdProposals,
 };
-use crate::model::{BitMexPriceEventId, Price, Timestamp, Usd};
+use crate::model::{BitMexPriceEventId, Price, Usd};
 use crate::monitor::{self, MonitorParams};
 use crate::tokio_ext::FutureExt;
 use crate::wire::{MakerToTaker, RollOverMsg, SetupMsg};
-use crate::{log_error, oracle, setup_contract, wallet, wire};
+use crate::{log_error, oracle, setup_contract, try_continue, wallet, wire};
 use anyhow::{bail, Context as _, Result};
 use async_trait::async_trait;
 use bdk::bitcoin::secp256k1::schnorrsig;
@@ -36,8 +36,10 @@ pub enum CfdAction {
 }
 
 pub struct ProposeRollOver {
-    order_id: OrderId,
+    proposal: RollOverProposal,
 }
+
+pub struct AutoRollover;
 
 pub struct CfdSetupCompleted {
     pub order_id: OrderId,
@@ -330,16 +332,29 @@ impl<O, M, W> Actor<O, M, W> {
         Ok(())
     }
 
-    async fn handle_propose_roll_over(&mut self, order_id: OrderId) -> Result<()> {
-        if self.current_pending_proposals.contains_key(&order_id) {
-            anyhow::bail!("An update for order id {} is already in progress", order_id)
+    async fn handle_auto_rollover(&mut self) -> Result<()> {
+        tracing::debug!("Auto rollover");
+
+        let mut conn = self.db.acquire().await?;
+        let cfds = load_all_cfds(&mut conn).await?;
+
+        // cleanup all pending proposals because auto-rollover will create a new one
+        self.current_pending_proposals.clear();
+
+        let proposals = cfds
+            .iter()
+            .filter_map(|cfd| cfd.rollover_proposal())
+            .collect::<Vec<RollOverProposal>>();
+
+        // TODO: Consider send message to ourselves
+        for proposal in proposals {
+            try_continue!(self.handle_propose_roll_over(proposal).await)
         }
 
-        let proposal = RollOverProposal {
-            order_id,
-            timestamp: Timestamp::now()?,
-        };
+        Ok(())
+    }
 
+    async fn handle_propose_roll_over(&mut self, proposal: RollOverProposal) -> Result<()> {
         self.current_pending_proposals.insert(
             proposal.order_id,
             UpdateCfdProposal::RollOverProposal {
@@ -819,7 +834,14 @@ where
 #[async_trait]
 impl<O: 'static, M: 'static, W: 'static> Handler<ProposeRollOver> for Actor<O, M, W> {
     async fn handle(&mut self, msg: ProposeRollOver, _ctx: &mut Context<Self>) {
-        log_error!(self.handle_propose_roll_over(msg.order_id))
+        log_error!(self.handle_propose_roll_over(msg.proposal))
+    }
+}
+
+#[async_trait]
+impl<O: 'static, M: 'static, W: 'static> Handler<AutoRollover> for Actor<O, M, W> {
+    async fn handle(&mut self, _msg: AutoRollover, _ctx: &mut Context<Self>) {
+        log_error!(self.handle_auto_rollover())
     }
 }
 
@@ -840,6 +862,10 @@ impl Message for CfdRollOverCompleted {
 }
 
 impl Message for ProposeRollOver {
+    type Result = ();
+}
+
+impl Message for AutoRollover {
     type Result = ();
 }
 

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -728,7 +728,6 @@ where
         + xtra::Handler<wallet::BuildPartyParams>,
 {
     async fn handle(&mut self, msg: wire::MakerToTaker, ctx: &mut Context<Self>) {
-        tracing::trace!("message from maker: {:?}", msg);
         match msg {
             wire::MakerToTaker::Heartbeat => {
                 unreachable!("Heartbeats should be handled somewhere else")

--- a/daemon/src/to_sse_event.rs
+++ b/daemon/src/to_sse_event.rs
@@ -176,7 +176,6 @@ pub enum CfdAction {
     Settle,
     AcceptSettlement,
     RejectSettlement,
-    RollOver,
     AcceptRollOver,
     RejectRollOver,
 }
@@ -504,7 +503,7 @@ fn available_actions(state: CfdState, role: Role) -> Vec<CfdAction> {
             vec![CfdAction::Commit]
         }
         (CfdState::Open { .. }, Role::Taker) => {
-            vec![CfdAction::RollOver, CfdAction::Commit, CfdAction::Settle]
+            vec![CfdAction::Commit, CfdAction::Settle]
         }
         (CfdState::Open { .. }, Role::Maker) => vec![CfdAction::Commit],
         _ => vec![],

--- a/daemon/src/to_sse_event.rs
+++ b/daemon/src/to_sse_event.rs
@@ -339,7 +339,7 @@ impl ToSseEvent for Option<model::cfd::Order> {
             liquidation_price: order.liquidation_price.into(),
             creation_timestamp: order.creation_timestamp,
             settlement_time_interval_in_secs: order
-                .settlement_time_interval_hours
+                .settlement_interval
                 .whole_seconds()
                 .try_into()
                 .expect("settlement_time_interval_hours is always positive number"),

--- a/daemon/src/tokio_ext.rs
+++ b/daemon/src/tokio_ext.rs
@@ -10,6 +10,8 @@ where
     F: Future<Output = Result<(), E>> + Send + 'static,
     E: fmt::Display,
 {
+    // we want to disallow calls to tokio::spawn outside FutureExt
+    #[allow(clippy::disallowed_method)]
     tokio::spawn(async move {
         if let Err(e) = future.await {
             tracing::warn!("Task failed: {:#}", e);
@@ -40,6 +42,8 @@ where
         Self: Future<Output = ()> + Send + 'static,
     {
         let (future, handle) = self.remote_handle();
+        // we want to disallow calls to tokio::spawn outside FutureExt
+        #[allow(clippy::disallowed_method)]
         tokio::spawn(future);
         handle
     }

--- a/daemon/src/tokio_ext.rs
+++ b/daemon/src/tokio_ext.rs
@@ -1,5 +1,6 @@
 use futures::future::RemoteHandle;
 use futures::FutureExt as _;
+use std::any::{Any, TypeId};
 use std::fmt;
 use std::future::Future;
 use std::time::Duration;
@@ -26,7 +27,7 @@ pub trait FutureExt: Future + Sized {
     /// The task will be stopped when the handle gets dropped.
     fn spawn_with_handle(self) -> RemoteHandle<Self::Output>
     where
-        Self: Future<Output = ()> + Send + 'static;
+        Self: Future<Output = ()> + Send + Any + 'static;
 }
 
 impl<F> FutureExt for F
@@ -39,12 +40,51 @@ where
 
     fn spawn_with_handle(self) -> RemoteHandle<()>
     where
-        Self: Future<Output = ()> + Send + 'static,
+        Self: Future<Output = ()> + Send + Any + 'static,
     {
+        debug_assert!(
+            TypeId::of::<RemoteHandle<()>>() != self.type_id(),
+            "RemoteHandle<()> is a handle to already spawned task",
+        );
+
         let (future, handle) = self.remote_handle();
         // we want to disallow calls to tokio::spawn outside FutureExt
         #[allow(clippy::disallowed_method)]
         tokio::spawn(future);
         handle
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic;
+
+    use tokio::time::sleep;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn spawning_a_regular_future_does_not_panic() {
+        let result = panic::catch_unwind(|| {
+            let _handle = sleep(Duration::from_secs(2)).spawn_with_handle();
+        });
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn panics_when_called_spawn_with_handle_on_remote_handle() {
+        let result = panic::catch_unwind(|| {
+            let handle = sleep(Duration::from_secs(2)).spawn_with_handle();
+            let _handle_to_a_handle = handle.spawn_with_handle();
+        });
+
+        if cfg!(debug_assertions) {
+            assert!(
+                result.is_err(),
+                "Spawning a remote handle into a separate task should panic_in_debug_mode"
+            );
+        } else {
+            assert!(result.is_ok(), "Do not panic in release mode");
+        }
     }
 }

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -7,7 +7,9 @@ use daemon::maker_cfd::CfdAction;
 use daemon::model::cfd::{Cfd, Order, Origin};
 use daemon::model::{Price, Usd};
 use daemon::seed::Seed;
+use daemon::tokio_ext::FutureExt;
 use daemon::{db, maker_cfd, maker_inc_connections, taker_cfd, MakerActorSystem};
+use futures::future::RemoteHandle;
 use rust_decimal_macros::dec;
 use sqlx::SqlitePool;
 use std::net::SocketAddr;
@@ -47,6 +49,7 @@ pub struct Maker {
     pub mocks: mocks::Mocks,
     pub listen_addr: SocketAddr,
     pub identity_pk: x25519_dalek::PublicKey,
+    _tasks: Vec<RemoteHandle<()>>,
 }
 
 impl Maker {
@@ -64,8 +67,10 @@ impl Maker {
         let mut mocks = mocks::Mocks::default();
         let (oracle, monitor, wallet) = mocks::create_actors(&mocks);
 
+        let mut tasks = vec![];
+
         let (wallet_addr, wallet_fut) = wallet.create(None).run();
-        tokio::spawn(wallet_fut);
+        tasks.push(wallet_fut.spawn_with_handle());
 
         let settlement_time_interval_hours = time::Duration::hours(24);
 
@@ -109,13 +114,20 @@ impl Maker {
             Poll::Ready(Some(message))
         });
 
-        tokio::spawn(maker.inc_conn_addr.clone().attach_stream(listener_stream));
+        tasks.push(
+            maker
+                .inc_conn_addr
+                .clone()
+                .attach_stream(listener_stream)
+                .spawn_with_handle(),
+        );
 
         Self {
             system: maker,
             identity_pk,
             listen_addr: address,
             mocks,
+            _tasks: tasks,
         }
     }
 
@@ -153,6 +165,7 @@ impl Maker {
 pub struct Taker {
     pub system: daemon::TakerActorSystem<OracleActor, MonitorActor, WalletActor>,
     pub mocks: mocks::Mocks,
+    _tasks: Vec<RemoteHandle<()>>,
 }
 
 impl Taker {
@@ -182,8 +195,10 @@ impl Taker {
         let mut mocks = mocks::Mocks::default();
         let (oracle, monitor, wallet) = mocks::create_actors(&mocks);
 
+        let mut tasks = vec![];
+
         let (wallet_addr, wallet_fut) = wallet.create(None).run();
-        tokio::spawn(wallet_fut);
+        tasks.push(wallet_fut.spawn_with_handle());
 
         // system startup sends sync messages, mock them
         mocks.mock_sync_handlers().await;
@@ -213,6 +228,7 @@ impl Taker {
         Self {
             system: taker,
             mocks,
+            _tasks: tasks,
         }
     }
 

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -70,7 +70,7 @@ impl Maker {
         let (wallet_addr, wallet_fut) = wallet.create(None).run();
         tasks.add(wallet_fut);
 
-        let settlement_time_interval_hours = time::Duration::hours(24);
+        let settlement_interval = time::Duration::hours(24);
 
         let seed = Seed::default();
         let (identity_pk, identity_sk) = seed.derive_identity();
@@ -91,7 +91,7 @@ impl Maker {
                     HEARTBEAT_INTERVAL_FOR_TEST,
                 )
             },
-            settlement_time_interval_hours,
+            settlement_interval,
             N_PAYOUTS_FOR_TEST,
         )
         .await

--- a/maker-frontend/src/components/Types.tsx
+++ b/maker-frontend/src/components/Types.tsx
@@ -185,7 +185,6 @@ export enum Action {
     REJECT_ORDER = "rejectOrder",
     COMMIT = "commit",
     SETTLE = "settle",
-    ROLL_OVER = "rollOver",
     ACCEPT_SETTLEMENT = "acceptSettlement",
     REJECT_SETTLEMENT = "rejectSettlement",
     ACCEPT_ROLL_OVER = "acceptRollOver",

--- a/maker-frontend/src/components/cfdtables/CfdTable.tsx
+++ b/maker-frontend/src/components/cfdtables/CfdTable.tsx
@@ -5,7 +5,6 @@ import {
     ChevronUpIcon,
     CloseIcon,
     ExternalLinkIcon,
-    RepeatIcon,
     TriangleDownIcon,
     TriangleUpIcon,
     WarningIcon,
@@ -225,8 +224,6 @@ function iconForAction(action: Action): any {
             return <CheckIcon />;
         case Action.REJECT_SETTLEMENT:
             return <CloseIcon />;
-        case Action.ROLL_OVER:
-            return <RepeatIcon />;
         case Action.ACCEPT_ROLL_OVER:
             return <CheckIcon />;
         case Action.REJECT_ROLL_OVER:
@@ -243,8 +240,6 @@ function colorSchemaForAction(action: Action): string {
         case Action.COMMIT:
             return "red";
         case Action.SETTLE:
-            return "green";
-        case Action.ROLL_OVER:
             return "green";
         case Action.ACCEPT_SETTLEMENT:
             return "green";


### PR DESCRIPTION
After discussion with @thomaseizinger we decided to put the rollover logic on the cfd and unit-test it. 

Auto-rollover actually only depends on the cfd expiry. We hardcode the roll-over offset as `1 hour` for the moment. The unit-tests should cover all bounds and should help understand the logic. (If not please scream :)
Auto-rollover itself is not tested as part of the actor tests. The unit tests should cover the logic. The rest is just wiring things together and should not require testing.

We are adding an actor test for `ProposeRollover` (to test the logic related to rollover itself - accept, reject...) in a follow up PR. This test will be triggered through sending the `ProposeRollover` message to the actor in the tests. 
In the production code we don't send this message to the cfd actor from the outside (it is triggered internally upon auto-rollover).

