### PR TITLE
Refactor projection actor before adding new functionality

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::bitmex_price_feed::Quote;
 use crate::model::TakerId;
 use crate::{Cfd, Order, UpdateCfdProposals};
@@ -5,31 +7,55 @@ use tokio::sync::watch;
 use xtra_productivity::xtra_productivity;
 
 pub struct Actor {
-    tx_cfds: watch::Sender<Vec<Cfd>>,
-    tx_order: watch::Sender<Option<Order>>,
-    tx_quote: watch::Sender<Quote>,
-    tx_settlements: watch::Sender<UpdateCfdProposals>,
-    // TODO: Use this channel to communicate maker status as well with generic
-    // ID of connected counterparties
-    tx_connected_takers: watch::Sender<Vec<TakerId>>,
+    tx: Tx,
+}
+
+pub struct Feeds {
+    pub cfds: watch::Receiver<Vec<Cfd>>,
+    pub order: watch::Receiver<Option<Order>>,
+    pub quote: watch::Receiver<Quote>,
+    pub settlements: watch::Receiver<UpdateCfdProposals>,
+    pub connected_takers: watch::Receiver<Vec<TakerId>>,
 }
 
 impl Actor {
-    pub fn new(
-        tx_cfds: watch::Sender<Vec<Cfd>>,
-        tx_order: watch::Sender<Option<Order>>,
-        tx_quote: watch::Sender<Quote>,
-        tx_settlements: watch::Sender<UpdateCfdProposals>,
-        tx_connected_takers: watch::Sender<Vec<TakerId>>,
-    ) -> Self {
-        Self {
-            tx_cfds,
-            tx_order,
-            tx_quote,
-            tx_settlements,
-            tx_connected_takers,
-        }
+    pub fn new(init_cfds: Vec<Cfd>, init_quote: Quote) -> (Self, Feeds) {
+        let (tx_cfds, rx_cfds) = watch::channel(init_cfds);
+        let (tx_order, rx_order) = watch::channel(None);
+        let (tx_update_cfd_feed, rx_update_cfd_feed) = watch::channel(HashMap::new());
+        let (tx_quote, rx_quote) = watch::channel(init_quote);
+        let (tx_connected_takers, rx_connected_takers) = watch::channel(Vec::new());
+
+        (
+            Self {
+                tx: Tx {
+                    cfds: tx_cfds,
+                    order: tx_order,
+                    quote: tx_quote,
+                    settlements: tx_update_cfd_feed,
+                    connected_takers: tx_connected_takers,
+                },
+            },
+            Feeds {
+                cfds: rx_cfds,
+                order: rx_order,
+                quote: rx_quote,
+                settlements: rx_update_cfd_feed,
+                connected_takers: rx_connected_takers,
+            },
+        )
     }
+}
+
+/// Internal struct to keep all the senders around in one place
+struct Tx {
+    pub cfds: watch::Sender<Vec<Cfd>>,
+    pub order: watch::Sender<Option<Order>>,
+    pub quote: watch::Sender<Quote>,
+    pub settlements: watch::Sender<UpdateCfdProposals>,
+    // TODO: Use this channel to communicate maker status as well with generic
+    // ID of connected counterparties
+    pub connected_takers: watch::Sender<Vec<TakerId>>,
 }
 
 pub struct Update<T>(pub T);
@@ -37,19 +63,19 @@ pub struct Update<T>(pub T);
 #[xtra_productivity]
 impl Actor {
     fn handle(&mut self, msg: Update<Vec<Cfd>>) {
-        let _ = self.tx_cfds.send(msg.0);
+        let _ = self.tx.cfds.send(msg.0);
     }
     fn handle(&mut self, msg: Update<Option<Order>>) {
-        let _ = self.tx_order.send(msg.0);
+        let _ = self.tx.order.send(msg.0);
     }
     fn handle(&mut self, msg: Update<Quote>) {
-        let _ = self.tx_quote.send(msg.0);
+        let _ = self.tx.quote.send(msg.0);
     }
     fn handle(&mut self, msg: Update<UpdateCfdProposals>) {
-        let _ = self.tx_settlements.send(msg.0);
+        let _ = self.tx.settlements.send(msg.0);
     }
     fn handle(&mut self, msg: Update<Vec<TakerId>>) {
-        let _ = self.tx_connected_takers.send(msg.0);
+        let _ = self.tx.connected_takers.send(msg.0);
     }
 }
 

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -4,15 +4,15 @@ use crate::harness::mocks::wallet::WalletActor;
 use crate::schnorrsig;
 use daemon::bitmex_price_feed::Quote;
 use daemon::connection::{connect, ConnectionStatus};
-use daemon::model::cfd::{Cfd, Order, Origin, UpdateCfdProposals};
+use daemon::model::cfd::{Cfd, Order, Origin};
 use daemon::model::{Price, TakerId, Timestamp, Usd};
+use daemon::projection::Feeds;
 use daemon::seed::Seed;
 use daemon::{
     db, maker_cfd, maker_inc_connections, projection, taker_cfd, MakerActorSystem, Tasks,
 };
 use rust_decimal_macros::dec;
 use sqlx::SqlitePool;
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::task::Poll;
@@ -94,25 +94,23 @@ pub struct Maker {
     pub system:
         MakerActorSystem<OracleActor, MonitorActor, maker_inc_connections::Actor, WalletActor>,
     pub mocks: mocks::Mocks,
+    pub feeds: Feeds,
     pub listen_addr: SocketAddr,
     pub identity_pk: x25519_dalek::PublicKey,
-    cfd_feed_receiver: watch::Receiver<Vec<Cfd>>,
-    order_feed_receiver: watch::Receiver<Option<Order>>,
-    connected_takers_feed_receiver: watch::Receiver<Vec<TakerId>>,
     _tasks: Tasks,
 }
 
 impl Maker {
     pub fn cfd_feed(&mut self) -> &mut watch::Receiver<Vec<Cfd>> {
-        &mut self.cfd_feed_receiver
+        &mut self.feeds.cfds
     }
 
     pub fn order_feed(&mut self) -> &mut watch::Receiver<Option<Order>> {
-        &mut self.order_feed_receiver
+        &mut self.feeds.order
     }
 
     pub fn connected_takers_feed(&mut self) -> &mut watch::Receiver<Vec<TakerId>> {
-        &mut self.connected_takers_feed_receiver
+        &mut self.feeds.connected_takers
     }
 
     pub async fn start(config: &MakerConfig, listener: TcpListener) -> Self {
@@ -162,21 +160,8 @@ impl Maker {
             ask: Price::new(dec!(10000)).unwrap(),
         };
 
-        let (cfd_feed_sender, cfd_feed_receiver) = watch::channel(vec![]);
-        let (order_feed_sender, order_feed_receiver) = watch::channel::<Option<Order>>(None);
-        let (update_cfd_feed_sender, _update_cfd_feed_receiver) =
-            watch::channel::<UpdateCfdProposals>(HashMap::new());
-        let (quote_sender, _) = watch::channel::<Quote>(dummy_quote);
-        let (connected_takers_feed_sender, connected_takers_feed_receiver) =
-            watch::channel::<Vec<TakerId>>(vec![]);
-
-        tasks.add(projection_context.run(projection::Actor::new(
-            cfd_feed_sender,
-            order_feed_sender,
-            quote_sender,
-            update_cfd_feed_sender,
-            connected_takers_feed_sender,
-        )));
+        let (proj_actor, feeds) = projection::Actor::new(vec![], dummy_quote);
+        tasks.add(projection_context.run(proj_actor));
 
         let address = listener.local_addr().unwrap();
 
@@ -195,13 +180,11 @@ impl Maker {
 
         Self {
             system: maker,
+            feeds,
             identity_pk,
             listen_addr: address,
             mocks,
             _tasks: tasks,
-            cfd_feed_receiver,
-            order_feed_receiver,
-            connected_takers_feed_receiver,
         }
     }
 
@@ -240,18 +223,17 @@ pub struct Taker {
     pub id: TakerId,
     pub system: daemon::TakerActorSystem<OracleActor, MonitorActor, WalletActor>,
     pub mocks: mocks::Mocks,
-    cfd_feed_receiver: watch::Receiver<Vec<Cfd>>,
-    order_feed_receiver: watch::Receiver<Option<Order>>,
+    pub feeds: Feeds,
     _tasks: Tasks,
 }
 
 impl Taker {
     pub fn cfd_feed(&mut self) -> &mut watch::Receiver<Vec<Cfd>> {
-        &mut self.cfd_feed_receiver
+        &mut self.feeds.cfds
     }
 
     pub fn order_feed(&mut self) -> &mut watch::Receiver<Option<Order>> {
-        &mut self.order_feed_receiver
+        &mut self.feeds.order
     }
 
     pub fn maker_status_feed(&mut self) -> &mut watch::Receiver<ConnectionStatus> {
@@ -299,21 +281,8 @@ impl Taker {
             ask: Price::new(dec!(10000)).unwrap(),
         };
 
-        let (cfd_feed_sender, cfd_feed_receiver) = watch::channel(vec![]);
-        let (order_feed_sender, order_feed_receiver) = watch::channel::<Option<Order>>(None);
-        let (update_cfd_feed_sender, _) = watch::channel::<UpdateCfdProposals>(HashMap::new());
-        let (quote_sender, _) = watch::channel::<Quote>(dummy_quote);
-
-        let (connected_takers_feed_sender, _connected_takers_feed_receiver) =
-            watch::channel::<Vec<TakerId>>(vec![]);
-
-        tasks.add(projection_context.run(projection::Actor::new(
-            cfd_feed_sender,
-            order_feed_sender,
-            quote_sender,
-            update_cfd_feed_sender,
-            connected_takers_feed_sender,
-        )));
+        let (proj_actor, feeds) = projection::Actor::new(vec![], dummy_quote);
+        tasks.add(projection_context.run(proj_actor));
 
         tasks.add(connect(
             taker.maker_online_status_feed_receiver.clone(),
@@ -325,10 +294,9 @@ impl Taker {
         Self {
             id: TakerId::new(identity_pk),
             system: taker,
+            feeds,
             mocks,
             _tasks: tasks,
-            order_feed_receiver,
-            cfd_feed_receiver,
         }
     }
 


### PR DESCRIPTION
Create watch channels within the actor, returning a single struct called `Feeds`.
Manage the struct with Rocket and use it in SSE events.

Changing the watch channel types etc. will be much easier after this cleanup.