### PR TITLE
Increase heartbeat timeout interval in debug mode to 45s

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -57,7 +57,7 @@ pub mod wire;
 // Increasing the value for debug mode makes sure that we don't cause problems
 // when testing / CI, whilst the release can still detect status faster
 pub const HEARTBEAT_INTERVAL: std::time::Duration =
-    Duration::from_secs(if cfg!(debug_assertions) { 30 } else { 5 });
+    Duration::from_secs(if cfg!(debug_assertions) { 45 } else { 5 });
 
 pub const N_PAYOUTS: usize = 200;
 


### PR DESCRIPTION
As we do not process messages concurrently, heartbeat messages are not processed
during lengthy operations, such as contract setup.

The spam in the amount of commit messages is a bit unfortunate, but only failing
tests on various machines can indicate that the timing might cause issues.