### PR TITLE
Don't allow rollover that is too close to expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3826,7 +3826,6 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "pollster",
- "tokio",
 ]
 
 [[package]]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,5 @@
 disallowed-methods = [
+  "tokio::spawn", # tasks can outlive the actor system, prefer spawn_with_handle()
   "xtra::Address::do_send_async", # discards the return value, possibly swallowing an error
   "xtra::Address::do_send", # discards the return value, possibly swallowing an error
 ]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -45,7 +45,7 @@ tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log", "json"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 x25519-dalek = { version = "1.1" }
-xtra = { version = "0.6", features = ["with-tokio-1"] }
+xtra = { version = "0.6" }
 xtra_productivity = { version = "0.1.0" }
 
 [[bin]]

--- a/daemon/clippy.toml
+++ b/daemon/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+  "tokio::spawn", # tasks can outlive the actor system, prefer spawn_with_handle()
+]

--- a/daemon/clippy.toml
+++ b/daemon/clippy.toml
@@ -1,3 +1,0 @@
-disallowed-methods = [
-  "tokio::spawn", # tasks can outlive the actor system, prefer spawn_with_handle()
-]

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -39,7 +39,7 @@ pub async fn insert_order(order: &Order, conn: &mut PoolConnection<Sqlite>) -> a
     .bind(order.leverage.get())
     .bind(&order.liquidation_price.to_string())
     .bind(&order.creation_timestamp.seconds())
-    .bind(&order.settlement_time_interval_hours.whole_seconds())
+    .bind(&order.settlement_interval.whole_seconds())
     .bind(&order.origin)
     .bind(&order.oracle_event_id.to_string())
     .execute(conn)
@@ -90,7 +90,7 @@ pub async fn load_order_by_id(
         leverage: row.leverage,
         liquidation_price: row.liquidation_price.parse()?,
         creation_timestamp: row.ts_secs,
-        settlement_time_interval_hours: Duration::new(row.settlement_time_interval_secs, 0),
+        settlement_interval: Duration::new(row.settlement_time_interval_secs, 0),
         origin: row.origin,
         oracle_event_id: row.oracle_event_id.parse()?,
     })
@@ -300,7 +300,7 @@ pub async fn load_cfd_by_order_id(
         leverage: row.leverage,
         liquidation_price: row.liquidation_price.parse()?,
         creation_timestamp: row.ts_secs,
-        settlement_time_interval_hours: Duration::new(row.settlement_time_interval_secs, 0),
+        settlement_interval: Duration::new(row.settlement_time_interval_secs, 0),
         origin: row.origin,
         oracle_event_id: row.oracle_event_id.parse()?,
     };
@@ -398,7 +398,7 @@ pub async fn load_all_cfds(conn: &mut PoolConnection<Sqlite>) -> anyhow::Result<
                 leverage: row.leverage,
                 liquidation_price: row.liquidation_price.parse()?,
                 creation_timestamp: row.ts_secs,
-                settlement_time_interval_hours: Duration::new(row.settlement_time_interval_secs, 0),
+                settlement_interval: Duration::new(row.settlement_time_interval_secs, 0),
                 origin: row.origin,
                 oracle_event_id: row.oracle_event_id.parse()?,
             };
@@ -504,7 +504,7 @@ pub async fn load_cfds_by_oracle_event_id(
                 leverage: row.leverage,
                 liquidation_price: row.liquidation_price.parse()?,
                 creation_timestamp: row.ts_secs,
-                settlement_time_interval_hours: Duration::new(row.settlement_time_interval_secs, 0),
+                settlement_interval: Duration::new(row.settlement_time_interval_secs, 0),
                 origin: row.origin,
                 oracle_event_id: row.oracle_event_id.parse()?,
             };

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -52,6 +52,8 @@ pub const HEARTBEAT_INTERVAL: std::time::Duration = Duration::from_secs(5);
 
 pub const N_PAYOUTS: usize = 200;
 
+pub const SETTLEMENT_INTERVAL: time::Duration = time::Duration::hours(24);
+
 /// Struct controlling the lifetime of the async tasks,
 /// such as running actors and periodic notifications.
 /// If it gets dropped, all tasks are cancelled.
@@ -109,7 +111,7 @@ where
             Box<dyn MessageChannel<NewTakerOnline>>,
             Box<dyn MessageChannel<FromTaker>>,
         ) -> T,
-        settlement_time_interval_hours: time::Duration,
+        settlement_interval: time::Duration,
         n_payouts: usize,
     ) -> Result<Self>
     where
