### PR TITLE
Contract setup `Completed` is the same for taker and maker

### DIFF
--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -1661,6 +1661,22 @@ impl CollaborativeSettlement {
     }
 }
 
+/// Message sent from a setup actor to the
+/// cfd actor to notify that the contract setup has finished.
+pub enum Completed {
+    NewContract {
+        order_id: OrderId,
+        dlc: Dlc,
+    },
+    Rejected {
+        order_id: OrderId,
+    },
+    Failed {
+        order_id: OrderId,
+        error: anyhow::Error,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -1,4 +1,4 @@
-use crate::model::cfd::{Cfd, CfdState, Dlc, Order, OrderId, Role};
+use crate::model::cfd::{Cfd, CfdState, Completed, Dlc, Order, OrderId, Role};
 use crate::model::Usd;
 use crate::oracle::Announcement;
 use crate::setup_contract::{self, SetupParams};
@@ -204,22 +204,6 @@ pub struct SetupSucceeded {
 pub struct SetupFailed {
     order_id: OrderId,
     error: anyhow::Error,
-}
-
-/// Message sent from the `setup_taker::Actor` to the
-/// `taker_cfd::Actor` to notify that the contract setup has finished.
-pub enum Completed {
-    NewContract {
-        order_id: OrderId,
-        dlc: Dlc,
-    },
-    Rejected {
-        order_id: OrderId,
-    },
-    Failed {
-        order_id: OrderId,
-        error: anyhow::Error,
-    },
 }
 
 impl xtra::Message for Started {


### PR DESCRIPTION
Either of the roles has to record the outcome of the setup, which should be the same for them.
In order to handle this in our event model we need `Completed` in the model so it is not role specific.