### PR TITLE
Add connected takers feed

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -10,7 +10,6 @@ use connection::ConnectionStatus;
 use futures::future::RemoteHandle;
 use maia::secp256k1_zkp::schnorrsig;
 use maker_cfd::TakerDisconnected;
-use model::TakerId;
 use sqlx::SqlitePool;
 use std::future::Future;
 use std::time::Duration;
@@ -91,7 +90,6 @@ impl Default for Tasks {
 
 pub struct MakerActorSystem<O, M, T, W> {
     pub cfd_actor_addr: Address<maker_cfd::Actor<O, M, T, W>>,
-    pub connected_takers_feed_receiver: watch::Receiver<Vec<TakerId>>,
     pub inc_conn_addr: Address<T>,
     pub tasks: Tasks,
 }
@@ -135,9 +133,6 @@ where
 
         let cfds = load_all_cfds(&mut conn).await?;
 
-        let (connected_takers_feed_sender, connected_takers_feed_receiver) =
-            watch::channel::<Vec<TakerId>>(Vec::new());
-
         let (monitor_addr, mut monitor_ctx) = xtra::Context::new(None);
         let (oracle_addr, mut oracle_ctx) = xtra::Context::new(None);
         let (inc_conn_addr, inc_conn_ctx) = xtra::Context::new(None);
@@ -150,7 +145,6 @@ where
             settlement_interval,
             oracle_pk,
             projection_actor,
-            connected_takers_feed_sender,
             inc_conn_addr.clone(),
             monitor_addr.clone(),
             oracle_addr.clone(),
@@ -196,7 +190,6 @@ where
 
         Ok(Self {
             cfd_actor_addr,
-            connected_takers_feed_receiver,
             inc_conn_addr,
             tasks,
         })

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -246,6 +246,7 @@ async fn main() -> Result<()> {
 
     let MakerActorSystem {
         cfd_actor_addr,
+        connected_takers_feed_receiver,
         inc_conn_addr: incoming_connection_addr,
         tasks: _tasks,
     } = MakerActorSystem::new(
@@ -259,8 +260,14 @@ async fn main() -> Result<()> {
                 monitor::Actor::new(electrum, channel, cfds)
             }
         },
-        |channel0, channel1| {
-            maker_inc_connections::Actor::new(channel0, channel1, identity_sk, HEARTBEAT_INTERVAL)
+        |channel0, channel1, channel2| {
+            maker_inc_connections::Actor::new(
+                channel0,
+                channel1,
+                channel2,
+                identity_sk,
+                HEARTBEAT_INTERVAL,
+            )
         },
         SETTLEMENT_INTERVAL,
         N_PAYOUTS,
@@ -309,6 +316,7 @@ async fn main() -> Result<()> {
         .manage(cfd_action_channel)
         .manage(new_order_channel)
         .manage(cfd_feed_receiver)
+        .manage(connected_takers_feed_receiver)
         .manage(wallet_feed_receiver)
         .manage(auth_password)
         .manage(quote_receiver)

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -7,7 +7,7 @@ use daemon::auth::{self, MAKER_USERNAME};
 use daemon::bitmex_price_feed::Quote;
 use daemon::db::load_all_cfds;
 use daemon::model::cfd::{Order, UpdateCfdProposals};
-use daemon::model::WalletInfo;
+use daemon::model::{TakerId, WalletInfo};
 use daemon::seed::Seed;
 use daemon::tokio_ext::FutureExt;
 use daemon::{
@@ -23,7 +23,6 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::task::Poll;
 use tokio::sync::watch;
-use tokio::sync::watch::channel;
 use tracing_subscriber::filter::LevelFilter;
 use xtra::prelude::*;
 use xtra::Actor;
@@ -246,7 +245,6 @@ async fn main() -> Result<()> {
 
     let MakerActorSystem {
         cfd_actor_addr,
-        connected_takers_feed_receiver,
         inc_conn_addr: incoming_connection_addr,
         tasks: _tasks,
     } = MakerActorSystem::new(
@@ -279,17 +277,20 @@ async fn main() -> Result<()> {
     tasks.add(task);
 
     let cfds = load_all_cfds(&mut conn).await?;
-    let (cfd_feed_sender, cfd_feed_receiver) = channel(cfds.clone());
-    let (order_feed_sender, order_feed_receiver) = channel::<Option<Order>>(None);
+    let (cfd_feed_sender, cfd_feed_receiver) = watch::channel(cfds.clone());
+    let (order_feed_sender, order_feed_receiver) = watch::channel::<Option<Order>>(None);
     let (update_cfd_feed_sender, update_cfd_feed_receiver) =
-        channel::<UpdateCfdProposals>(HashMap::new());
-    let (quote_sender, quote_receiver) = channel::<Quote>(init_quote);
+        watch::channel::<UpdateCfdProposals>(HashMap::new());
+    let (quote_sender, quote_receiver) = watch::channel::<Quote>(init_quote);
+    let (connected_takers_feed_sender, connected_takers_feed_receiver) =
+        watch::channel::<Vec<TakerId>>(Vec::new());
 
     tasks.add(projection_context.run(projection::Actor::new(
         cfd_feed_sender,
         order_feed_sender,
         quote_sender,
         update_cfd_feed_sender,
+        connected_takers_feed_sender,
     )));
 
     let listener_stream = futures::stream::poll_fn(move |ctx| {

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -21,8 +21,9 @@ use futures::{future, SinkExt};
 use maia::secp256k1_zkp::Signature;
 use sqlx::pool::PoolConnection;
 use sqlx::Sqlite;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use time::Duration;
+use tokio::sync::watch;
 use xtra::prelude::*;
 
 pub enum CfdAction {
@@ -41,7 +42,11 @@ pub struct NewOrder {
     pub max_quantity: Usd,
 }
 
-pub struct NewTakerOnline {
+pub struct TakerConnected {
+    pub id: TakerId,
+}
+
+pub struct TakerDisconnected {
     pub id: TakerId,
 }
 
@@ -66,6 +71,7 @@ pub struct Actor<O, M, T, W> {
     settlement_interval: Duration,
     oracle_pk: schnorrsig::PublicKey,
     projection_actor: Address<projection::Actor>,
+    connected_takers_feed_sender: watch::Sender<Vec<TakerId>>,
     takers: Address<T>,
     current_order_id: Option<OrderId>,
     monitor_actor: Address<M>,
@@ -75,6 +81,8 @@ pub struct Actor<O, M, T, W> {
     // Maker needs to also store TakerId to be able to send a reply back
     current_pending_proposals: HashMap<OrderId, (UpdateCfdProposal, TakerId)>,
     current_agreed_proposals: HashMap<OrderId, (SettlementProposal, TakerId)>,
+    // TODO: Keep in projection actor
+    connected_takers: HashSet<TakerId>,
     n_payouts: usize,
 }
 
@@ -104,6 +112,7 @@ impl<O, M, T, W> Actor<O, M, T, W> {
         settlement_interval: Duration,
         oracle_pk: schnorrsig::PublicKey,
         projection_actor: Address<projection::Actor>,
+        connected_takers_feed_sender: watch::Sender<Vec<TakerId>>,
         takers: Address<T>,
         monitor_actor: Address<M>,
         oracle_actor: Address<O>,
@@ -115,6 +124,7 @@ impl<O, M, T, W> Actor<O, M, T, W> {
             settlement_interval,
             oracle_pk,
             projection_actor,
+            connected_takers_feed_sender,
             takers,
             current_order_id: None,
             monitor_actor,
@@ -124,6 +134,7 @@ impl<O, M, T, W> Actor<O, M, T, W> {
             current_pending_proposals: HashMap::new(),
             current_agreed_proposals: HashMap::new(),
             n_payouts,
+            connected_takers: HashSet::new(),
         }
     }
 
@@ -314,7 +325,7 @@ impl<O, M, T, W> Actor<O, M, T, W>
 where
     T: xtra::Handler<maker_inc_connections::TakerMessage>,
 {
-    async fn handle_new_taker_online(&mut self, taker_id: TakerId) -> Result<()> {
+    async fn handle_taker_connected(&mut self, taker_id: TakerId) -> Result<()> {
         let mut conn = self.db.acquire().await?;
 
         let current_order = match self.current_order_id {
@@ -332,6 +343,21 @@ where
             })
             .await?;
 
+        if !self.connected_takers.insert(taker_id) {
+            tracing::warn!("Taker already connected: {:?}", &taker_id);
+        }
+        self.connected_takers_feed_sender
+            .send(self.connected_takers.clone().into_iter().collect())?;
+
+        Ok(())
+    }
+
+    async fn handle_taker_disconnected(&mut self, taker_id: TakerId) -> Result<()> {
+        if !self.connected_takers.remove(&taker_id) {
+            tracing::warn!("Removed unknown taker: {:?}", &taker_id);
+        }
+        self.connected_takers_feed_sender
+            .send(self.connected_takers.clone().into_iter().collect())?;
         Ok(())
     }
 
@@ -998,12 +1024,23 @@ where
 }
 
 #[async_trait]
-impl<O: 'static, M: 'static, T: 'static, W: 'static> Handler<NewTakerOnline> for Actor<O, M, T, W>
+impl<O: 'static, M: 'static, T: 'static, W: 'static> Handler<TakerConnected> for Actor<O, M, T, W>
 where
     T: xtra::Handler<maker_inc_connections::TakerMessage>,
 {
-    async fn handle(&mut self, msg: NewTakerOnline, _ctx: &mut Context<Self>) {
-        log_error!(self.handle_new_taker_online(msg.id));
+    async fn handle(&mut self, msg: TakerConnected, _ctx: &mut Context<Self>) {
+        log_error!(self.handle_taker_connected(msg.id));
+    }
+}
+
+#[async_trait]
+impl<O: 'static, M: 'static, T: 'static, W: 'static> Handler<TakerDisconnected>
+    for Actor<O, M, T, W>
+where
+    T: xtra::Handler<maker_inc_connections::TakerMessage>,
+{
+    async fn handle(&mut self, msg: TakerDisconnected, _ctx: &mut Context<Self>) {
+        log_error!(self.handle_taker_disconnected(msg.id));
     }
 }
 
@@ -1116,7 +1153,11 @@ impl Message for NewOrder {
     type Result = Result<()>;
 }
 
-impl Message for NewTakerOnline {
+impl Message for TakerConnected {
+    type Result = ();
+}
+
+impl Message for TakerDisconnected {
     type Result = ();
 }
 

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -1,4 +1,5 @@
 use crate::bitmex_price_feed::Quote;
+use crate::model::TakerId;
 use crate::{Cfd, Order, UpdateCfdProposals};
 use tokio::sync::watch;
 use xtra_productivity::xtra_productivity;
@@ -8,6 +9,9 @@ pub struct Actor {
     tx_order: watch::Sender<Option<Order>>,
     tx_quote: watch::Sender<Quote>,
     tx_settlements: watch::Sender<UpdateCfdProposals>,
+    // TODO: Use this channel to communicate maker status as well with generic
+    // ID of connected counterparties
+    tx_connected_takers: watch::Sender<Vec<TakerId>>,
 }
 
 impl Actor {
@@ -16,12 +20,14 @@ impl Actor {
         tx_order: watch::Sender<Option<Order>>,
         tx_quote: watch::Sender<Quote>,
         tx_settlements: watch::Sender<UpdateCfdProposals>,
+        tx_connected_takers: watch::Sender<Vec<TakerId>>,
     ) -> Self {
         Self {
             tx_cfds,
             tx_order,
             tx_quote,
             tx_settlements,
+            tx_connected_takers,
         }
     }
 }
@@ -41,6 +47,9 @@ impl Actor {
     }
     fn handle(&mut self, msg: Update<UpdateCfdProposals>) {
         let _ = self.tx_settlements.send(msg.0);
+    }
+    fn handle(&mut self, msg: Update<Vec<TakerId>>) {
+        let _ = self.tx_connected_takers.send(msg.0);
     }
 }
 

--- a/daemon/src/to_sse_event.rs
+++ b/daemon/src/to_sse_event.rs
@@ -2,7 +2,7 @@ use crate::connection::ConnectionStatus;
 use crate::model::cfd::{
     Dlc, OrderId, Payout, Role, SettlementKind, UpdateCfdProposal, UpdateCfdProposals,
 };
-use crate::model::{Leverage, Position, Timestamp, TradingPair};
+use crate::model::{Leverage, Position, TakerId, Timestamp, TradingPair};
 use crate::{bitmex_price_feed, model};
 use bdk::bitcoin::{Amount, Network, SignedAmount, Txid};
 use rocket::request::FromParam;
@@ -324,6 +324,13 @@ impl ToSseEvent for CfdsWithAuxData {
             .collect::<Vec<Cfd>>();
 
         Event::json(&cfds).event("cfds")
+    }
+}
+
+impl ToSseEvent for Vec<TakerId> {
+    fn to_sse_event(&self) -> Event {
+        let takers = self.iter().map(|x| x.to_string()).collect::<Vec<_>>();
+        Event::json(&takers).event("takers")
     }
 }
 

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -5,7 +5,7 @@ use crate::harness::{
 };
 use daemon::connection::ConnectionStatus;
 use daemon::model::cfd::CfdState;
-use daemon::model::Usd;
+use daemon::model::{TakerId, Usd};
 use maia::secp256k1_zkp::schnorrsig;
 use rust_decimal_macros::dec;
 use tokio::time::sleep;
@@ -152,5 +152,23 @@ async fn taker_notices_lack_of_maker() {
     assert_eq!(
         ConnectionStatus::Online,
         next(taker.maker_status_feed()).await.unwrap(),
+    );
+}
+
+#[tokio::test]
+async fn maker_notices_lack_of_taker() {
+    let _guard = init_tracing();
+
+    let (mut maker, taker) = start_both().await;
+    assert_eq!(
+        vec![taker.id],
+        next(maker.connected_takers_feed()).await.unwrap()
+    );
+
+    std::mem::drop(taker);
+
+    assert_eq!(
+        Vec::<TakerId>::new(),
+        next(maker.connected_takers_feed()).await.unwrap()
     );
 }

--- a/maker-frontend/src/MakerApp.tsx
+++ b/maker-frontend/src/MakerApp.tsx
@@ -20,6 +20,7 @@ import React, { useEffect, useState } from "react";
 import { useAsync } from "react-async";
 import { useEventSource } from "react-sse-hooks";
 import { CfdTable } from "./components/cfdtables/CfdTable";
+import ConnectedTakers, { TakerId } from "./components/ConnectedTakers";
 import CurrencyInputField from "./components/CurrencyInputField";
 import CurrentPrice from "./components/CurrentPrice";
 import createErrorToast from "./components/ErrorToast";
@@ -41,6 +42,8 @@ export default function App() {
     const order = useLatestEvent<Order>(source, "order", intoOrder);
     const walletInfo = useLatestEvent<WalletInfo>(source, "wallet");
     const priceInfo = useLatestEvent<PriceInfo>(source, "quote");
+    const takersOrUndefined = useLatestEvent<TakerId[]>(source, "takers");
+    let takers = takersOrUndefined || [];
 
     const toast = useToast();
 
@@ -151,7 +154,10 @@ export default function App() {
                         </GridItem>
                     </Grid>
                 </VStack>
-                {order && <OrderTile order={order} />}
+                <VStack>
+                    <ConnectedTakers takers={takers} />
+                    {order && <OrderTile order={order} />}
+                </VStack>
                 <Box width="40%" />
             </HStack>
 

--- a/maker-frontend/src/components/ConnectedTakers.tsx
+++ b/maker-frontend/src/components/ConnectedTakers.tsx
@@ -1,0 +1,25 @@
+import { Heading, ListItem, UnorderedList, VStack } from "@chakra-ui/react";
+import React from "react";
+
+export interface TakerId {
+    id: string;
+}
+
+interface Props {
+    takers: TakerId[];
+}
+
+const ConnectedTakers = ({ takers }: Props) => {
+    return (
+        <VStack spacing={3}>
+            <Heading size={"sm"} padding={2}>{"Connected takers: " + takers.length}</Heading>
+            <UnorderedList>
+                {takers.map((taker) => {
+                    return (<ListItem>{taker}</ListItem>);
+                })}
+            </UnorderedList>
+        </VStack>
+    );
+};
+
+export default ConnectedTakers;


### PR DESCRIPTION
- add a new watch channel with information about connected takers from the maker's actor system
- test the watch channel behaviour with a unit test
- add a list of connected takers to maker's UI (for testing/monitoring)

This PR will enable us to write more elaborate assertions (e.g. reconnection of the same taker & resuming its operation) and also enables us to gauge the length & amount of inteactions with the maker