### PR TITLE
Settle CFDs after 7 days

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -75,7 +75,7 @@ pub const N_PAYOUTS: usize = 200;
 /// - How the oracle event id is chosen when creating an order (maker)
 /// - The sliding window of cached oracle announcements (maker, taker)
 /// - The auto-rollover time-window (taker)
-pub const SETTLEMENT_INTERVAL: time::Duration = time::Duration::hours(2);
+pub const SETTLEMENT_INTERVAL: time::Duration = time::Duration::days(7);
 
 /// Struct controlling the lifetime of the async tasks,
 /// such as running actors and periodic notifications.


### PR DESCRIPTION
Only merge before the final release for umbrel. We want to have long running CFDs until we have auto rollover.