### PR TITLE
We can safely assume that creating a timestamp should not fail

### DIFF
--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -474,7 +474,7 @@ where
             quantity,
             CfdState::IncomingOrderRequest {
                 common: CfdStateCommon {
-                    transition_timestamp: Timestamp::now()?,
+                    transition_timestamp: Timestamp::now(),
                 },
                 taker_id,
             },

--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -515,15 +515,15 @@ impl Timestamp {
         Self(seconds)
     }
 
-    pub fn now() -> Result<Self> {
+    pub fn now() -> Self {
         let seconds: i64 = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .context("time has gone backwards!")?
+            .expect("time not to go backwards")
             .as_secs()
             .try_into()
-            .context("Unable to convert u64 to i64")?;
+            .expect("seconds of system time to fit into i64");
 
-        Ok(Self(seconds))
+        Self(seconds)
     }
 
     pub fn parse_from_rfc3339(datetime_str: &str) -> Result<Self> {

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -146,7 +146,7 @@ impl Order {
             trading_pair: TradingPair::BtcUsd,
             liquidation_price,
             position: Position::Short,
-            creation_timestamp: Timestamp::now()?,
+            creation_timestamp: Timestamp::now(),
             settlement_time_interval_hours,
             origin,
             oracle_event_id,
@@ -173,7 +173,7 @@ pub struct CfdStateCommon {
 impl Default for CfdStateCommon {
     fn default() -> Self {
         Self {
-            transition_timestamp: Timestamp::now().expect("Unable to get current time"),
+            transition_timestamp: Timestamp::now(),
         }
     }
 }
@@ -649,7 +649,7 @@ impl Cfd {
 
         let settlement = SettlementProposal {
             order_id: self.order.id,
-            timestamp: Timestamp::now()?,
+            timestamp: Timestamp::now(),
             taker: *payout.taker_amount(),
             maker: *payout.maker_amount(),
             price: current_price,
@@ -718,7 +718,7 @@ impl Cfd {
                 if let PendingOpen { dlc, .. } = self.state.clone() {
                     CfdState::Open {
                         common: CfdStateCommon {
-                            transition_timestamp: Timestamp::now()?,
+                            transition_timestamp: Timestamp::now(),
                         },
                         dlc,
                         attestation: None,
@@ -733,7 +733,7 @@ impl Cfd {
                 {
                     CfdState::Open {
                         common: CfdStateCommon {
-                            transition_timestamp: Timestamp::now()?,
+                            transition_timestamp: Timestamp::now(),
                         },
                         dlc,
                         attestation,
@@ -770,7 +770,7 @@ impl Cfd {
 
                 OpenCommitted {
                     common: CfdStateCommon {
-                        transition_timestamp: Timestamp::now()?,
+                        transition_timestamp: Timestamp::now(),
                     },
                     dlc,
                     cet_status: if let Some(attestation) = attestation {
@@ -794,7 +794,7 @@ impl Cfd {
                     ..
                 } => CfdState::OpenCommitted {
                     common: CfdStateCommon {
-                        transition_timestamp: Timestamp::now()?,
+                        transition_timestamp: Timestamp::now(),
                     },
                     dlc,
                     cet_status: CetStatus::TimelockExpired,
@@ -805,7 +805,7 @@ impl Cfd {
                     ..
                 } => CfdState::OpenCommitted {
                     common: CfdStateCommon {
-                        transition_timestamp: Timestamp::now()?,
+                        transition_timestamp: Timestamp::now(),
                     },
                     dlc,
                     cet_status: CetStatus::Ready(attestation),
@@ -822,7 +822,7 @@ impl Cfd {
                     tracing::debug!(%order_id, "Was in unexpected state {}, jumping ahead to OpenCommitted", self.state);
                     CfdState::OpenCommitted {
                         common: CfdStateCommon {
-                            transition_timestamp: Timestamp::now()?,
+                            transition_timestamp: Timestamp::now(),
                         },
                         dlc,
                         cet_status: match attestation {
@@ -904,7 +904,7 @@ impl Cfd {
 
         self.state = PendingCommit {
             common: CfdStateCommon {
-                transition_timestamp: Timestamp::now()?,
+                transition_timestamp: Timestamp::now(),
             },
             dlc,
             attestation,
@@ -931,14 +931,14 @@ impl Cfd {
         let new_state = match self.state.clone() {
             CfdState::PendingOpen { dlc, .. } => CfdState::PendingOpen {
                 common: CfdStateCommon {
-                    transition_timestamp: Timestamp::now()?,
+                    transition_timestamp: Timestamp::now(),
                 },
                 dlc,
                 attestation: Some(attestation),
             },
             CfdState::Open { dlc, .. } => CfdState::Open {
                 common: CfdStateCommon {
-                    transition_timestamp: Timestamp::now()?,
+                    transition_timestamp: Timestamp::now(),
                 },
                 dlc,
                 attestation: Some(attestation),
@@ -946,7 +946,7 @@ impl Cfd {
             },
             CfdState::PendingCommit { dlc, .. } => CfdState::PendingCommit {
                 common: CfdStateCommon {
-                    transition_timestamp: Timestamp::now()?,
+                    transition_timestamp: Timestamp::now(),
                 },
                 dlc,
                 attestation: Some(attestation),
@@ -957,7 +957,7 @@ impl Cfd {
                 ..
             } => CfdState::OpenCommitted {
                 common: CfdStateCommon {
-                    transition_timestamp: Timestamp::now()?,
+                    transition_timestamp: Timestamp::now(),
                 },
                 dlc,
                 cet_status: CetStatus::OracleSigned(attestation),
@@ -968,7 +968,7 @@ impl Cfd {
                 ..
             } => CfdState::OpenCommitted {
                 common: CfdStateCommon {
-                    transition_timestamp: Timestamp::now()?,
+                    transition_timestamp: Timestamp::now(),
                 },
                 dlc,
                 cet_status: CetStatus::Ready(attestation),
@@ -1003,7 +1003,7 @@ impl Cfd {
 
         self.state = CfdState::PendingCet {
             common: CfdStateCommon {
-                transition_timestamp: Timestamp::now()?,
+                transition_timestamp: Timestamp::now(),
             },
             dlc,
             attestation,
@@ -1880,7 +1880,7 @@ impl CollaborativeSettlement {
 
         Ok(Self {
             tx,
-            timestamp: Timestamp::now().context("Unable to get current time")?,
+            timestamp: Timestamp::now(),
             payout,
             price,
         })

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -356,7 +356,7 @@ where
 
         let proposal = RollOverProposal {
             order_id,
-            timestamp: Timestamp::now()?,
+            timestamp: Timestamp::now(),
         };
 
         self.current_pending_proposals.insert(

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -105,7 +105,7 @@ impl Actor {
         let wallet_info = WalletInfo {
             balance: Amount::from_sat(balance),
             address,
-            last_updated_at: Timestamp::now()?,
+            last_updated_at: Timestamp::now(),
         };
 
         Ok(wallet_info)

--- a/daemon/tests/harness/mocks/wallet.rs
+++ b/daemon/tests/harness/mocks/wallet.rs
@@ -66,7 +66,7 @@ fn dummy_wallet_info() -> Result<WalletInfo> {
     Ok(WalletInfo {
         balance: bdk::bitcoin::Amount::ONE_BTC,
         address,
-        last_updated_at: Timestamp::now()?,
+        last_updated_at: Timestamp::now(),
     })
 }
 

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -108,7 +108,7 @@ impl Maker {
         .unwrap();
 
         let dummy_quote = Quote {
-            timestamp: Timestamp::now().unwrap(),
+            timestamp: Timestamp::now(),
             bid: Price::new(dec!(10000)).unwrap(),
             ask: Price::new(dec!(10000)).unwrap(),
         };
@@ -244,7 +244,7 @@ impl Taker {
         .unwrap();
 
         let dummy_quote = Quote {
-            timestamp: Timestamp::now().unwrap(),
+            timestamp: Timestamp::now(),
             bid: Price::new(dec!(10000)).unwrap(),
             ask: Price::new(dec!(10000)).unwrap(),
         };


### PR DESCRIPTION
Expect instead of returning a `Result`.