### PR TITLE
Allow projection actor to retrieve latest Cfd state itself from DB

### DIFF
--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -4,15 +4,13 @@ use anyhow::{bail, Context, Result};
 use sqlx::pool::PoolConnection;
 use sqlx::Sqlite;
 
-pub async fn insert_cfd_and_send_to_feed(
+pub async fn insert_cfd_and_update_feed(
     cfd: &Cfd,
     conn: &mut PoolConnection<Sqlite>,
     projection_address: &xtra::Address<projection::Actor>,
 ) -> Result<()> {
     db::insert_cfd(cfd, conn).await?;
-    projection_address
-        .send(projection::Update(db::load_all_cfds(conn).await?))
-        .await?;
+    projection_address.send(projection::CfdsChanged).await??;
     Ok(())
 }
 
@@ -22,9 +20,7 @@ pub async fn append_cfd_state(
     projection_address: &xtra::Address<projection::Actor>,
 ) -> Result<()> {
     db::append_cfd_state(cfd, conn).await?;
-    projection_address
-        .send(projection::Update(db::load_all_cfds(conn).await?))
-        .await?;
+    projection_address.send(projection::CfdsChanged).await??;
     Ok(())
 }
 

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -1,5 +1,5 @@
 use crate::address_map::{AddressMap, Stopping};
-use crate::cfd_actors::{self, append_cfd_state, insert_cfd_and_send_to_feed};
+use crate::cfd_actors::{self, append_cfd_state, insert_cfd_and_update_feed};
 use crate::db::{insert_order, load_cfd_by_order_id, load_order_by_id};
 use crate::model::cfd::{
     Cfd, CfdState, CfdStateCommon, CollaborativeSettlement, Dlc, Order, OrderId, Origin, Role,
@@ -478,7 +478,7 @@ where
                 taker_id,
             },
         );
-        insert_cfd_and_send_to_feed(&cfd, &mut conn, &self.projection_actor).await?;
+        insert_cfd_and_update_feed(&cfd, &mut conn, &self.projection_actor).await?;
 
         // 4. Try to get the oracle announcement, if that fails we should exit prior to changing any
         // state

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -1,5 +1,5 @@
 use crate::address_map::AddressMap;
-use crate::cfd_actors::{self, append_cfd_state, insert_cfd_and_send_to_feed};
+use crate::cfd_actors::{self, append_cfd_state, insert_cfd_and_update_feed};
 use crate::db::{insert_order, load_cfd_by_order_id, load_order_by_id};
 use crate::model::cfd::{
     Cfd, CfdState, CfdStateCommon, Completed, Dlc, Order, OrderId, Origin, Role, RollOverProposal,
@@ -416,7 +416,7 @@ where
             CfdState::outgoing_order_request(),
         );
 
-        insert_cfd_and_send_to_feed(&cfd, &mut conn, &self.projection_actor).await?;
+        insert_cfd_and_update_feed(&cfd, &mut conn, &self.projection_actor).await?;
 
         // Cleanup own order feed, after inserting the cfd.
         // Due to the 1:1 relationship between order and cfd we can never create another cfd for the

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -147,7 +147,7 @@ impl Maker {
         // system startup sends sync messages, mock them
         mocks.mock_sync_handlers().await;
         let maker = daemon::MakerActorSystem::new(
-            db,
+            db.clone(),
             wallet_addr,
             config.oracle_pk,
             |_, _| oracle,
@@ -169,7 +169,9 @@ impl Maker {
         .unwrap();
 
         let (proj_actor, feeds) =
-            projection::Actor::new(Role::Maker, Network::Testnet, vec![], dummy_quote());
+            projection::Actor::new(db, Role::Maker, Network::Testnet, dummy_quote())
+                .await
+                .unwrap();
         tasks.add(projection_context.run(proj_actor));
 
         let address = listener.local_addr().unwrap();
@@ -280,7 +282,7 @@ impl Taker {
         // system startup sends sync messages, mock them
         mocks.mock_sync_handlers().await;
         let taker = daemon::TakerActorSystem::new(
-            db,
+            db.clone(),
             wallet_addr,
             config.oracle_pk,
             identity_sk,
@@ -295,7 +297,9 @@ impl Taker {
         .unwrap();
 
         let (proj_actor, feeds) =
-            projection::Actor::new(Role::Taker, Network::Testnet, vec![], dummy_quote());
+            projection::Actor::new(db, Role::Taker, Network::Testnet, dummy_quote())
+                .await
+                .unwrap();
         tasks.add(projection_context.run(proj_actor));
 
         tasks.add(connect(


### PR DESCRIPTION
Instead of retrieving Cfds inside Cfd actors, send a msg that they changed and
retrieve them by the projection actor itself.