### PR TITLE
Implement sqlx::Type for more datatypes

### DIFF
--- a/daemon/sqlx-data.json
+++ b/daemon/sqlx-data.json
@@ -1,101 +1,5 @@
 {
   "db": "SQLite",
-  "04399897350d026ee0830ccaba3638f8aa8f4ef9694d59286f32b9e2449a99fa": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.uuid = $1\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "uuid: crate::model::cfd::OrderId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "trading_pair: crate::model::TradingPair",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "position: crate::model::Position",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "initial_price",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "min_quantity",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "max_quantity",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "leverage: crate::model::Leverage",
-          "ordinal": 6,
-          "type_info": "Int64"
-        },
-        {
-          "name": "liquidation_price",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "ts_secs: crate::model::Timestamp",
-          "ordinal": 8,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_secs: i64",
-          "ordinal": 9,
-          "type_info": "Int64"
-        },
-        {
-          "name": "origin: crate::model::cfd::Origin",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "oracle_event_id",
-          "ordinal": 11,
-          "type_info": "Text"
-        },
-        {
-          "name": "quantity_usd",
-          "ordinal": 12,
-          "type_info": "Text"
-        },
-        {
-          "name": "state",
-          "ordinal": 13,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
   "221a6283db798bacaba99e7e85130f9a8bbea1299d8cb99d272b1d478dc19775": {
     "query": "\n        select\n            state\n        from cfd_states\n        where cfd_id = $1\n        order by id desc\n        limit 1;\n        ",
     "describe": {
@@ -114,8 +18,8 @@
       ]
     }
   },
-  "22aae04782d6d9d6fa025e7606e3dcce91bfb9aca4aef9089a9ff9407c9f2715": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n        ",
+  "3d41b8a81df84252dae228d8512b7491416520a6ad89561f67cdfb673f864a5a": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n        ",
     "describe": {
       "columns": [
         {
@@ -134,17 +38,17 @@
           "type_info": "Text"
         },
         {
-          "name": "initial_price",
+          "name": "initial_price: crate::model::Price",
           "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "name": "min_quantity",
+          "name": "min_quantity: crate::model::Usd",
           "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "name": "max_quantity",
+          "name": "max_quantity: crate::model::Usd",
           "ordinal": 5,
           "type_info": "Text"
         },
@@ -154,7 +58,7 @@
           "type_info": "Int64"
         },
         {
-          "name": "liquidation_price",
+          "name": "liquidation_price: crate::model::Price",
           "ordinal": 7,
           "type_info": "Text"
         },
@@ -174,12 +78,12 @@
           "type_info": "Text"
         },
         {
-          "name": "oracle_event_id",
+          "name": "oracle_event_id: crate::model::BitMexPriceEventId",
           "ordinal": 11,
           "type_info": "Text"
         },
         {
-          "name": "quantity_usd",
+          "name": "quantity_usd: crate::model::Usd",
           "ordinal": 12,
           "type_info": "Text"
         },
@@ -210,8 +114,8 @@
       ]
     }
   },
