### PR TITLE
Drop windows daemon test on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
   test_daemons:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
Windows build fails sporadically on CI without a clear reason.
As windows support is not our goal for now, disable the job until we explicitly
decide to support windows.