### PR TITLE
Increase the timeout in debug mode to fix CI/bors

### DIFF
--- a/daemon/tests/harness/flow.rs
+++ b/daemon/tests/harness/flow.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use tokio::sync::watch;
 
 /// Waiting time for the time on the watch channel before returning error
-const NEXT_WAIT_TIME: Duration = Duration::from_secs(if cfg!(debug_assertions) { 120 } else { 30 });
+const NEXT_WAIT_TIME: Duration = Duration::from_secs(if cfg!(debug_assertions) { 180 } else { 30 });
 
 /// Returns the first `Cfd` from both channels
 ///


### PR DESCRIPTION
Contract setup test keeps failing when bors runs it.

Note: contract setup got recently refactored into a dedicated actor, this might
     have increased the time it takes to finish the process.