@@ -133,7 +135,7 @@ where
         let (cfd_actor_addr, cfd_actor_fut) = maker_cfd::Actor::new(
             db,
             wallet_addr,
-            settlement_time_interval_hours,
+            settlement_interval,
             oracle_pk,
             cfd_feed_sender,
             order_feed_sender,

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
 #![warn(clippy::disallowed_method)]
-
 use crate::db::load_all_cfds;
 use crate::maker_cfd::{FromTaker, NewTakerOnline};
 use crate::model::cfd::{Cfd, Order, UpdateCfdProposals};

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -52,6 +52,16 @@ pub const HEARTBEAT_INTERVAL: std::time::Duration = Duration::from_secs(5);
 
 pub const N_PAYOUTS: usize = 200;
 
+/// The interval until the cfd gets settled, i.e. the attestation happens
+///
+/// This variable defines at what point in time the oracle event id will be chose to settle the cfd.
+/// Hence, this constant defines how long a cfd is open (until it gets either settled or rolled
+/// over).
+///
+/// Multiple code parts align on this constant:
+/// - How the oracle event id is chosen when creating an order (maker)
+/// - The sliding window of cached oracle announcements (maker, taker)
+/// - The auto-rollover time-window (taker)
 pub const SETTLEMENT_INTERVAL: time::Duration = time::Duration::hours(24);
 
 /// Struct controlling the lifetime of the async tasks,

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -303,9 +303,7 @@ where
 
         tasks.add(oracle_ctx.run(oracle_constructor(cfds, Box::new(fan_out_actor))));
 
-        cfd_actor_addr
-            .do_send_async(taker_cfd::AutoRollover)
-            .await?;
+        cfd_actor_addr.send(taker_cfd::AutoRollover).await?;
 
         tracing::debug!("Taker actor system ready");
 

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -62,7 +62,7 @@ pub struct FromTaker {
 pub struct Actor<O, M, T, W> {
     db: sqlx::SqlitePool,
     wallet: Address<W>,
-    settlement_time_interval_hours: Duration,
+    settlement_interval: Duration,
     oracle_pk: schnorrsig::PublicKey,
     cfd_feed_actor_inbox: watch::Sender<Vec<Cfd>>,
     order_feed_sender: watch::Sender<Option<Order>>,
@@ -102,7 +102,7 @@ impl<O, M, T, W> Actor<O, M, T, W> {
     pub fn new(
         db: sqlx::SqlitePool,
         wallet: Address<W>,
-        settlement_time_interval_hours: Duration,
+        settlement_interval: Duration,
         oracle_pk: schnorrsig::PublicKey,
         cfd_feed_actor_inbox: watch::Sender<Vec<Cfd>>,
         order_feed_sender: watch::Sender<Option<Order>>,
@@ -115,7 +115,7 @@ impl<O, M, T, W> Actor<O, M, T, W> {
         Self {
             db,
             wallet,
-            settlement_time_interval_hours,
+            settlement_interval,
             oracle_pk,
             cfd_feed_actor_inbox,
             order_feed_sender,
@@ -747,7 +747,7 @@ where
         let dlc = cfd.open_dlc().context("CFD was in wrong state")?;
 
         let oracle_event_id = oracle::next_announcement_after(
-            time::OffsetDateTime::now_utc() + cfd.order.settlement_time_interval_hours,
+            time::OffsetDateTime::now_utc() + cfd.order.settlement_interval,
         )?;
         let announcement = self
             .oracle_actor
@@ -959,7 +959,7 @@ where
         } = msg;
 
         let oracle_event_id = oracle::next_announcement_after(
-            time::OffsetDateTime::now_utc() + self.settlement_time_interval_hours,
+            time::OffsetDateTime::now_utc() + self.settlement_interval,
         )?;
 
         let order = Order::new(
@@ -968,7 +968,7 @@ where
             max_quantity,
             Origin::Ours,
             oracle_event_id,
-            self.settlement_time_interval_hours,
+            self.settlement_interval,
         )?;
 
         // 1. Save to DB

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -115,7 +115,7 @@ pub struct Order {
     pub creation_timestamp: Timestamp,
 
     /// The duration that will be used for calculating the settlement timestamp
-    pub settlement_time_interval_hours: Duration,
+    pub settlement_interval: Duration,
 
     pub origin: Origin,
 
@@ -132,7 +132,7 @@ impl Order {
         max_quantity: Usd,
         origin: Origin,
         oracle_event_id: BitMexPriceEventId,
-        settlement_time_interval_hours: Duration,
+        settlement_interval: Duration,
     ) -> Result<Self> {
         let leverage = Leverage::new(2)?;
         let liquidation_price = calculate_long_liquidation_price(leverage, price);
@@ -147,7 +147,7 @@ impl Order {
             liquidation_price,
             position: Position::Short,
             creation_timestamp: Timestamp::now()?,
-            settlement_time_interval_hours,
+            settlement_interval,
             origin,
             oracle_event_id,
         })
@@ -671,7 +671,7 @@ impl Cfd {
     }
 
     pub fn refund_timelock_in_blocks(&self) -> u32 {
-        (self.order.settlement_time_interval_hours * Cfd::REFUND_THRESHOLD)
+        (self.order.settlement_interval * Cfd::REFUND_THRESHOLD)
             .as_blocks()
             .ceil() as u32
     }
@@ -680,20 +680,20 @@ impl Cfd {
         self.order.oracle_event_id.timestamp()
     }
 
-    /// A factor to be added to the CFD order settlement_time_interval_hours for calculating the
+    /// A factor to be added to the CFD order settlement_interval for calculating the
     /// refund timelock.
     ///
     /// The refund timelock is important in case the oracle disappears or never publishes a
     /// signature. Ideally, both users collaboratively settle in the refund scenario. This
     /// factor is important if the users do not settle collaboratively.
-    /// `1.5` times the settlement_time_interval_hours as defined in CFD order should be safe in the
+    /// `1.5` times the settlement_interval as defined in CFD order should be safe in the
     /// extreme case where a user publishes the commit transaction right after the contract was
     /// initialized. In this case, the oracle still has `1.0 *
-    /// cfdorder.settlement_time_interval_hours` time to attest and no one can publish the refund
+    /// cfdorder.settlement_interval` time to attest and no one can publish the refund
     /// transaction.
     /// The downside is that if the oracle disappears: the users would only notice at the end
-    /// of the cfd settlement_time_interval_hours. In this case the users has to wait for another
-    /// `1.5` times of the settlement_time_interval_hours to get his funds back.
+    /// of the cfd settlement_interval. In this case the users has to wait for another
+    /// `1.5` times of the settlement_interval to get his funds back.
     const REFUND_THRESHOLD: f32 = 1.5;
 
     pub const CET_TIMELOCK: u32 = 12;

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -1416,6 +1416,181 @@ fn calculate_profit(
     Ok((profit, Percent(percent)))
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Cet {
+    pub tx: Transaction,
+    pub adaptor_sig: EcdsaAdaptorSignature,
+
+    // TODO: Range + number of digits (usize) could be represented as Digits similar to what we do
+    // in the protocol lib
+    pub range: RangeInclusive<u64>,
+    pub n_bits: usize,
+}
+
+/// Contains all data we've assembled about the CFD through the setup protocol.
+///
+/// All contained signatures are the signatures of THE OTHER PARTY.
+/// To use any of these transactions, we need to re-sign them with the correct secret key.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Dlc {
+    pub identity: SecretKey,
+    pub identity_counterparty: PublicKey,
+    pub revocation: SecretKey,
+    pub revocation_pk_counterparty: PublicKey,
+    pub publish: SecretKey,
+    pub publish_pk_counterparty: PublicKey,
+    pub maker_address: Address,
+    pub taker_address: Address,
+
+    /// The fully signed lock transaction ready to be published on chain
+    pub lock: (Transaction, Descriptor<PublicKey>),
+    pub commit: (Transaction, EcdsaAdaptorSignature, Descriptor<PublicKey>),
+    pub cets: HashMap<BitMexPriceEventId, Vec<Cet>>,
+    pub refund: (Transaction, Signature),
+
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    pub maker_lock_amount: Amount,
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    pub taker_lock_amount: Amount,
+
+    pub revoked_commit: Vec<RevokedCommit>,
+}
+
+impl Dlc {
+    /// Create a close transaction based on the current contract and a settlement proposals
+    pub fn close_transaction(
+        &self,
+        proposal: &crate::model::cfd::SettlementProposal,
+    ) -> Result<(Transaction, Signature)> {
+        let (lock_tx, lock_desc) = &self.lock;
+        let (lock_outpoint, lock_amount) = {
+            let outpoint = lock_tx
+                .outpoint(&lock_desc.script_pubkey())
+                .expect("lock script to be in lock tx");
+            let amount = Amount::from_sat(lock_tx.output[outpoint.vout as usize].value);
+
+            (outpoint, amount)
+        };
+        let (tx, sighash) = maia::close_transaction(
+            lock_desc,
+            lock_outpoint,
+            lock_amount,
+            (&self.maker_address, proposal.maker),
+            (&self.taker_address, proposal.taker),
+        )
+        .context("Unable to collaborative close transaction")?;
+
+        let sig = SECP256K1.sign(&sighash, &self.identity);
+
+        Ok((tx, sig))
+    }
+
+    pub fn finalize_spend_transaction(
+        &self,
+        (close_tx, own_sig): (Transaction, Signature),
+        counterparty_sig: Signature,
+    ) -> Result<Transaction> {
+        let own_pk = PublicKey::new(secp256k1_zkp::PublicKey::from_secret_key(
+            SECP256K1,
+            &self.identity,
+        ));
+
+        let (_, lock_desc) = &self.lock;
+        let spend_tx = maia::finalize_spend_transaction(
+            close_tx,
+            lock_desc,
+            (own_pk, own_sig),
+            (self.identity_counterparty, counterparty_sig),
+        )?;
+
+        Ok(spend_tx)
+    }
+
+    pub fn refund_amount(&self, role: Role) -> Amount {
+        let our_script_pubkey = match role {
+            Role::Taker => self.taker_address.script_pubkey(),
+            Role::Maker => self.maker_address.script_pubkey(),
+        };
+
+        self.refund
+            .0
+            .output
+            .iter()
+            .find(|output| output.script_pubkey == our_script_pubkey)
+            .map(|output| Amount::from_sat(output.value))
+            .unwrap_or_default()
+    }
+
+    pub fn script_pubkey_for(&self, role: Role) -> Script {
+        match role {
+            Role::Maker => self.maker_address.script_pubkey(),
+            Role::Taker => self.taker_address.script_pubkey(),
+        }
+    }
+}
+
+/// Information which we need to remember in order to construct a
+/// punishment transaction in case the counterparty publishes a
+/// revoked commit transaction.
+///
+/// It also includes the information needed to monitor for the
+/// publication of the revoked commit transaction.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RevokedCommit {
+    // To build punish transaction
+    pub encsig_ours: EcdsaAdaptorSignature,
+    pub revocation_sk_theirs: SecretKey,
+    pub publication_pk_theirs: PublicKey,
+    // To monitor revoked commit transaction
+    pub txid: Txid,
+    pub script_pubkey: Script,
+}
+
+/// Used when transactions (e.g. collaborative close) are recorded as a part of
+/// CfdState in the cases when we can't solely rely on state transition
+/// timestamp as it could have occured for different reasons (like a new
+/// attestation in Open state)
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct CollaborativeSettlement {
+    pub tx: Transaction,
+    pub timestamp: Timestamp,
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    payout: Amount,
+    price: Price,
+}
+
+impl CollaborativeSettlement {
+    pub fn new(tx: Transaction, own_script_pubkey: Script, price: Price) -> Result<Self> {
+        // Falls back to Amount::ZERO in case we don't find an output that matches out script pubkey
+        // The assumption is, that this can happen for cases where we were liuqidated
+        let payout = match tx
+            .output
+            .iter()
+            .find(|output| output.script_pubkey == own_script_pubkey)
+            .map(|output| Amount::from_sat(output.value))
+        {
+            Some(payout) => payout,
+            None => {
+                tracing::error!(
+                    "Collaborative settlement with a zero amount, this should really not happen!"
+                );
+                Amount::ZERO
+            }
+        };
+
+        Ok(Self {
+            tx,
+            timestamp: Timestamp::now().context("Unable to get current time")?,
+            payout,
+            price,
+        })
+    }
+
+    pub fn payout(&self) -> Amount {
+        self.payout
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1665,180 +1840,5 @@ mod tests {
         let deserialized = serde_json::from_str(&serde_json::to_string(&id).unwrap()).unwrap();
 
         assert_eq!(id, deserialized);
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Cet {
-    pub tx: Transaction,
-    pub adaptor_sig: EcdsaAdaptorSignature,
-
-    // TODO: Range + number of digits (usize) could be represented as Digits similar to what we do
-    // in the protocol lib
-    pub range: RangeInclusive<u64>,
-    pub n_bits: usize,
-}
-
-/// Contains all data we've assembled about the CFD through the setup protocol.
-///
-/// All contained signatures are the signatures of THE OTHER PARTY.
-/// To use any of these transactions, we need to re-sign them with the correct secret key.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Dlc {
-    pub identity: SecretKey,
-    pub identity_counterparty: PublicKey,
-    pub revocation: SecretKey,
-    pub revocation_pk_counterparty: PublicKey,
-    pub publish: SecretKey,
-    pub publish_pk_counterparty: PublicKey,
-    pub maker_address: Address,
-    pub taker_address: Address,
-
-    /// The fully signed lock transaction ready to be published on chain
-    pub lock: (Transaction, Descriptor<PublicKey>),
-    pub commit: (Transaction, EcdsaAdaptorSignature, Descriptor<PublicKey>),
-    pub cets: HashMap<BitMexPriceEventId, Vec<Cet>>,
-    pub refund: (Transaction, Signature),
-
-    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
-    pub maker_lock_amount: Amount,
-    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
-    pub taker_lock_amount: Amount,
-
-    pub revoked_commit: Vec<RevokedCommit>,
-}
-
-impl Dlc {
-    /// Create a close transaction based on the current contract and a settlement proposals
-    pub fn close_transaction(
-        &self,
-        proposal: &crate::model::cfd::SettlementProposal,
-    ) -> Result<(Transaction, Signature)> {
-        let (lock_tx, lock_desc) = &self.lock;
-        let (lock_outpoint, lock_amount) = {
-            let outpoint = lock_tx
-                .outpoint(&lock_desc.script_pubkey())
-                .expect("lock script to be in lock tx");
-            let amount = Amount::from_sat(lock_tx.output[outpoint.vout as usize].value);
-
-            (outpoint, amount)
-        };
-        let (tx, sighash) = maia::close_transaction(
-            lock_desc,
-            lock_outpoint,
-            lock_amount,
-            (&self.maker_address, proposal.maker),
-            (&self.taker_address, proposal.taker),
-        )
-        .context("Unable to collaborative close transaction")?;
-
-        let sig = SECP256K1.sign(&sighash, &self.identity);
-
-        Ok((tx, sig))
-    }
-
-    pub fn finalize_spend_transaction(
-        &self,
-        (close_tx, own_sig): (Transaction, Signature),
-        counterparty_sig: Signature,
-    ) -> Result<Transaction> {
-        let own_pk = PublicKey::new(secp256k1_zkp::PublicKey::from_secret_key(
-            SECP256K1,
-            &self.identity,
-        ));
-
-        let (_, lock_desc) = &self.lock;
-        let spend_tx = maia::finalize_spend_transaction(
-            close_tx,
-            lock_desc,
-            (own_pk, own_sig),
-            (self.identity_counterparty, counterparty_sig),
-        )?;
-
-        Ok(spend_tx)
-    }
-
-    pub fn refund_amount(&self, role: Role) -> Amount {
-        let our_script_pubkey = match role {
-            Role::Taker => self.taker_address.script_pubkey(),
-            Role::Maker => self.maker_address.script_pubkey(),
-        };
-
-        self.refund
-            .0
-            .output
-            .iter()
-            .find(|output| output.script_pubkey == our_script_pubkey)
-            .map(|output| Amount::from_sat(output.value))
-            .unwrap_or_default()
-    }
-
-    pub fn script_pubkey_for(&self, role: Role) -> Script {
-        match role {
-            Role::Maker => self.maker_address.script_pubkey(),
-            Role::Taker => self.taker_address.script_pubkey(),
-        }
-    }
-}
-
-/// Information which we need to remember in order to construct a
-/// punishment transaction in case the counterparty publishes a
-/// revoked commit transaction.
-///
-/// It also includes the information needed to monitor for the
-/// publication of the revoked commit transaction.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct RevokedCommit {
-    // To build punish transaction
-    pub encsig_ours: EcdsaAdaptorSignature,
-    pub revocation_sk_theirs: SecretKey,
-    pub publication_pk_theirs: PublicKey,
-    // To monitor revoked commit transaction
-    pub txid: Txid,
-    pub script_pubkey: Script,
-}
-
-/// Used when transactions (e.g. collaborative close) are recorded as a part of
-/// CfdState in the cases when we can't solely rely on state transition
-/// timestamp as it could have occured for different reasons (like a new
-/// attestation in Open state)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct CollaborativeSettlement {
-    pub tx: Transaction,
-    pub timestamp: Timestamp,
-    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
-    payout: Amount,
-    price: Price,
-}
-
-impl CollaborativeSettlement {
-    pub fn new(tx: Transaction, own_script_pubkey: Script, price: Price) -> Result<Self> {
-        // Falls back to Amount::ZERO in case we don't find an output that matches out script pubkey
-        // The assumption is, that this can happen for cases where we were liuqidated
-        let payout = match tx
-            .output
-            .iter()
-            .find(|output| output.script_pubkey == own_script_pubkey)
-            .map(|output| Amount::from_sat(output.value))
-        {
-            Some(payout) => payout,
-            None => {
-                tracing::error!(
-                    "Collaborative settlement with a zero amount, this should really not happen!"
-                );
-                Amount::ZERO
-            }
-        };
-
-        Ok(Self {
-            tx,
-            timestamp: Timestamp::now().context("Unable to get current time")?,
-            payout,
-            price,
-        })
-    }
-
-    pub fn payout(&self) -> Amount {
-        self.payout
     }
 }

--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -170,11 +170,6 @@ pub async fn post_cfd_action(
             tracing::error!(msg);
             return Err(HttpApiProblem::new(StatusCode::BAD_REQUEST).detail(msg));
         }
-        CfdAction::RollOver => {
-            let msg = "RollOver proposal can only be triggered by taker";
-            tracing::error!(msg);
-            return Err(HttpApiProblem::new(StatusCode::BAD_REQUEST).detail(msg));
-        }
     };
 
     result

--- a/daemon/src/routes_taker.rs
+++ b/daemon/src/routes_taker.rs
@@ -149,7 +149,6 @@ pub async fn post_cfd_action(
                 current_price,
             })
         }
-        CfdAction::RollOver => cfd_action_channel.send(ProposeRollOver { order_id: id }),
     };
 
     result

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -9,7 +9,7 @@ use daemon::seed::Seed;
 use daemon::tokio_ext::FutureExt;
 use daemon::{
     bitmex_price_feed, connection, db, housekeeping, logger, monitor, oracle, taker_cfd, wallet,
-    wallet_sync, TakerActorSystem, Tasks, HEARTBEAT_INTERVAL, N_PAYOUTS,
+    wallet_sync, TakerActorSystem, Tasks, HEARTBEAT_INTERVAL, N_PAYOUTS, SETTLEMENT_INTERVAL,
 };
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::SqlitePool;
@@ -25,7 +25,6 @@ use xtra::Actor;
 
 mod routes_taker;
 
-pub const ANNOUNCEMENT_LOOKAHEAD: time::Duration = time::Duration::hours(24);
 const CONNECTION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Parser)]
