### PR TITLE
Keep BitMex API connection API open

### DIFF
--- a/daemon/src/bitmex_price_feed.rs
+++ b/daemon/src/bitmex_price_feed.rs
@@ -43,7 +43,7 @@ impl Actor {
         self.tasks.add(connect_until_successful(this));
     }
 
-    async fn handle(&mut self, _: Connect, ctx: &mut xtra::Context<Self>) -> Result<Quote> {
+    async fn handle(&mut self, _: Connect, ctx: &mut xtra::Context<Self>) -> Result<()> {
         tracing::debug!("Connecting to BitMex realtime API");
 
         let (connection, _) = tokio_tungstenite::connect_async(URL).await?;
@@ -54,8 +54,6 @@ impl Actor {
             .fuse();
 
         tracing::info!("Connected to BitMex realtime API");
-
-        let initial_quote = quotes.select_next_some().await?;
 
         let this = ctx.address().expect("we are alive");
 
@@ -78,7 +76,7 @@ impl Actor {
             }
         });
 
-        Ok(initial_quote)
+        Ok(())
     }
 }
 

--- a/daemon/src/bitmex_price_feed.rs
+++ b/daemon/src/bitmex_price_feed.rs
@@ -1,9 +1,10 @@
 use crate::model::{Price, Timestamp};
 use crate::{projection, Tasks};
 use anyhow::Result;
-use futures::{StreamExt, TryStreamExt};
+use futures::{SinkExt, TryStreamExt};
 use rust_decimal::Decimal;
 use std::convert::TryFrom;
+use std::time::Duration;
 use tokio_tungstenite::tungstenite;
 use xtra::prelude::MessageChannel;
 use xtra_productivity::xtra_productivity;
