### PR TITLE
Log target = module

### DIFF
--- a/daemon/src/logger.rs
+++ b/daemon/src/logger.rs
@@ -20,8 +20,7 @@ pub fn init(level: LevelFilter, json_format: bool) -> Result<()> {
         .with_env_filter(filter)
         .with_writer(std::io::stderr)
         .with_ansi(is_terminal)
-        .with_timer(ChronoLocal::with_format("%F %T".to_owned()))
-        .with_target(false);
+        .with_timer(ChronoLocal::with_format("%F %T".to_owned()));
 
     if json_format {
         builder.json().init();


### PR DESCRIPTION
```
2021-11-30 16:39:33  INFO daemon::logger: Initialized logger
2021-11-30 16:39:33  INFO taker: Running version: 0.1.2-11-g09cfe03
```

instead of

```
2021-11-30 14:33:14  INFO Initialized logger
2021-11-30 14:33:14  INFO Running version: 0.1.1-367-gcbc42b6
```

Makes it way easier to interpret logs because we have context who logged what.