@@ -246,7 +245,7 @@ async fn main() -> Result<()> {
         wallet.clone(),
         oracle,
         identity_sk,
-        |cfds, channel| oracle::Actor::new(cfds, channel, ANNOUNCEMENT_LOOKAHEAD),
+        |cfds, channel| oracle::Actor::new(cfds, channel, SETTLEMENT_INTERVAL),
         {
             |channel, cfds| {
                 let electrum = opts.network.electrum().to_string();

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -331,6 +331,7 @@ impl<O, M, W> Actor<O, M, W> {
     }
 
     async fn handle_propose_roll_over(&mut self, proposal: RollOverProposal) -> Result<()> {
+        tracing::trace!(order_id=%proposal.order_id, "Propose rollover message received");
         self.current_pending_proposals.insert(
             proposal.order_id,
             UpdateCfdProposal::RollOverProposal {
@@ -340,6 +341,7 @@ impl<O, M, W> Actor<O, M, W> {
         );
         self.send_pending_update_proposals()?;
 
+        tracing::info!(order_id=%proposal.order_id, "Sending rollover proposal to maker");
         self.send_to_maker
             .do_send(wire::TakerToMaker::ProposeRollOver {
                 order_id: proposal.order_id,
@@ -351,7 +353,7 @@ impl<O, M, W> Actor<O, M, W> {
 
 impl<O: 'static, M: 'static, W: 'static> Actor<O, M, W> {
     async fn handle_auto_rollover(&mut self, ctx: &mut Context<Self>) -> Result<()> {
-        tracing::debug!("Auto rollover");
+        tracing::trace!("Auto rollover message received");
 
         let mut conn = self.db.acquire().await?;
         let cfds = load_all_cfds(&mut conn).await?;
@@ -369,6 +371,7 @@ impl<O: 'static, M: 'static, W: 'static> Actor<O, M, W> {
             .expect("actor to be able to retrieve own address");
 
         for proposal in proposals {
+            tracing::trace!(order_id=%proposal.order_id, "Sending rollover proposal message");
             try_continue!(address.send(ProposeRollOver { proposal }).await)
         }
 

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -7,12 +7,14 @@ use crate::model::cfd::{
 };
 use crate::model::{BitMexPriceEventId, Price, Timestamp, Usd};
 use crate::monitor::{self, MonitorParams};
+use crate::tokio_ext::FutureExt;
 use crate::wire::{MakerToTaker, RollOverMsg, SetupMsg};
 use crate::{log_error, oracle, setup_contract, wallet, wire};
 use anyhow::{bail, Context as _, Result};
 use async_trait::async_trait;
 use bdk::bitcoin::secp256k1::schnorrsig;
 use futures::channel::mpsc;
+use futures::future::RemoteHandle;
 use futures::{future, SinkExt};
 use std::collections::HashMap;
 use tokio::sync::watch;
@@ -49,6 +51,7 @@ pub struct CfdRollOverCompleted {
 enum SetupState {
     Active {
         sender: mpsc::UnboundedSender<SetupMsg>,
+        _task: RemoteHandle<()>,
     },
     None,
 }
@@ -56,6 +59,7 @@ enum SetupState {
 enum RollOverState {
     Active {
         sender: mpsc::UnboundedSender<RollOverMsg>,
+        _task: RemoteHandle<()>,
     },
     None,
 }
@@ -252,7 +256,7 @@ where
 
     async fn handle_inc_protocol_msg(&mut self, msg: SetupMsg) -> Result<()> {
         match &mut self.setup_state {
-            SetupState::Active { sender } => {
+            SetupState::Active { sender, .. } => {
                 sender.send(msg).await?;
             }
             SetupState::None => {
@@ -265,7 +269,7 @@ where
 
     async fn handle_inc_roll_over_msg(&mut self, msg: RollOverMsg) -> Result<()> {
         match &mut self.roll_over_state {
-            RollOverState::Active { sender } => {
+            RollOverState::Active { sender, .. } => {
                 sender.send(msg).await?;
             }
             RollOverState::None => {
@@ -515,15 +519,19 @@ where
             .address()
             .expect("actor to be able to give address to itself");
 
-        tokio::spawn(async move {
+        let task = async move {
             let dlc = contract_future.await;
 
             this.send(CfdSetupCompleted { order_id, dlc })
                 .await
                 .expect("always connected to ourselves")
-        });
+        }
+        .spawn_with_handle();
 
-        self.setup_state = SetupState::Active { sender };
+        self.setup_state = SetupState::Active {
+            sender,
+            _task: task,
+        };
 
         Ok(())
     }
@@ -578,15 +586,19 @@ where
             .address()
             .expect("actor to be able to give address to itself");
 
-        self.roll_over_state = RollOverState::Active { sender };
-
-        tokio::spawn(async move {
+        let task = async move {
             let dlc = contract_future.await;
 
             this.send(CfdRollOverCompleted { order_id, dlc })
                 .await
                 .expect("always connected to ourselves")
-        });
+        }
+        .spawn_with_handle();
+
+        self.roll_over_state = RollOverState::Active {
+            sender,
+            _task: task,
+        };
 
         self.remove_pending_proposal(&order_id)
             .context("Could not remove accepted roll over")?;

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -17,6 +17,7 @@ use futures::channel::mpsc;
 use futures::future::RemoteHandle;
 use futures::{future, SinkExt};
 use std::collections::HashMap;
+use time::OffsetDateTime;
 use tokio::sync::watch;
 use xtra::prelude::*;
 
@@ -361,9 +362,10 @@ impl<O: 'static, M: 'static, W: 'static> Actor<O, M, W> {
         // cleanup all pending proposals because auto-rollover will create a new one
         self.current_pending_proposals.clear();
 
+        let now = OffsetDateTime::now_utc();
         let proposals = cfds
             .iter()
-            .filter_map(|cfd| cfd.rollover_proposal())
+            .filter_map(|cfd| cfd.rollover_proposal(now))
             .collect::<Vec<RollOverProposal>>();
 
         let address = ctx

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -30,12 +30,13 @@ pub enum CfdAction {
         order_id: OrderId,
         current_price: Price,
     },
-    ProposeRollOver {
-        order_id: OrderId,
-    },
     Commit {
         order_id: OrderId,
     },
+}
+
+pub struct ProposeRollOver {
+    order_id: OrderId,
 }
 
 pub struct CfdSetupCompleted {
@@ -709,7 +710,6 @@ where
                 self.handle_propose_settlement(order_id, current_price)
                     .await
             }
-            ProposeRollOver { order_id } => self.handle_propose_roll_over(order_id).await,
         } {
             tracing::error!("Message handler failed: {:#}", e);
             anyhow::bail!(e)
@@ -813,6 +813,13 @@ where
     }
 }
 
+#[async_trait]
+impl<O: 'static, M: 'static, W: 'static> Handler<ProposeRollOver> for Actor<O, M, W> {
+    async fn handle(&mut self, msg: ProposeRollOver, _ctx: &mut Context<Self>) {
+        log_error!(self.handle_propose_roll_over(msg.order_id))
+    }
+}
+
 impl Message for TakeOffer {
     type Result = Result<()>;
 }
@@ -826,6 +833,10 @@ impl Message for CfdSetupCompleted {
 }
 
 impl Message for CfdRollOverCompleted {
+    type Result = ();
+}
+
+impl Message for ProposeRollOver {
     type Result = ();
 }
 

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -326,6 +326,33 @@ impl<O, M, W> Actor<O, M, W> {
         }
         Ok(())
     }
+
+    async fn handle_propose_roll_over(&mut self, order_id: OrderId) -> Result<()> {
+        if self.current_pending_proposals.contains_key(&order_id) {
+            anyhow::bail!("An update for order id {} is already in progress", order_id)
+        }
+
+        let proposal = RollOverProposal {
+            order_id,
+            timestamp: Timestamp::now()?,
+        };
+
+        self.current_pending_proposals.insert(
+            proposal.order_id,
+            UpdateCfdProposal::RollOverProposal {
+                proposal: proposal.clone(),
+                direction: SettlementKind::Outgoing,
+            },
+        );
+        self.send_pending_update_proposals()?;
+
+        self.send_to_maker
+            .do_send(wire::TakerToMaker::ProposeRollOver {
+                order_id: proposal.order_id,
+                timestamp: proposal.timestamp,
+            })?;
+        Ok(())
+    }
 }
 
 impl<O, M, W> Actor<O, M, W>
@@ -355,44 +382,6 @@ where
         .await?;
         Ok(())
     }
-}
-
-impl<O, M, W> Actor<O, M, W>
-where
-    W: xtra::Handler<wallet::TryBroadcastTransaction>,
-{
-    async fn handle_propose_roll_over(&mut self, order_id: OrderId) -> Result<()> {
-        if self.current_pending_proposals.contains_key(&order_id) {
-            anyhow::bail!("An update for order id {} is already in progress", order_id)
-        }
-
-        let proposal = RollOverProposal {
-            order_id,
-            timestamp: Timestamp::now()?,
-        };
-
-        self.current_pending_proposals.insert(
-            proposal.order_id,
-            UpdateCfdProposal::RollOverProposal {
-                proposal: proposal.clone(),
-                direction: SettlementKind::Outgoing,
-            },
-        );
-        self.send_pending_update_proposals()?;
-
-        self.send_to_maker
-            .do_send(wire::TakerToMaker::ProposeRollOver {
-                order_id: proposal.order_id,
-                timestamp: proposal.timestamp,
-            })?;
-        Ok(())
-    }
-}
-impl<O, M, W> Actor<O, M, W> where
-    W: xtra::Handler<wallet::TryBroadcastTransaction>
-        + xtra::Handler<wallet::Sign>
-        + xtra::Handler<wallet::BuildPartyParams>
-{
 }
 
 impl<O, M, W> Actor<O, M, W>

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -9,7 +9,7 @@ use crate::model::{BitMexPriceEventId, Price, Usd};
 use crate::monitor::{self, MonitorParams};
 use crate::tokio_ext::FutureExt;
 use crate::wire::{MakerToTaker, RollOverMsg, SetupMsg};
-use crate::{log_error, oracle, setup_contract, try_continue, wallet, wire};
+use crate::{log_error, oracle, setup_contract, wallet, wire};
 use anyhow::{bail, Context as _, Result};
 use async_trait::async_trait;
 use bdk::bitcoin::secp256k1::schnorrsig;
@@ -372,7 +372,10 @@ impl<O: 'static, M: 'static, W: 'static> Actor<O, M, W> {
 
         for proposal in proposals {
             tracing::trace!(order_id=%proposal.order_id, "Sending rollover proposal message");
-            try_continue!(address.send(ProposeRollOver { proposal }).await)
+
+            // avoid deadlock sending message to actor itself
+            #[allow(clippy::disallowed_method)]
+            address.do_send_async(ProposeRollOver { proposal }).await?;
         }
 
         Ok(())

--- a/daemon/src/to_sse_event.rs
+++ b/daemon/src/to_sse_event.rs
@@ -176,7 +176,6 @@ pub enum CfdAction {
     Settle,
     AcceptSettlement,
     RejectSettlement,
-    RollOver,
     AcceptRollOver,
     RejectRollOver,
 }
@@ -504,7 +503,7 @@ fn available_actions(state: CfdState, role: Role) -> Vec<CfdAction> {
             vec![CfdAction::Commit]
         }
         (CfdState::Open { .. }, Role::Taker) => {
-            vec![CfdAction::RollOver, CfdAction::Commit, CfdAction::Settle]
+            vec![CfdAction::Commit, CfdAction::Settle]
         }
         (CfdState::Open { .. }, Role::Maker) => vec![CfdAction::Commit],
         _ => vec![],

--- a/daemon/src/to_sse_event.rs
+++ b/daemon/src/to_sse_event.rs
@@ -339,7 +339,7 @@ impl ToSseEvent for Option<model::cfd::Order> {
             liquidation_price: order.liquidation_price.into(),
             creation_timestamp: order.creation_timestamp,
             settlement_time_interval_in_secs: order
-                .settlement_time_interval_hours
+                .settlement_interval
                 .whole_seconds()
                 .try_into()
                 .expect("settlement_time_interval_hours is always positive number"),

--- a/daemon/src/tokio_ext.rs
+++ b/daemon/src/tokio_ext.rs
@@ -10,6 +10,8 @@ where
     F: Future<Output = Result<(), E>> + Send + 'static,
     E: fmt::Display,
 {
+    // we want to disallow calls to tokio::spawn outside FutureExt
+    #[allow(clippy::disallowed_method)]
     tokio::spawn(async move {
         if let Err(e) = future.await {
             tracing::warn!("Task failed: {:#}", e);
@@ -40,6 +42,8 @@ where
         Self: Future<Output = ()> + Send + 'static,
     {
         let (future, handle) = self.remote_handle();
+        // we want to disallow calls to tokio::spawn outside FutureExt
+        #[allow(clippy::disallowed_method)]
         tokio::spawn(future);
         handle
     }

--- a/daemon/src/tokio_ext.rs
+++ b/daemon/src/tokio_ext.rs
@@ -1,5 +1,6 @@
 use futures::future::RemoteHandle;
 use futures::FutureExt as _;
+use std::any::{Any, TypeId};
 use std::fmt;
 use std::future::Future;
 use std::time::Duration;
@@ -26,7 +27,7 @@ pub trait FutureExt: Future + Sized {
     /// The task will be stopped when the handle gets dropped.
     fn spawn_with_handle(self) -> RemoteHandle<Self::Output>
     where
-        Self: Future<Output = ()> + Send + 'static;
+        Self: Future<Output = ()> + Send + Any + 'static;
 }
 
 impl<F> FutureExt for F
@@ -39,12 +40,51 @@ where
 
     fn spawn_with_handle(self) -> RemoteHandle<()>
     where
-        Self: Future<Output = ()> + Send + 'static,
+        Self: Future<Output = ()> + Send + Any + 'static,
     {
+        debug_assert!(
+            TypeId::of::<RemoteHandle<()>>() != self.type_id(),
+            "RemoteHandle<()> is a handle to already spawned task",
+        );
+
         let (future, handle) = self.remote_handle();
         // we want to disallow calls to tokio::spawn outside FutureExt
         #[allow(clippy::disallowed_method)]
         tokio::spawn(future);
         handle
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic;
+
+    use tokio::time::sleep;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn spawning_a_regular_future_does_not_panic() {
+        let result = panic::catch_unwind(|| {
+            let _handle = sleep(Duration::from_secs(2)).spawn_with_handle();
+        });
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn panics_when_called_spawn_with_handle_on_remote_handle() {
+        let result = panic::catch_unwind(|| {
+            let handle = sleep(Duration::from_secs(2)).spawn_with_handle();
+            let _handle_to_a_handle = handle.spawn_with_handle();
+        });
+
+        if cfg!(debug_assertions) {
+            assert!(
+                result.is_err(),
+                "Spawning a remote handle into a separate task should panic_in_debug_mode"
+            );
+        } else {
+            assert!(result.is_ok(), "Do not panic in release mode");
+        }
     }
 }

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -7,7 +7,9 @@ use daemon::maker_cfd::CfdAction;
 use daemon::model::cfd::{Cfd, Order, Origin};
 use daemon::model::{Price, Usd};
 use daemon::seed::Seed;
+use daemon::tokio_ext::FutureExt;
 use daemon::{db, maker_cfd, maker_inc_connections, taker_cfd, MakerActorSystem};
+use futures::future::RemoteHandle;
 use rust_decimal_macros::dec;
 use sqlx::SqlitePool;
 use std::net::SocketAddr;
@@ -47,6 +49,7 @@ pub struct Maker {
     pub mocks: mocks::Mocks,
     pub listen_addr: SocketAddr,
     pub identity_pk: x25519_dalek::PublicKey,
+    _tasks: Vec<RemoteHandle<()>>,
 }
 
 impl Maker {
@@ -64,8 +67,10 @@ impl Maker {
         let mut mocks = mocks::Mocks::default();
         let (oracle, monitor, wallet) = mocks::create_actors(&mocks);
 
+        let mut tasks = vec![];
+
         let (wallet_addr, wallet_fut) = wallet.create(None).run();
-        tokio::spawn(wallet_fut);
+        tasks.push(wallet_fut.spawn_with_handle());
 
         let settlement_time_interval_hours = time::Duration::hours(24);
 
@@ -109,13 +114,20 @@ impl Maker {
             Poll::Ready(Some(message))
         });
 
-        tokio::spawn(maker.inc_conn_addr.clone().attach_stream(listener_stream));
+        tasks.push(
+            maker
+                .inc_conn_addr
+                .clone()
+                .attach_stream(listener_stream)
+                .spawn_with_handle(),
+        );
 
         Self {
             system: maker,
             identity_pk,
             listen_addr: address,
             mocks,
+            _tasks: tasks,
         }
     }
 
@@ -153,6 +165,7 @@ impl Maker {
 pub struct Taker {
     pub system: daemon::TakerActorSystem<OracleActor, MonitorActor, WalletActor>,
     pub mocks: mocks::Mocks,
+    _tasks: Vec<RemoteHandle<()>>,
 }
 
 impl Taker {
@@ -182,8 +195,10 @@ impl Taker {
         let mut mocks = mocks::Mocks::default();
         let (oracle, monitor, wallet) = mocks::create_actors(&mocks);
 
+        let mut tasks = vec![];
+
         let (wallet_addr, wallet_fut) = wallet.create(None).run();
-        tokio::spawn(wallet_fut);
+        tasks.push(wallet_fut.spawn_with_handle());
 
         // system startup sends sync messages, mock them
         mocks.mock_sync_handlers().await;
@@ -213,6 +228,7 @@ impl Taker {
         Self {
             system: taker,
             mocks,
+            _tasks: tasks,
         }
     }
 

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -70,7 +70,7 @@ impl Maker {
         let (wallet_addr, wallet_fut) = wallet.create(None).run();
         tasks.add(wallet_fut);
 
-        let settlement_time_interval_hours = time::Duration::hours(24);
+        let settlement_interval = time::Duration::hours(24);
 
         let seed = Seed::default();
         let (identity_pk, identity_sk) = seed.derive_identity();
@@ -91,7 +91,7 @@ impl Maker {
                     HEARTBEAT_INTERVAL_FOR_TEST,
                 )
             },
-            settlement_time_interval_hours,
+            settlement_interval,
             N_PAYOUTS_FOR_TEST,
         )
         .await

--- a/maker-frontend/src/components/Types.tsx
+++ b/maker-frontend/src/components/Types.tsx
@@ -185,7 +185,6 @@ export enum Action {
     REJECT_ORDER = "rejectOrder",
     COMMIT = "commit",
     SETTLE = "settle",
-    ROLL_OVER = "rollOver",
     ACCEPT_SETTLEMENT = "acceptSettlement",
     REJECT_SETTLEMENT = "rejectSettlement",
     ACCEPT_ROLL_OVER = "acceptRollOver",

--- a/maker-frontend/src/components/cfdtables/CfdTable.tsx
+++ b/maker-frontend/src/components/cfdtables/CfdTable.tsx
@@ -5,7 +5,6 @@ import {
     ChevronUpIcon,
     CloseIcon,
     ExternalLinkIcon,
-    RepeatIcon,
     TriangleDownIcon,
     TriangleUpIcon,
     WarningIcon,
@@ -225,8 +224,6 @@ function iconForAction(action: Action): any {
             return <CheckIcon />;
         case Action.REJECT_SETTLEMENT:
             return <CloseIcon />;
-        case Action.ROLL_OVER:
-            return <RepeatIcon />;
         case Action.ACCEPT_ROLL_OVER:
             return <CheckIcon />;
         case Action.REJECT_ROLL_OVER:
@@ -243,8 +240,6 @@ function colorSchemaForAction(action: Action): string {
         case Action.COMMIT:
             return "red";
         case Action.SETTLE:
-            return "green";
-        case Action.ROLL_OVER:
             return "green";
         case Action.ACCEPT_SETTLEMENT:
             return "green";


### PR DESCRIPTION
When writing tests we noticed, that we will have unpredictable behaviour allowing rollover that is too close to the expiry time.

@thomaseizinger we discussed hat earlier and I implemented it, but then came to the conclusion that we should not use it. 
I still add it as a draft up for discussion. 

Here's my reasoning:

The taker should be able to propose a rollover until the very last second. If the maker already committed, the maker already committed. The rollover should be rejected then (rollovers should only be accepted if we are in an open state, once committed we can't roll over anymore). 
I think that behaviour is resilient enough and we don't have to introduce a `too_late_to_rollover` - I don't think it would add value. From a taker-UX point of view: We need feedback from maker->taker upon rejection. If there is no feedback then the UX will suffer. But I would solve that by sending proper errors over rather than introducing this interval. 

If I am missing something please let me know.