### PR TITLE
Move settlement oracle event id into the Dlc

### DIFF
--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -693,17 +693,13 @@ where
         self.monitor_actor
             .send(monitor::StartMonitoring {
                 id: order_id,
-                params: MonitorParams::new(
-                    dlc,
-                    cfd.refund_timelock_in_blocks(),
-                    cfd.order.oracle_event_id,
-                ),
+                params: MonitorParams::new(dlc.clone(), cfd.refund_timelock_in_blocks()),
             })
             .await?;
 
         self.oracle_actor
             .send(oracle::MonitorAttestation {
-                event_id: cfd.order.oracle_event_id,
+                event_id: dlc.settlement_event_id,
             })
             .await?;
 
@@ -818,8 +814,9 @@ where
 impl<O, M, T, W> Actor<O, M, T, W>
 where
     M: xtra::Handler<monitor::StartMonitoring>,
+    O: xtra::Handler<oracle::MonitorAttestation>,
 {
-    async fn handle_cfd_roll_over_completed(
+    async fn handle_roll_over_completed(
         &mut self,
         order_id: OrderId,
         dlc: Result<Dlc>,
@@ -840,11 +837,13 @@ where
         self.monitor_actor
             .send(monitor::StartMonitoring {
                 id: order_id,
-                params: MonitorParams::new(
-                    dlc,
-                    cfd.refund_timelock_in_blocks(),
-                    cfd.order.oracle_event_id,
-                ),
+                params: MonitorParams::new(dlc.clone(), cfd.refund_timelock_in_blocks()),
+            })
+            .await?;
+
+        self.oracle_actor
+            .send(oracle::MonitorAttestation {
+                event_id: dlc.settlement_event_id,
             })
             .await?;
 
@@ -1025,9 +1024,10 @@ impl<O: 'static, M: 'static, T: 'static, W: 'static> Handler<CfdRollOverComplete
     for Actor<O, M, T, W>
 where
     M: xtra::Handler<monitor::StartMonitoring>,
+    O: xtra::Handler<oracle::MonitorAttestation>,
 {
     async fn handle(&mut self, msg: CfdRollOverCompleted, _ctx: &mut Context<Self>) {
-        log_error!(self.handle_cfd_roll_over_completed(msg.order_id, msg.dlc));
+        log_error!(self.handle_roll_over_completed(msg.order_id, msg.dlc));
     }
 }
 

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -758,12 +758,6 @@ where
             })
             .await??;
 
-        self.oracle_actor
-            .send(oracle::MonitorAttestation {
-                event_id: announcement.id,
-            })
-            .await?;
-
         let (sender, receiver) = mpsc::unbounded();
         let contract_future = setup_contract::roll_over(
             self.takers.clone().into_sink().with(move |msg| {

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -676,8 +676,8 @@ impl Cfd {
             .ceil() as u32
     }
 
-    pub fn expiry_timestamp(&self) -> OffsetDateTime {
-        self.order.oracle_event_id.timestamp()
+    pub fn expiry_timestamp(&self) -> Option<OffsetDateTime> {
+        self.dlc().map(|dlc| dlc.settlement_event_id.timestamp)
     }
 
     /// A factor to be added to the CFD order settlement_interval for calculating the
@@ -1506,6 +1506,12 @@ pub struct Dlc {
     pub taker_lock_amount: Amount,
 
     pub revoked_commit: Vec<RevokedCommit>,
+
+    // TODO: For now we store this seperately - it is a duplicate of what is stored in the cets
+    // hashmap. The cet hashmap allows storing cets for event-ids with different concern
+    // (settlement and liquidation-point). We should NOT make these fields public on the Dlc
+    // and create an internal structure that depicts this properly and avoids duplication.
+    pub settlement_event_id: BitMexPriceEventId,
 }
 
 impl Dlc {

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -68,13 +68,13 @@ impl Actor {
 
         for cfd in cfds {
             match cfd.state.clone() {
-                CfdState::PendingOpen { .. }
-                | CfdState::Open { .. }
-                | CfdState::PendingCommit { .. }
-                | CfdState::OpenCommitted { .. }
-                | CfdState::PendingCet { .. } =>
+                CfdState::PendingOpen { dlc, ..}
+                | CfdState::Open { dlc, .. }
+                | CfdState::PendingCommit { dlc, .. }
+                | CfdState::OpenCommitted { dlc, .. }
+                | CfdState::PendingCet { dlc, .. } =>
                 {
-                    pending_attestations.insert(cfd.order.oracle_event_id);
+                    pending_attestations.insert(dlc.settlement_event_id);
                 }
 
                 // Irrelevant for restart

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -111,6 +111,7 @@ where
         )
     }
 
+    let settlement_event_id = announcement.id;
     let payouts = HashMap::from_iter([(
         announcement.into(),
         payout_curve::calculate(
@@ -289,6 +290,7 @@ where
         maker_lock_amount: params.maker().lock_amount,
         taker_lock_amount: params.taker().lock_amount,
         revoked_commit: Vec::new(),
+        settlement_event_id,
     })
 }
 
@@ -575,6 +577,7 @@ pub async fn roll_over(
         maker_lock_amount,
         taker_lock_amount,
         revoked_commit,
+        settlement_event_id: announcement.id,
     })
 }
 

--- a/daemon/src/to_sse_event.rs
+++ b/daemon/src/to_sse_event.rs
@@ -318,7 +318,10 @@ impl ToSseEvent for CfdsWithAuxData {
                     margin: cfd.margin().expect("margin to be available"),
                     margin_counterparty: cfd.counterparty_margin().expect("margin to be available"),
                     details,
-                    expiry_timestamp: cfd.expiry_timestamp(),
+                    expiry_timestamp: match cfd.expiry_timestamp() {
+                        None => cfd.order.oracle_event_id.timestamp(),
+                        Some(timestamp) => timestamp,
+                    },
                 }
             })
             .collect::<Vec<Cfd>>();


### PR DESCRIPTION
Oracle event-id and Dlc have to exist together, one without the other is incomplete, hence we move the event id inside.
Note that the ID is actually already know  to the Dlc as part of the `cet` hashmap, but this was not cleaned up in this patch.

This patch goes towards getting the model boundaries right to transition the architecture towards an event model.

Note: This would theoretically allow us to land auto-rollover, because we don't now pass the correct event-id through. However, we decided that it's better to pull the architecture refactoring through before landing the rollover feature 😬