### PR TITLE
Replace automated reconnecting with button in UI

### DIFF
--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -164,19 +164,13 @@ async fn collaboratively_close_an_open_cfd() {
 #[tokio::test]
 async fn taker_notices_lack_of_maker() {
     let short_interval = Duration::from_secs(1);
-
     let _guard = init_tracing();
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-
-    let local_addr = listener.local_addr().unwrap();
-
     let maker_config = MakerConfig::default().with_heartbeat_interval(short_interval);
-
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let maker = Maker::start(&maker_config, listener).await;
 
     let taker_config = TakerConfig::default().with_heartbeat_timeout(short_interval * 2);
-
     let mut taker = Taker::start(&taker_config, maker.listen_addr, maker.identity).await;
 
     assert_eq!(
@@ -190,17 +184,6 @@ async fn taker_notices_lack_of_maker() {
 
     assert_eq!(
         ConnectionStatus::Offline { reason: None },
-        next(taker.maker_status_feed()).await.unwrap(),
-    );
-
-    let listener = tokio::net::TcpListener::bind(local_addr).await.unwrap();
-
-    let _maker = Maker::start(&maker_config, listener).await;
-
-    sleep(taker_config.heartbeat_timeout).await;
-
-    assert_eq!(
-        ConnectionStatus::Online,
         next(taker.maker_status_feed()).await.unwrap(),
     );
 }

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -1,4 +1,4 @@
-import { HamburgerIcon, MoonIcon, SunIcon } from "@chakra-ui/icons";
+import { HamburgerIcon, LinkIcon, MoonIcon, SunIcon } from "@chakra-ui/icons";
 import {
     Box,
     Button,
@@ -18,6 +18,7 @@ import { useNavigate } from "react-router-dom";
 import logoBlack from "../images/logo_nav_bar_black.svg";
 import logoWhite from "../images/logo_nav_bar_white.svg";
 import { ConnectionCloseReason, ConnectionStatus, WalletInfo } from "../types";
+import usePostRequest from "../usePostRequest";
 
 interface NavProps {
     walletInfo: WalletInfo | null;
@@ -49,6 +50,7 @@ export default function Nav({ walletInfo, connectedToMaker }: NavProps) {
                 break;
         }
     }
+    let [connect, isConnecting] = usePostRequest<{}, {}>("/api/connect");
 
     return (
         <>
@@ -71,6 +73,14 @@ export default function Nav({ walletInfo, connectedToMaker }: NavProps) {
                     <Heading size={"sm"}>{"Maker status: " + connectionMessage}</Heading>
                     <Flex alignItems={"center"}>
                         <Stack direction={"row"} spacing={7}>
+                            <Button
+                                onClick={() => connect({})}
+                                disabled={connectedToMaker.online}
+                                isLoading={isConnecting}
+                                rightIcon={<LinkIcon />}
+                            >
+                                Reconnect
+                            </Button>
                             <Button onClick={toggleColorMode} bg={"transparent"}>
                                 {toggleIcon}
                             </Button>


### PR DESCRIPTION
Not only does this simplify the implementation a bit, it also gives
the user more control and a way of actioning an error state. It is
also more efficient because we don't try to re-connect in an endless
loop.

When disconnected:

![image](https://user-images.githubusercontent.com/5486389/144529104-b455027f-b0e7-432e-81d9-245dbd9aaff8.png)

When connected:

![image](https://user-images.githubusercontent.com/5486389/144529184-eb289678-21f6-460d-89da-899f57150900.png)
