### PR TITLE
Upgrade to Rust 1.57

### DIFF
--- a/daemon/src/housekeeping.rs
+++ b/daemon/src/housekeeping.rs
@@ -38,7 +38,7 @@ async fn rebroadcast_transactions(
 ) -> Result<()> {
     let cfds = load_all_cfds(conn).await?;
 
-    for dlc in cfds.iter().filter_map(|cfd| Cfd::pending_open_dlc(cfd)) {
+    for dlc in cfds.iter().filter_map(Cfd::pending_open_dlc) {
         let txid = try_continue!(wallet
             .send(wallet::TryBroadcastTransaction {
                 tx: dlc.lock.0.clone()

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -80,6 +80,7 @@ pub const SETTLEMENT_INTERVAL: time::Duration = time::Duration::hours(24);
 /// Struct controlling the lifetime of the async tasks,
 /// such as running actors and periodic notifications.
 /// If it gets dropped, all tasks are cancelled.
+#[derive(Default)]
 pub struct Tasks(Vec<RemoteHandle<()>>);
 
 impl Tasks {
@@ -89,12 +90,6 @@ impl Tasks {
     pub fn add(&mut self, f: impl Future<Output = ()> + Send + 'static) {
         let handle = f.spawn_with_handle();
         self.0.push(handle);
-    }
-}
-
-impl Default for Tasks {
-    fn default() -> Self {
-        Tasks(vec![])
     }
 }
 

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -1663,6 +1663,7 @@ impl CollaborativeSettlement {
 
 /// Message sent from a setup actor to the
 /// cfd actor to notify that the contract setup has finished.
+#[allow(clippy::large_enum_variant)]
 pub enum Completed {
     NewContract {
         order_id: OrderId,

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -587,7 +587,6 @@ struct Cet {
     txid: Txid,
     script: Script,
     range: RangeInclusive<u64>,
-    n_bits: usize,
 }
 
 impl From<model::cfd::Cet> for Cet {
@@ -596,7 +595,6 @@ impl From<model::cfd::Cet> for Cet {
             txid: cet.tx.txid(),
             script: cet.tx.output[0].script_pubkey.clone(),
             range: cet.range.clone(),
-            n_bits: cet.n_bits,
         }
     }
 }

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -352,7 +352,6 @@ mod olivia_api {
     #[derive(Debug, Clone, serde::Deserialize)]
     pub struct Announcement {
         oracle_event: OracleEvent,
-        signature: String,
     }
 
     #[derive(Debug, Clone, serde::Deserialize)]
@@ -373,8 +372,6 @@ mod olivia_api {
     pub struct Attestation {
         outcome: String,
         schemes: Schemes,
-        #[serde(with = "timestamp")]
-        time: OffsetDateTime,
     }
 
     #[derive(Debug, Clone, serde::Deserialize)]

--- a/daemon/src/payout_curve.rs
+++ b/daemon/src/payout_curve.rs
@@ -191,8 +191,6 @@ pub enum Error {
 struct PayoutCurve {
     curve: Curve,
     has_upper_limit: bool,
-    lower_corner: f64,
-    upper_corner: f64,
     total_value: f64,
 }
 
@@ -222,7 +220,6 @@ impl PayoutCurve {
             curve_factory::fit(payout, bounds.0, bounds.1, Some(tolerance), None)?;
         curve.append(variable_payout)?;
 
-        let upper_corner;
         if bounds.2 {
             let upper_liquidation = curve_factory::line(
                 (bounds.1, total_value),
@@ -230,16 +227,11 @@ impl PayoutCurve {
                 false,
             )?;
             curve.append(upper_liquidation)?;
-            upper_corner = bounds.1;
-        } else {
-            upper_corner = curve.spline.bases[0].end();
-        }
+        };
 
         Ok(PayoutCurve {
             curve,
             has_upper_limit: bounds.2,
-            lower_corner: bounds.0,
-            upper_corner,
             total_value,
         })
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.56"
+channel = "1.57"
 components = ["clippy"]
 targets = ["aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
The clippy version included with 1.57 flagged several problems:

1. Multiple fields were never read, removed those.
2. The `Default` impl on `Tasks` could be derived.
3. A redundant closure
4. A large enum variant