-  "4bb5424ebcd683a149f15df5560fdea6727174f4cd6e0709e526ac3a690e2e5e": {
-    "query": "\n        select\n            uuid as \"uuid: crate::model::cfd::OrderId\",\n            trading_pair as \"trading_pair: crate::model::TradingPair\",\n            position as \"position: crate::model::Position\",\n            initial_price,\n            min_quantity,\n            max_quantity,\n            leverage as \"leverage: crate::model::Leverage\",\n            liquidation_price,\n            creation_timestamp_seconds as \"ts_secs: crate::model::Timestamp\",\n            settlement_time_interval_seconds as \"settlement_time_interval_secs: i64\",\n            origin as \"origin: crate::model::cfd::Origin\",\n            oracle_event_id\n\n        from orders\n        where uuid = $1\n        ",
+  "414ecf7f0cfce0a1a482b1b430d960867df835aae7fe1b306aa7f22353795dcf": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.uuid = $1\n        ",
     "describe": {
       "columns": [
         {
@@ -230,17 +134,17 @@
           "type_info": "Text"
         },
         {
-          "name": "initial_price",
+          "name": "initial_price: crate::model::Price",
           "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "name": "min_quantity",
+          "name": "min_quantity: crate::model::Usd",
           "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "name": "max_quantity",
+          "name": "max_quantity: crate::model::Usd",
           "ordinal": 5,
           "type_info": "Text"
         },
@@ -250,7 +154,7 @@
           "type_info": "Int64"
         },
         {
-          "name": "liquidation_price",
+          "name": "liquidation_price: crate::model::Price",
           "ordinal": 7,
           "type_info": "Text"
         },
@@ -270,96 +174,12 @@
           "type_info": "Text"
         },
         {
-          "name": "oracle_event_id",
-          "ordinal": 11,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "6dbd14a613a982521b4cc9179fd6f6b0298c0a4475508536379e9b82c9f2d0a0": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price,\n            ord.min_quantity,\n            ord.max_quantity,\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price,\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id,\n            state.quantity_usd,\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.oracle_event_id = $1\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "uuid: crate::model::cfd::OrderId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "trading_pair: crate::model::TradingPair",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "position: crate::model::Position",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "initial_price",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "min_quantity",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "max_quantity",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "leverage: crate::model::Leverage",
-          "ordinal": 6,
-          "type_info": "Int64"
-        },
-        {
-          "name": "liquidation_price",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "ts_secs: crate::model::Timestamp",
-          "ordinal": 8,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_secs: i64",
-          "ordinal": 9,
-          "type_info": "Int64"
-        },
-        {
-          "name": "origin: crate::model::cfd::Origin",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "oracle_event_id",
+          "name": "oracle_event_id: crate::model::BitMexPriceEventId",
           "ordinal": 11,
           "type_info": "Text"
         },
         {
-          "name": "quantity_usd",
+          "name": "quantity_usd: crate::model::Usd",
           "ordinal": 12,
           "type_info": "Text"
         },
@@ -390,6 +210,90 @@
       ]
     }
   },
+  "5569292de42c8ce5cff83beb43af1f8e6c3c12b17e740550c1303a1a6d151100": {
+    "query": "\n        select\n            uuid as \"uuid: crate::model::cfd::OrderId\",\n            trading_pair as \"trading_pair: crate::model::TradingPair\",\n            position as \"position: crate::model::Position\",\n            initial_price as \"initial_price: crate::model::Price\",\n            min_quantity as \"min_quantity: crate::model::Usd\",\n            max_quantity as \"max_quantity: crate::model::Usd\",\n            leverage as \"leverage: crate::model::Leverage\",\n            liquidation_price as \"liquidation_price: crate::model::Price\",\n            creation_timestamp_seconds as \"ts_secs: crate::model::Timestamp\",\n            settlement_time_interval_seconds as \"settlement_time_interval_secs: i64\",\n            origin as \"origin: crate::model::cfd::Origin\",\n            oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\"\n        from\n            orders\n        where\n            uuid = $1\n        ",
+    "describe": {
+      "columns": [
+        {
+          "name": "uuid: crate::model::cfd::OrderId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "trading_pair: crate::model::TradingPair",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: crate::model::Position",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price: crate::model::Price",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "min_quantity: crate::model::Usd",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "max_quantity: crate::model::Usd",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "leverage: crate::model::Leverage",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "liquidation_price: crate::model::Price",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "ts_secs: crate::model::Timestamp",
+          "ordinal": 8,
+          "type_info": "Int64"
+        },
+        {
+          "name": "settlement_time_interval_secs: i64",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "origin: crate::model::cfd::Origin",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "oracle_event_id: crate::model::BitMexPriceEventId",
+          "ordinal": 11,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "8cbe349911b35d8e79763d64b4f5813b4bd98f12e0bba5ada84d2cae8b08ef4f": {
     "query": "\n        select\n            id\n        from cfds\n        where order_uuid = $1;\n        ",
     "describe": {
@@ -405,6 +309,102 @@
       },
       "nullable": [
         true
+      ]
+    }
+  },
+  "f822252e3d3eb70a03300529d8de8f553e8d97b1aac72fb964cbde49d65fe153": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.oracle_event_id = $1\n        ",
+    "describe": {
+      "columns": [
+        {
+          "name": "uuid: crate::model::cfd::OrderId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "trading_pair: crate::model::TradingPair",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: crate::model::Position",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price: crate::model::Price",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "min_quantity: crate::model::Usd",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "max_quantity: crate::model::Usd",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "leverage: crate::model::Leverage",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "liquidation_price: crate::model::Price",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "ts_secs: crate::model::Timestamp",
+          "ordinal": 8,
+          "type_info": "Int64"
+        },
+        {
+          "name": "settlement_time_interval_secs: i64",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "origin: crate::model::cfd::Origin",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "oracle_event_id: crate::model::BitMexPriceEventId",
+          "ordinal": 11,
+          "type_info": "Text"
+        },
+        {
+          "name": "quantity_usd: crate::model::Usd",
+          "ordinal": 12,
+          "type_info": "Text"
+        },
+        {
+          "name": "state",
+          "ordinal": 13,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
       ]
     }
   }

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -16,6 +16,8 @@ use tokio::sync::watch;
 use xtra::message_channel::{MessageChannel, StrongMessageChannel};
 use xtra::{Actor, Address};
 
+pub mod sqlx_ext; // Must come first because it is a macro.
+
 pub mod actors;
 pub mod auth;
 pub mod bitmex_price_feed;

--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -1,4 +1,4 @@
-use crate::olivia;
+use crate::{impl_sqlx_type_display_from_str, olivia};
 use anyhow::{Context, Result};
 use bdk::bitcoin::{Address, Amount, Denomination};
 use chrono::DateTime;
@@ -62,8 +62,12 @@ impl str::FromStr for Usd {
     }
 }
 
+impl_sqlx_type_display_from_str!(Usd);
+
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Price(Decimal);
+
+impl_sqlx_type_display_from_str!(Price);
 
 impl Price {
     pub fn new(value: Decimal) -> Result<Self, Error> {
@@ -133,6 +137,7 @@ impl InversePrice {
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, sqlx::Type)]
+#[sqlx(transparent)]
 pub struct Leverage(u8);
 
 impl Leverage {
@@ -377,7 +382,7 @@ pub enum TradingPair {
     BtcUsd,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::Type)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, sqlx::Type)]
 pub enum Position {
     Long,
     Short,
@@ -506,6 +511,8 @@ impl str::FromStr for BitMexPriceEventId {
         })
     }
 }