@@ -31,7 +32,7 @@ impl Actor {
     async fn handle(&mut self, msg: NotifyNoConnection, ctx: &mut xtra::Context<Self>) {
         match msg {
             NotifyNoConnection::Failed { error } => {
-                tracing::warn!("Connection to BitMex realtime API failed: {:#}", error)
+                tracing::warn!("Connection to BitMex realtime API failed: {}", error)
             }
             NotifyNoConnection::StreamEnded => {
                 tracing::warn!("Connection to BitMex realtime API closed")
@@ -46,12 +47,7 @@ impl Actor {
     async fn handle(&mut self, _: Connect, ctx: &mut xtra::Context<Self>) -> Result<()> {
         tracing::debug!("Connecting to BitMex realtime API");
 
-        let (connection, _) = tokio_tungstenite::connect_async(URL).await?;
-        let mut quotes = connection
-            .map(|msg| Quote::from_message(msg?))
-            .filter_map(|result| async move { result.transpose() })
-            .boxed()
-            .fuse();
+        let (mut connection, _) = tokio_tungstenite::connect_async(URL).await?;
 
         tracing::info!("Connected to BitMex realtime API");
 
@@ -61,14 +57,45 @@ impl Actor {
             let receiver = self.receiver.clone_channel();
             async move {
                 let no_connection = loop {
-                    match quotes.try_next().await {
-                        Ok(Some(quote)) => {
-                            if receiver.send(projection::Update(quote)).await.is_err() {
-                                return; // if the receiver dies, our job is done
+                    tokio::select! {
+                        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                            tracing::trace!("No message from BitMex in the last 5 seconds, pinging");
+                            let _ = connection.send(tungstenite::Message::Ping([0u8; 32].to_vec())).await;
+                        },
+                        msg = connection.try_next() => {
+                            match msg {
+                                Ok(Some(tungstenite::Message::Pong(_))) => {
+                                    tracing::trace!("Received pong");
+                                    continue;
+                                }
+                                Ok(Some(tungstenite::Message::Text(text))) => {
+                                    match Quote::from_str(&text) {
+                                        Ok(None) => {
+                                            continue;
+                                        }
+                                        Ok(Some(quote)) => {
+                                            if receiver.send(projection::Update(quote)).await.is_err() {
+                                                return; // if the receiver dies, our job is done
+                                            }
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!("Failed to parse quote: {:#}", e);
+                                            return;
+                                        }
+                                    }
+                                }
+                                Ok(Some(other)) => {
+                                    tracing::trace!("Unsupported message: {:?}", other);
+                                    continue;
+                                }
+                                Ok(None) => {
+                                    break NotifyNoConnection::StreamEnded
+                                }
+                                Err(e) => {
+                                    break NotifyNoConnection::Failed { error: e }
+                                }
                             }
-                        }
-                        Ok(None) => break NotifyNoConnection::StreamEnded,
-                        Err(e) => break NotifyNoConnection::Failed { error: e },
+                        },
                     }
                 };
 
@@ -93,7 +120,7 @@ async fn connect_until_successful(this: xtra::Address<Actor>) {
 pub struct Connect;
 
 enum NotifyNoConnection {
-    Failed { error: anyhow::Error },
+    Failed { error: tungstenite::Error },
     StreamEnded,
 }
 
@@ -105,16 +132,11 @@ pub struct Quote {
 }
 
 impl Quote {
-    fn from_message(message: tungstenite::Message) -> Result<Option<Self>> {
-        let text_message = match message {
-            tungstenite::Message::Text(text_message) => text_message,
-            _ => anyhow::bail!("Bad message type, only text is supported"),
-        };
-
-        let table_message = match serde_json::from_str::<wire::TableMessage>(&text_message) {
+    fn from_str(text: &str) -> Result<Option<Self>> {
+        let table_message = match serde_json::from_str::<wire::TableMessage>(text) {
             Ok(table_message) => table_message,
             Err(_) => {
-                tracing::trace!(%text_message, "Not a 'table' message, skipping...");
+                tracing::trace!(%text, "Not a 'table' message, skipping...");
                 return Ok(None);
             }
         };
@@ -171,9 +193,7 @@ mod tests {
 
     #[test]
     fn can_deserialize_quote_message() {
-        let message = tungstenite::Message::Text(r#"{"table":"quoteBin1m","action":"insert","data":[{"timestamp":"2021-09-21T02:40:00.000Z","symbol":"XBTUSD","bidSize":50200,"bidPrice":42640.5,"askPrice":42641,"askSize":363600}]}"#.to_owned());
-
-        let quote = Quote::from_message(message).unwrap().unwrap();
+        let quote = Quote::from_str(r#"{"table":"quoteBin1m","action":"insert","data":[{"timestamp":"2021-09-21T02:40:00.000Z","symbol":"XBTUSD","bidSize":50200,"bidPrice":42640.5,"askPrice":42641,"askSize":363600}]}"#).unwrap().unwrap();
 
         assert_eq!(quote.bid, Price::new(dec!(42640.5)).unwrap());
         assert_eq!(quote.ask, Price::new(dec!(42641)).unwrap());

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -262,12 +262,12 @@ async fn main() -> Result<()> {
         .run();
     tasks.add(task);
 
-    let init_quote = price_feed_address
+    price_feed_address
         .send(bitmex_price_feed::Connect)
         .await??;
 
     let (proj_actor, projection_feeds) =
-        projection::Actor::new(db.clone(), Role::Maker, bitcoin_network, init_quote).await?;
+        projection::Actor::new(db.clone(), Role::Maker, bitcoin_network).await?;
     tasks.add(projection_context.run(proj_actor));
 
     let listener_stream = futures::stream::poll_fn(move |ctx| {

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -490,7 +490,7 @@ pub struct Cfd {
 
     #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
     pub profit_btc: SignedAmount,
-    pub profit_in_percent: String,
+    pub profit_percent: String,
 
     pub state: CfdState,
     pub actions: Vec<CfdAction>,
@@ -511,7 +511,7 @@ impl From<CfdsWithAuxData> for Vec<Cfd> {
             .cfds
             .iter()
             .map(|cfd| {
-                let (profit_btc, profit_in_percent) =
+                let (profit_btc, profit_percent) =
                     cfd.profit(current_price).unwrap_or_else(|error| {
                         tracing::warn!(
                             "Calculating profit/loss failed. Falling back to 0. {:#}",
@@ -532,7 +532,7 @@ impl From<CfdsWithAuxData> for Vec<Cfd> {
                     liquidation_price: cfd.order.liquidation_price.into(),
                     quantity_usd: cfd.quantity_usd.into(),
                     profit_btc,
-                    profit_in_percent: profit_in_percent.round_dp(1).to_string(),
+                    profit_percent: profit_percent.round_dp(1).to_string(),
                     state: state.clone(),
                     actions: available_actions(state, cfd.role()),
                     state_transition_timestamp: cfd.state.get_transition_timestamp().seconds(),

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -246,12 +246,12 @@ async fn main() -> Result<()> {
         .run();
     tasks.add(task);
 
-    let init_quote = price_feed_address
+    price_feed_address
         .send(bitmex_price_feed::Connect)
         .await??;
 
     let (proj_actor, projection_feeds) =
-        projection::Actor::new(db.clone(), Role::Taker, bitcoin_network, init_quote).await?;
+        projection::Actor::new(db.clone(), Role::Taker, bitcoin_network).await?;
     tasks.add(projection_context.run(proj_actor));
 
     let possible_addresses = resolve_maker_addresses(&opts.maker).await?;

--- a/daemon/src/to_sse_event.rs
+++ b/daemon/src/to_sse_event.rs
@@ -98,7 +98,7 @@ impl ToSseEvent for connection::ConnectionStatus {
     }
 }
 
-impl ToSseEvent for Quote {
+impl ToSseEvent for Option<Quote> {
     fn to_sse_event(&self) -> Event {
         Event::json(self).event("quote")
     }

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -3,10 +3,9 @@ use crate::harness::mocks::oracle::OracleActor;
 use crate::harness::mocks::wallet::WalletActor;
 use crate::schnorrsig;
 use ::bdk::bitcoin::Network;
-use daemon::bitmex_price_feed::Quote;
 use daemon::connection::{connect, ConnectionStatus};
 use daemon::model::cfd::{OrderId, Role};
-use daemon::model::{self, Price, Timestamp, Usd};
+use daemon::model::{self, Price, Usd};
 use daemon::projection::{Cfd, CfdOrder, Feeds, Identity};
 use daemon::seed::Seed;
 use daemon::{
@@ -168,10 +167,9 @@ impl Maker {
         .await
         .unwrap();
 
-        let (proj_actor, feeds) =
-            projection::Actor::new(db, Role::Maker, Network::Testnet, dummy_quote())
-                .await
-                .unwrap();
+        let (proj_actor, feeds) = projection::Actor::new(db, Role::Maker, Network::Testnet)
+            .await
+            .unwrap();
         tasks.add(projection_context.run(proj_actor));
 
         let address = listener.local_addr().unwrap();
@@ -296,10 +294,9 @@ impl Taker {
         .await
         .unwrap();
 
-        let (proj_actor, feeds) =
-            projection::Actor::new(db, Role::Taker, Network::Testnet, dummy_quote())
-                .await
-                .unwrap();
+        let (proj_actor, feeds) = projection::Actor::new(db, Role::Taker, Network::Testnet)
+            .await
+            .unwrap();
         tasks.add(projection_context.run(proj_actor));
 
         tasks.add(connect(
@@ -388,14 +385,6 @@ async fn in_memory_db() -> SqlitePool {
 
 pub fn dummy_price() -> Price {
     Price::new(dec!(50_000)).expect("to not fail")
-}
-
-pub fn dummy_quote() -> Quote {
-    Quote {
-        timestamp: Timestamp::now(),
-        bid: dummy_price(),
-        ask: dummy_price(),
-    }
 }
 
 pub fn dummy_new_order() -> maker_cfd::NewOrder {

--- a/taker-frontend/src/components/History.tsx
+++ b/taker-frontend/src/components/History.tsx
@@ -8,6 +8,7 @@ import {
     HStack,
     Link,
     SimpleGrid,
+    Skeleton,
     Spinner,
     Table,
     Tbody,
@@ -60,11 +61,6 @@ const CfdDetails = ({ cfd, connectedToMaker }: CfdDetailsProps) => {
     const margin = `₿${Math.round((cfd.margin) * 1_000_000) / 1_000_000}`;
     const liquidationPrice = `$${cfd.liquidation_price}`;
 
-    const pAndLNumber = Math.round((cfd.profit_btc) * 1_000_000) / 1_000_000;
-    const pAndL = pAndLNumber < 0 ? `-₿${Math.abs(pAndLNumber)}` : `₿${Math.abs(pAndLNumber)}`;
-
-    const payout = `₿${Math.round((cfd.margin + cfd.profit_btc) * 1_000_000) / 1_000_000}`;
-
     const txLock = cfd.details.tx_url_list.find((tx) => tx.label === TxLabel.Lock);
     const txCommit = cfd.details.tx_url_list.find((tx) => tx.label === TxLabel.Commit);
     const txRefund = cfd.details.tx_url_list.find((tx) => tx.label === TxLabel.Refund);
@@ -102,11 +98,19 @@ const CfdDetails = ({ cfd, connectedToMaker }: CfdDetailsProps) => {
                         </Tr>
                         <Tr>
                             <Td><Text as={"b"}>Unrealized P/L</Text></Td>
-                            <Td textAlign="right">{pAndL}</Td>
+                            <Td textAlign="right">
+                                <Skeleton isLoaded={cfd.profit_btc != null}>
+                                    <ProfitAndLoss profitBtc={cfd.profit_btc!} />
+                                </Skeleton>
+                            </Td>
                         </Tr>
                         <Tr>
                             <Td><Text as={"b"}>Payout</Text></Td>
-                            <Td textAlign="right">{payout}</Td>
+                            <Td textAlign="right">
+                                <Skeleton isLoaded={cfd.profit_btc != null}>
+                                    <Payout profitBtc={cfd.profit_btc!} margin={cfd.margin} />
+                                </Skeleton>
+                            </Td>
                         </Tr>
                     </Tbody>
                 </Table>
@@ -157,6 +161,33 @@ const CfdDetails = ({ cfd, connectedToMaker }: CfdDetailsProps) => {
         </HStack>
     );
 };
+
+interface ProfitAndLossProps {
+    profitBtc: number;
+}
+
+function ProfitAndLoss({ profitBtc }: ProfitAndLossProps) {
+    const pAndLNumber = Math.round((profitBtc) * 1_000_000) / 1_000_000;
+    const absPAndL = Math.abs(pAndLNumber);
+    const negativeSign = pAndLNumber < 0 ? "-" : "";
+
+    return <Text>
+        {negativeSign}₿{absPAndL}
+    </Text>;
+}
+
+interface PayoutProps {
+    profitBtc: number;
+    margin: number;
+}
+
+function Payout({ profitBtc, margin }: PayoutProps) {
+    let payoutBtc = Math.round((margin + profitBtc) * 1_000_000) / 1_000_000;
+
+    return <Text>
+        ₿{payoutBtc}
+    </Text>;
+}
 
 const CircleIcon = (props: any) => (
     <Icon viewBox="0 0 200 200" {...props}>

--- a/taker-frontend/src/types.ts
+++ b/taker-frontend/src/types.ts
@@ -53,7 +53,7 @@ export interface Cfd {
     margin: number;
 
     profit_btc: number;
-    profit_in_percent: number;
+    profit_percent: number;
 
     state: State;
     state_transition_timestamp: number;

--- a/taker-frontend/src/types.ts
+++ b/taker-frontend/src/types.ts
@@ -52,8 +52,8 @@ export interface Cfd {
 
     margin: number;
 
-    profit_btc: number;
-    profit_percent: number;
+    profit_btc?: number;
+    profit_percent?: number;
 
     state: State;
     state_transition_timestamp: number;


### PR DESCRIPTION
To keep the BitMex API connection open, we need to send `Ping` messages to it.
To send `Ping` messages, we need access to the `Sink` API of the websocket connection.
By get access to the `Sink` API, we must not use any of the `Stream` combinators on the connection.
Not using any of the stream combinators makes it clunky to retrieve an initial quote before we start the loop.

Relying on an initial quote being available has been annoying in the past, and also doesn't help with ideas like https://github.com/itchysats/itchysats/discussions/753.

We also already had some hacky solution in place that defaulted to 0 for errors in calculating the profit.

Fix both problems by rendering only a part of the CFD blank:

![Screenshot from 2021-12-08 11-47-35](https://user-images.githubusercontent.com/5486389/145134380-c85e3cb7-31d6-482f-9ad0-2cdc8745d986.png)

Fixes #736.