### PR TITLE
Allow maker to control lock and commit transaction fee rate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "maia"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/maia?branch=temp-bdk-dependency#45e886ef9e04ce37c26b628abe143fd98e967fdd"
+source = "git+https://github.com/comit-network/maia#baaad94a10291d4e55c3d2cd30f3736035ee10ea"
 dependencies = [
  "anyhow",
  "bdk",
@@ -2618,8 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-zkp"
-version = "0.4.0"
-source = "git+https://github.com/ElementsProject/rust-secp256k1-zkp#c8ff901516c9c299c9cc7331b15a7a14a05ced89"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e2709b09561dfb584b366bd418ee5549a858873baa707ed83d3eb986e34abf"
 dependencies = [
  "rand 0.6.5",
  "secp256k1",
@@ -2629,8 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-zkp-sys"
-version = "0.4.0"
-source = "git+https://github.com/ElementsProject/rust-secp256k1-zkp#c8ff901516c9c299c9cc7331b15a7a14a05ced89"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c48e70d04fdd871498db6ac3b35eeae0a339ab1cd06af483fe8a6835d36def"
 dependencies = [
  "cc",
  "secp256k1-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ resolver = "2"
 [patch.crates-io]
 rocket = { git = "https://github.com/SergioBenitez/Rocket" } # Need to patch rocket dependency of `rocket_basicauth` until there is an official release.
 xtra = { git = "https://github.com/Restioson/xtra" } # We need to use unreleased patches.
-secp256k1-zkp = { git = "https://github.com/ElementsProject/rust-secp256k1-zkp" } # We need to use unreleased patches.
-maia = { git = "https://github.com/comit-network/maia", branch = "temp-bdk-dependency" } # Unreleased
+maia = { git = "https://github.com/comit-network/maia" } # Unreleased
 xtra_productivity = { git = "https://github.com/comit-network/xtra-productivity" } # Unreleased
 bdk = { git = "https://github.com/bitcoindevkit/bdk" } # Unreleased

--- a/daemon/migrations/20211207035936_add-fee-to-order.sql
+++ b/daemon/migrations/20211207035936_add-fee-to-order.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+ALTER TABLE orders ADD COLUMN fee_rate not null default 1;

--- a/daemon/sqlx-data.json
+++ b/daemon/sqlx-data.json
@@ -1,25 +1,7 @@
 {
   "db": "SQLite",
-  "221a6283db798bacaba99e7e85130f9a8bbea1299d8cb99d272b1d478dc19775": {
-    "query": "\n        select\n            state\n        from cfd_states\n        where cfd_id = $1\n        order by id desc\n        limit 1;\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "state",
-          "ordinal": 0,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "3d41b8a81df84252dae228d8512b7491416520a6ad89561f67cdfb673f864a5a": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n        ",
+  "047070578f79ceaa739c1b307d138ee30e3a8730c4ac357213801e23d73f2841": {
+    "query": "\n        select\n            uuid as \"uuid: crate::model::cfd::OrderId\",\n            trading_pair as \"trading_pair: crate::model::TradingPair\",\n            position as \"position: crate::model::Position\",\n            initial_price as \"initial_price: crate::model::Price\",\n            min_quantity as \"min_quantity: crate::model::Usd\",\n            max_quantity as \"max_quantity: crate::model::Usd\",\n            leverage as \"leverage: crate::model::Leverage\",\n            liquidation_price as \"liquidation_price: crate::model::Price\",\n            creation_timestamp_seconds as \"ts_secs: crate::model::Timestamp\",\n            settlement_time_interval_seconds as \"settlement_time_interval_secs: i64\",\n            origin as \"origin: crate::model::cfd::Origin\",\n            oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            fee_rate as \"fee_rate: u32\"\n        from\n            orders\n        where\n            uuid = $1\n        ",
     "describe": {
       "columns": [
         {
@@ -83,13 +65,126 @@
           "type_info": "Text"
         },
         {
-          "name": "quantity_usd: crate::model::Usd",
+          "name": "fee_rate: u32",
           "ordinal": 12,
+          "type_info": "Null"
+        }
+      ],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "221a6283db798bacaba99e7e85130f9a8bbea1299d8cb99d272b1d478dc19775": {
+    "query": "\n        select\n            state\n        from cfd_states\n        where cfd_id = $1\n        order by id desc\n        limit 1;\n        ",
+    "describe": {
+      "columns": [
+        {
+          "name": "state",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "278833084178753ca86aa8bf9ac50fad8b6fd22dd978e2c803a8b7ba79bd5e1d": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id,\n                fee_rate\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            ord.fee_rate as \"fee_rate: u32\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n        ",
+    "describe": {
+      "columns": [
+        {
+          "name": "uuid: crate::model::cfd::OrderId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "trading_pair: crate::model::TradingPair",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: crate::model::Position",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price: crate::model::Price",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "min_quantity: crate::model::Usd",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "max_quantity: crate::model::Usd",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "leverage: crate::model::Leverage",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "liquidation_price: crate::model::Price",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "ts_secs: crate::model::Timestamp",
+          "ordinal": 8,
+          "type_info": "Int64"
+        },
+        {
+          "name": "settlement_time_interval_secs: i64",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "origin: crate::model::cfd::Origin",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "oracle_event_id: crate::model::BitMexPriceEventId",
+          "ordinal": 11,
+          "type_info": "Text"
+        },
+        {
+          "name": "fee_rate: u32",
+          "ordinal": 12,
+          "type_info": "Null"
+        },
+        {
+          "name": "quantity_usd: crate::model::Usd",
+          "ordinal": 13,
           "type_info": "Text"
         },
         {
           "name": "state",
-          "ordinal": 13,
+          "ordinal": 14,
           "type_info": "Text"
         }
       ],
@@ -110,12 +205,13 @@
         false,
         false,
         false,
+        false,
         false
       ]
     }
   },
-  "414ecf7f0cfce0a1a482b1b430d960867df835aae7fe1b306aa7f22353795dcf": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.uuid = $1\n        ",
+  "898c1f59733397d90d39a73e160f47ab8dc68322f5b421056ffdf38c911cac2d": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id,\n                fee_rate\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            ord.fee_rate as \"fee_rate: u32\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.oracle_event_id = $1\n        ",
     "describe": {
       "columns": [
         {
@@ -179,13 +275,18 @@
           "type_info": "Text"
         },
         {
-          "name": "quantity_usd: crate::model::Usd",
+          "name": "fee_rate: u32",
           "ordinal": 12,
+          "type_info": "Null"
+        },
+        {
+          "name": "quantity_usd: crate::model::Usd",
+          "ordinal": 13,
           "type_info": "Text"
         },
         {
           "name": "state",
-          "ordinal": 13,
+          "ordinal": 14,
           "type_info": "Text"
         }
       ],
@@ -196,89 +297,6 @@
         false,
         false,
         false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "5569292de42c8ce5cff83beb43af1f8e6c3c12b17e740550c1303a1a6d151100": {
-    "query": "\n        select\n            uuid as \"uuid: crate::model::cfd::OrderId\",\n            trading_pair as \"trading_pair: crate::model::TradingPair\",\n            position as \"position: crate::model::Position\",\n            initial_price as \"initial_price: crate::model::Price\",\n            min_quantity as \"min_quantity: crate::model::Usd\",\n            max_quantity as \"max_quantity: crate::model::Usd\",\n            leverage as \"leverage: crate::model::Leverage\",\n            liquidation_price as \"liquidation_price: crate::model::Price\",\n            creation_timestamp_seconds as \"ts_secs: crate::model::Timestamp\",\n            settlement_time_interval_seconds as \"settlement_time_interval_secs: i64\",\n            origin as \"origin: crate::model::cfd::Origin\",\n            oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\"\n        from\n            orders\n        where\n            uuid = $1\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "uuid: crate::model::cfd::OrderId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "trading_pair: crate::model::TradingPair",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "position: crate::model::Position",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "initial_price: crate::model::Price",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "min_quantity: crate::model::Usd",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "max_quantity: crate::model::Usd",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "leverage: crate::model::Leverage",
-          "ordinal": 6,
-          "type_info": "Int64"
-        },
-        {
-          "name": "liquidation_price: crate::model::Price",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "ts_secs: crate::model::Timestamp",
-          "ordinal": 8,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_secs: i64",
-          "ordinal": 9,
-          "type_info": "Int64"
-        },
-        {
-          "name": "origin: crate::model::cfd::Origin",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "oracle_event_id: crate::model::BitMexPriceEventId",
-          "ordinal": 11,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": [
         false,
         false,
         false,
@@ -312,8 +330,8 @@
       ]
     }
   },
-  "f822252e3d3eb70a03300529d8de8f553e8d97b1aac72fb964cbde49d65fe153": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.oracle_event_id = $1\n        ",
+  "a6031f4720d1c6acf7043c9f9ee5035f5ffea0520220ad6b578b7ad0117ab58f": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id,\n                fee_rate\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            ord.fee_rate as \"fee_rate: u32\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.uuid = $1\n        ",
     "describe": {
       "columns": [
         {
@@ -377,13 +395,18 @@
           "type_info": "Text"
         },
         {
-          "name": "quantity_usd: crate::model::Usd",
+          "name": "fee_rate: u32",
           "ordinal": 12,
+          "type_info": "Null"
+        },
+        {
+          "name": "quantity_usd: crate::model::Usd",
+          "ordinal": 13,
           "type_info": "Text"
         },
         {
           "name": "state",
-          "ordinal": 13,
+          "ordinal": 14,
           "type_info": "Text"
         }
       ],
@@ -391,6 +414,7 @@
         "Right": 1
       },
       "nullable": [
+        false,
         false,
         false,
         false,

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -58,6 +58,7 @@ pub struct NewOrder {
     pub price: Price,
     pub min_quantity: Usd,
     pub max_quantity: Usd,
+    pub fee_rate: u32,
 }
 
 pub struct TakerConnected {
@@ -739,6 +740,7 @@ where
                 cfd.quantity_usd,
                 cfd.order.leverage,
                 cfd.refund_timelock_in_blocks(),
+                cfd.order.fee_rate,
             ),
             Role::Maker,
             dlc,
@@ -908,6 +910,7 @@ where
             price,
             min_quantity,
             max_quantity,
+            fee_rate,
         } = msg;
 
         let oracle_event_id = oracle::next_announcement_after(
@@ -921,6 +924,7 @@ where
             Origin::Ours,
             oracle_event_id,
             self.settlement_interval,
+            fee_rate,
         )?;
 
         // 1. Save to DB

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -123,6 +123,8 @@ pub struct Order {
     ///
     /// The maker includes this into the Order based on the Oracle announcement to be used.
     pub oracle_event_id: BitMexPriceEventId,
+
+    pub fee_rate: u32,
 }
 
 impl Order {
@@ -133,6 +135,7 @@ impl Order {
         origin: Origin,
         oracle_event_id: BitMexPriceEventId,
         settlement_interval: Duration,
+        fee_rate: u32,
     ) -> Result<Self> {
         let leverage = Leverage::new(2)?;
         let liquidation_price = calculate_long_liquidation_price(leverage, price);
@@ -150,6 +153,7 @@ impl Order {
             settlement_interval,
             origin,
             oracle_event_id,
+            fee_rate,
         })
     }
 }

--- a/daemon/src/rollover_taker.rs
+++ b/daemon/src/rollover_taker.rs
@@ -108,6 +108,7 @@ impl Actor {
                 self.cfd.quantity_usd,
                 self.cfd.order.leverage,
                 self.cfd.refund_timelock_in_blocks(),
+                self.cfd.order.fee_rate,
             ),
             Role::Taker,
             self.cfd.dlc().context("No DLC in CFD")?,

--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -91,6 +91,7 @@ pub struct CfdNewOrderRequest {
     // always 1 USD
     pub min_quantity: Usd,
     pub max_quantity: Usd,
+    pub fee_rate: Option<u32>,
 }
 
 #[rocket::post("/order/sell", data = "<order>")]
@@ -104,6 +105,7 @@ pub async fn post_sell_order(
             price: order.price,
             min_quantity: order.min_quantity,
             max_quantity: order.max_quantity,
+            fee_rate: order.fee_rate.unwrap_or(1),
         })
         .await
         .unwrap_or_else(|e| anyhow::bail!(e))

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -33,6 +33,7 @@ pub struct SetupParams {
     quantity: Usd,
     leverage: Leverage,
     refund_timelock: u32,
+    fee_rate: u32,
 }
 
 impl SetupParams {
@@ -43,6 +44,7 @@ impl SetupParams {
         quantity: Usd,
         leverage: Leverage,
         refund_timelock: u32,
+        fee_rate: u32,
     ) -> Self {
         Self {
             margin,
@@ -51,6 +53,7 @@ impl SetupParams {
             quantity,
             leverage,
             refund_timelock,
+            fee_rate,
         }
     }
 }
@@ -76,6 +79,7 @@ pub async fn new(
         .send(wallet::BuildPartyParams {
             amount: setup_params.margin,
             identity_pk: pk,
+            fee_rate: setup_params.fee_rate,
         })
         .await
         .context("Failed to send message to wallet actor")?
@@ -129,6 +133,7 @@ pub async fn new(
         (model::cfd::Cfd::CET_TIMELOCK, setup_params.refund_timelock),
         payouts,
         sk,
+        setup_params.fee_rate,
     )
     .context("Failed to create CFD transactions")?;
 
@@ -312,15 +317,23 @@ pub struct RolloverParams {
     quantity: Usd,
     leverage: Leverage,
     refund_timelock: u32,
+    fee_rate: u32,
 }
 
 impl RolloverParams {
-    pub fn new(price: Price, quantity: Usd, leverage: Leverage, refund_timelock: u32) -> Self {
+    pub fn new(
+        price: Price,
+        quantity: Usd,
+        leverage: Leverage,
+        refund_timelock: u32,
+        fee_rate: u32,
+    ) -> Self {
         Self {
             price,
             quantity,
             leverage,
             refund_timelock,
+            fee_rate,
         }
     }
 }
@@ -419,6 +432,7 @@ pub async fn roll_over(
         ),
         payouts,
         sk,
+        rollover_params.fee_rate,
     )
     .context("Failed to create new CFD transactions")?;
 

--- a/daemon/src/setup_maker.rs
+++ b/daemon/src/setup_maker.rs
@@ -94,6 +94,7 @@ impl Actor {
                 cfd.quantity_usd,
                 cfd.order.leverage,
                 cfd.refund_timelock_in_blocks(),
+                cfd.order.fee_rate,
             ),
             self.build_party_params.clone_channel(),
             self.sign.clone_channel(),

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -86,6 +86,7 @@ impl Actor {
                 cfd.quantity_usd,
                 cfd.order.leverage,
                 cfd.refund_timelock_in_blocks(),
+                cfd.order.fee_rate,
             ),
             self.build_party_params.clone_channel(),
             self.sign.clone_channel(),

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -403,6 +403,7 @@ pub fn dummy_new_order() -> maker_cfd::NewOrder {
         price: dummy_price(),
         min_quantity: Usd::new(dec!(5)),
         max_quantity: Usd::new(dec!(100)),
+        fee_rate: 1,
     }
 }
 


### PR DESCRIPTION
resolves #677

Temporarily we also use the same fee rate as for the tx_lock for tx_commit. With #491 this should go away again. 