+
+impl_sqlx_type_display_from_str!(BitMexPriceEventId);
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, sqlx::Type)]
 pub struct Timestamp(i64);

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -660,7 +660,7 @@ impl Cfd {
 
     pub fn position(&self) -> Position {
         match self.order.origin {
-            Origin::Ours => self.order.position.clone(),
+            Origin::Ours => self.order.position,
 
             // If the order is not our own we take the counter-position in the CFD
             Origin::Theirs => match self.order.position {

--- a/daemon/src/sqlx_ext.rs
+++ b/daemon/src/sqlx_ext.rs
@@ -1,0 +1,30 @@
+#[macro_export]
+macro_rules! impl_sqlx_type_display_from_str {
+    ($ty:ty) => {
+        impl sqlx::Type<sqlx::Sqlite> for $ty {
+            fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
+                String::type_info()
+            }
+        }
+
+        impl<'q> sqlx::Encode<'q, sqlx::Sqlite> for $ty {
+            fn encode_by_ref(
+                &self,
+                args: &mut Vec<sqlx::sqlite::SqliteArgumentValue<'q>>,
+            ) -> sqlx::encode::IsNull {
+                self.to_string().encode_by_ref(args)
+            }
+        }
+
+        impl<'r> sqlx::Decode<'r, sqlx::Sqlite> for $ty {
+            fn decode(
+                value: sqlx::sqlite::SqliteValueRef<'r>,
+            ) -> Result<Self, sqlx::error::BoxDynError> {
+                let string = String::decode(value)?;
+                let value = string.parse()?;
+
+                Ok(value)
+            }
+        }
+    };
+}


### PR DESCRIPTION
This maker our DB code slightly simpler because we can directly use
our newtypes in the query and they are also constructed right away
by sqlx.

@da-kami @klochowicz Could one of you run `./prepare-db.sh` locally? It doesn't work on my machine for some reason ...