### PR TITLE
Simplify wallet actor

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -161,8 +161,7 @@ async fn main() -> Result<()> {
         opts.network.electrum(),
         &data_dir.join("maker_wallet.sqlite"),
         ext_priv_key,
-    )
-    .await?
+    )?
     .create(None)
     .run();
     let _wallet_handle = wallet_fut.spawn_with_handle();

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -171,8 +171,7 @@ async fn main() -> Result<()> {
         opts.network.electrum(),
         &data_dir.join("taker_wallet.sqlite"),
         ext_priv_key,
-    )
-    .await?
+    )?
     .create(None)
     .run();
     let _wallet_handle = wallet_fut.spawn_with_handle();


### PR DESCRIPTION
We don't need to `Clone` the wallet actor ever so we can remove this
custom derive which allows us to also drop the `Arc<Mutex>` of the
`bdk::Wallet`, thus simplifying all of the handlers quite a bit.

We also add `&mut` to all handlers. Even though not strictly necessary
(because they are processed by `xtra-productivity`), it is more correct
to write `&mut self` because that is what the macro will output anyway.
