### PR TITLE
Remove `maker_cfd::CfdAction` enum

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -11,7 +11,7 @@ use daemon::model::{TakerId, WalletInfo};
 use daemon::seed::Seed;
 use daemon::tokio_ext::FutureExt;
 use daemon::{
-    bitmex_price_feed, db, housekeeping, logger, maker_cfd, maker_inc_connections, monitor, oracle,
+    bitmex_price_feed, db, housekeeping, logger, maker_inc_connections, monitor, oracle,
     projection, wallet, wallet_sync, MakerActorSystem, Tasks, HEARTBEAT_INTERVAL, N_PAYOUTS,
     SETTLEMENT_INTERVAL,
 };
@@ -24,7 +24,6 @@ use std::str::FromStr;
 use std::task::Poll;
 use tokio::sync::watch;
 use tracing_subscriber::filter::LevelFilter;
-use xtra::prelude::*;
 use xtra::Actor;
 
 mod routes_maker;
@@ -305,17 +304,12 @@ async fn main() -> Result<()> {
     });
 
     tasks.add(incoming_connection_addr.attach_stream(listener_stream));
-
     tasks.add(wallet_sync::new(wallet.clone(), wallet_feed_sender));
-
-    let cfd_action_channel = MessageChannel::<maker_cfd::CfdAction>::clone_channel(&cfd_actor_addr);
-    let new_order_channel = MessageChannel::<maker_cfd::NewOrder>::clone_channel(&cfd_actor_addr);
 
     rocket::custom(figment)
         .manage(order_feed_receiver)
         .manage(update_cfd_feed_receiver)
-        .manage(cfd_action_channel)
-        .manage(new_order_channel)
+        .manage(cfd_actor_addr)
         .manage(cfd_feed_receiver)
         .manage(connected_takers_feed_receiver)
         .manage(wallet_feed_receiver)

--- a/daemon/tests/harness/mocks/wallet.rs
+++ b/daemon/tests/harness/mocks/wallet.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use bdk::bitcoin::util::psbt::PartiallySignedTransaction;
 use bdk::bitcoin::{ecdsa, Amount, Txid};
 use daemon::model::{Timestamp, WalletInfo};
-use daemon::wallet::{self};
+use daemon::wallet;
 use maia::secp256k1_zkp::Secp256k1;
 use maia::{PartyParams, WalletExt};
 use mockall::*;

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -4,7 +4,6 @@ use crate::harness::mocks::wallet::WalletActor;
 use crate::schnorrsig;
 use daemon::bitmex_price_feed::Quote;
 use daemon::connection::{connect, ConnectionStatus};
-use daemon::maker_cfd::CfdAction;
 use daemon::model::cfd::{Cfd, Order, Origin, UpdateCfdProposals};
 use daemon::model::{Price, TakerId, Timestamp, Usd};
 use daemon::seed::Seed;
@@ -183,7 +182,7 @@ impl Maker {
     pub async fn reject_take_request(&self, order: Order) {
         self.system
             .cfd_actor_addr
-            .send(CfdAction::RejectOrder { order_id: order.id })
+            .send(maker_cfd::RejectOrder { order_id: order.id })
             .await
             .unwrap()
             .unwrap();
@@ -192,7 +191,7 @@ impl Maker {
     pub async fn accept_take_request(&self, order: Order) {
         self.system
             .cfd_actor_addr
-            .send(CfdAction::AcceptOrder { order_id: order.id })
+            .send(maker_cfd::AcceptOrder { order_id: order.id })
             .await
             .unwrap()
             .unwrap();


### PR DESCRIPTION
Originally we thought we need this enum because we would need to use
`MessageChannel`s from the rocket layer. But we can actually fully
qualify the address without issues.

We also introduce `xtra_productivity` to remove some of the indirection
that is happening in this file.
