### PR TITLE
Workaround tags not being fetched correctly

### DIFF
--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -42,6 +42,9 @@ jobs:
           ref: ${{ github.event.release.target_commitish }}
           token: ${{ secrets.ITCHY_GITHUB_TOKEN }}
 
+      - name: Fetch all tags (workaround for https://github.com/actions/checkout/issues/290)
+        run: git fetch --tags --force
+
       - name: Install toolchain from `rust-toolchain.toml`
         run: rustup show
 


### PR DESCRIPTION
This results in the version within the container being displayed
incorrectly (always 0.1.1).

Fixes https://github.com/itchysats/itchysats/issues/537.
