### PR TITLE
Explicitly drop database connection acquired during application setup

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -235,10 +235,7 @@ async fn main() -> Result<()> {
         .context("Db migrations failed")?;
 
     // Create actors
-    let mut conn = db.acquire().await?;
-
-    housekeeping::transition_non_continue_cfds_to_setup_failed(&mut conn).await?;
-    housekeeping::rebroadcast_transactions(&mut conn, &wallet).await?;
+    housekeeping::new(&db, &wallet).await?;
 
     let (projection_actor, projection_context) = xtra::Context::new(None);
 
@@ -275,7 +272,12 @@ async fn main() -> Result<()> {
     let (task, init_quote) = bitmex_price_feed::new(projection_actor).await?;
     tasks.add(task);
 
-    let cfds = load_all_cfds(&mut conn).await?;
+    // TODO: Move to projection actor
+    let cfds = {
+        let mut conn = db.acquire().await?;
+
+        load_all_cfds(&mut conn).await?
+    };
     let (cfd_feed_sender, cfd_feed_receiver) = watch::channel(cfds.clone());
     let (order_feed_sender, order_feed_receiver) = watch::channel::<Option<Order>>(None);
     let (update_cfd_feed_sender, update_cfd_feed_receiver) =


### PR DESCRIPTION
The dirty shutdown we observed were caused by the sqlite pool patiently waiting
until we close the connection we've opened in the application setup.
This is turn was eventually triggering Rocket timeout (which is by default
configured to wait 5s for cleanup).

When loading cfds gets moved into the projection actor, the connection can be
moved to a tighter scope (only for the housekeeping functions).

Resolves #477 