### PR TITLE
Counterparty identity

### DIFF
--- a/daemon/migrations/20211208000000_associate_counterpart_identity_with_cfd.sql
+++ b/daemon/migrations/20211208000000_associate_counterpart_identity_with_cfd.sql
@@ -1,0 +1,25 @@
+-- Add migration script here
+drop table cfd_states;
+drop table cfds;
+
+create table if not exists cfds
+(
+    id                    integer primary key autoincrement,
+    order_id              integer unique not null,
+    order_uuid            text unique    not null,
+    quantity_usd          text           not null,
+    counterparty text           not null,
+    foreign key (order_id) references orders (id)
+);
+
+create unique index if not exists cfd_order_uuid
+    on cfds (order_uuid);
+
+create table if not exists cfd_states
+(
+    id     integer primary key autoincrement,
+    cfd_id integer not null,
+    state  text    not null,
+    foreign key (cfd_id) references cfds (id)
+);
+

--- a/daemon/sqlx-data.json
+++ b/daemon/sqlx-data.json
@@ -108,8 +108,8 @@
       ]
     }
   },
-  "278833084178753ca86aa8bf9ac50fad8b6fd22dd978e2c803a8b7ba79bd5e1d": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id,\n                fee_rate\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            ord.fee_rate as \"fee_rate: u32\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n        ",
+  "28d8b9ddd2dd85a9096200e6abd170a09ed35e1c905c081e535e19800016cd7d": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id,\n                fee_rate\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd,\n                counterparty\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                cfd.counterparty,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            ord.fee_rate as \"fee_rate: u32\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.counterparty as \"counterparty: crate::model::Identity\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.uuid = $1\n        ",
     "describe": {
       "columns": [
         {
@@ -183,110 +183,13 @@
           "type_info": "Text"
         },
         {
-          "name": "state",
+          "name": "counterparty: crate::model::Identity",
           "ordinal": 14,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 0
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "898c1f59733397d90d39a73e160f47ab8dc68322f5b421056ffdf38c911cac2d": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id,\n                fee_rate\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            ord.fee_rate as \"fee_rate: u32\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.oracle_event_id = $1\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "uuid: crate::model::cfd::OrderId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "trading_pair: crate::model::TradingPair",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "position: crate::model::Position",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "initial_price: crate::model::Price",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "min_quantity: crate::model::Usd",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "max_quantity: crate::model::Usd",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "leverage: crate::model::Leverage",
-          "ordinal": 6,
-          "type_info": "Int64"
-        },
-        {
-          "name": "liquidation_price: crate::model::Price",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "ts_secs: crate::model::Timestamp",
-          "ordinal": 8,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_secs: i64",
-          "ordinal": 9,
-          "type_info": "Int64"
-        },
-        {
-          "name": "origin: crate::model::cfd::Origin",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "oracle_event_id: crate::model::BitMexPriceEventId",
-          "ordinal": 11,
-          "type_info": "Text"
-        },
-        {
-          "name": "fee_rate: u32",
-          "ordinal": 12,
-          "type_info": "Null"
-        },
-        {
-          "name": "quantity_usd: crate::model::Usd",
-          "ordinal": 13,
           "type_info": "Text"
         },
         {
           "name": "state",
-          "ordinal": 14,
+          "ordinal": 15,
           "type_info": "Text"
         }
       ],
@@ -294,6 +197,7 @@
         "Right": 1
       },
       "nullable": [
+        false,
         false,
         false,
         false,
@@ -330,8 +234,8 @@
       ]
     }
   },
-  "a6031f4720d1c6acf7043c9f9ee5035f5ffea0520220ad6b578b7ad0117ab58f": {
-    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id,\n                fee_rate\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            ord.fee_rate as \"fee_rate: u32\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.uuid = $1\n        ",
+  "ef4fb6c58e79051bd09ad04f59b7896df5228c6c848c999149668d7c733115c2": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id,\n                fee_rate\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd,\n                counterparty\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                cfd.counterparty,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            ord.fee_rate as \"fee_rate: u32\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.counterparty as \"counterparty: crate::model::Identity\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n        ",
     "describe": {
       "columns": [
         {
@@ -405,8 +309,121 @@
           "type_info": "Text"
         },
         {
-          "name": "state",
+          "name": "counterparty: crate::model::Identity",
           "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "state",
+          "ordinal": 15,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 0
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "f6ac595731d61e166b2afaa4923e9f05c75cfad6d1d734ab43e7567d0e29adec": {
+    "query": "\n        with ord as (\n            select\n                id as order_id,\n                uuid,\n                trading_pair,\n                position,\n                initial_price,\n                min_quantity,\n                max_quantity,\n                leverage,\n                liquidation_price,\n                creation_timestamp_seconds as ts_secs,\n                settlement_time_interval_seconds as settlement_time_interval_secs,\n                origin,\n                oracle_event_id,\n                fee_rate\n            from orders\n        ),\n\n        cfd as (\n            select\n                ord.order_id,\n                id as cfd_id,\n                quantity_usd,\n                counterparty\n            from cfds\n                inner join ord on ord.order_id = cfds.order_id\n        ),\n\n        state as (\n            select\n                id as state_id,\n                cfd.order_id,\n                cfd.quantity_usd,\n                cfd.counterparty,\n                state\n            from cfd_states\n                inner join cfd on cfd.cfd_id = cfd_states.cfd_id\n            where id in (\n                select\n                    max(id) as id\n                from cfd_states\n                group by (cfd_id)\n            )\n        )\n\n        select\n            ord.uuid as \"uuid: crate::model::cfd::OrderId\",\n            ord.trading_pair as \"trading_pair: crate::model::TradingPair\",\n            ord.position as \"position: crate::model::Position\",\n            ord.initial_price as \"initial_price: crate::model::Price\",\n            ord.min_quantity as \"min_quantity: crate::model::Usd\",\n            ord.max_quantity as \"max_quantity: crate::model::Usd\",\n            ord.leverage as \"leverage: crate::model::Leverage\",\n            ord.liquidation_price as \"liquidation_price: crate::model::Price\",\n            ord.ts_secs as \"ts_secs: crate::model::Timestamp\",\n            ord.settlement_time_interval_secs as \"settlement_time_interval_secs: i64\",\n            ord.origin as \"origin: crate::model::cfd::Origin\",\n            ord.oracle_event_id as \"oracle_event_id: crate::model::BitMexPriceEventId\",\n            ord.fee_rate as \"fee_rate: u32\",\n            state.quantity_usd as \"quantity_usd: crate::model::Usd\",\n            state.counterparty as \"counterparty: crate::model::Identity\",\n            state.state\n\n        from ord\n            inner join state on state.order_id = ord.order_id\n\n        where ord.oracle_event_id = $1\n        ",
+    "describe": {
+      "columns": [
+        {
+          "name": "uuid: crate::model::cfd::OrderId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "trading_pair: crate::model::TradingPair",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: crate::model::Position",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price: crate::model::Price",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "min_quantity: crate::model::Usd",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "max_quantity: crate::model::Usd",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "leverage: crate::model::Leverage",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "liquidation_price: crate::model::Price",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "ts_secs: crate::model::Timestamp",
+          "ordinal": 8,
+          "type_info": "Int64"
+        },
+        {
+          "name": "settlement_time_interval_secs: i64",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "origin: crate::model::cfd::Origin",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "oracle_event_id: crate::model::BitMexPriceEventId",
+          "ordinal": 11,
+          "type_info": "Text"
+        },
+        {
+          "name": "fee_rate: u32",
+          "ordinal": 12,
+          "type_info": "Null"
+        },
+        {
+          "name": "quantity_usd: crate::model::Usd",
+          "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "counterparty: crate::model::Identity",
+          "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "state",
+          "ordinal": 15,
           "type_info": "Text"
         }
       ],
@@ -414,6 +431,7 @@
         "Right": 1
       },
       "nullable": [
+        false,
         false,
         false,
         false,

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -3,6 +3,7 @@
 use crate::db::load_all_cfds;
 use crate::maker_cfd::{FromTaker, TakerConnected};
 use crate::model::cfd::{Cfd, Order, UpdateCfdProposals};
+use crate::model::Identity;
 use crate::oracle::Attestation;
 use crate::tokio_ext::FutureExt;
 use address_map::Stopping;
@@ -235,6 +236,7 @@ where
         maker_heartbeat_interval: Duration,
         connect_timeout: Duration,
         projection_actor: Address<projection::Actor>,
+        maker_identity: Identity,
     ) -> Result<Self>
     where
         F: Future<Output = Result<M>>,
@@ -261,6 +263,7 @@ where
             monitor_addr.clone(),
             oracle_addr,
             n_payouts,
+            maker_identity,
         )
         .create(None)
         .run();

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -478,6 +478,7 @@ where
                 },
                 taker_id,
             },
+            taker_id,
         );
         insert_cfd_and_update_feed(&cfd, &mut conn, &self.projection_actor).await?;
 

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -577,16 +577,19 @@ pub struct Cfd {
     pub order: Order,
     pub quantity_usd: Usd,
     pub state: CfdState,
+
+    pub counterparty: Identity,
     /* TODO: Leverage is currently derived from the Order, but the actual leverage should be
      * stored in the Cfd once there is multiple choices of leverage */
 }
 
 impl Cfd {
-    pub fn new(order: Order, quantity: Usd, state: CfdState) -> Self {
+    pub fn new(order: Order, quantity: Usd, state: CfdState, counterparty: Identity) -> Self {
         Cfd {
             order,
             quantity_usd: quantity,
             state,
+            counterparty,
         }
     }
 

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -500,6 +500,8 @@ pub struct Cfd {
 
     #[serde(with = "::time::serde::timestamp")]
     pub expiry_timestamp: OffsetDateTime,
+
+    pub counterparty: Identity,
 }
 
 impl From<CfdsWithAuxData> for Vec<Cfd> {
@@ -546,6 +548,7 @@ impl From<CfdsWithAuxData> for Vec<Cfd> {
                         None => cfd.order.oracle_event_id.timestamp(),
                         Some(timestamp) => timestamp,
                     },
+                    counterparty: cfd.counterparty.into(),
                 }
             })
             .collect::<Vec<Cfd>>();

--- a/daemon/src/setup_maker.rs
+++ b/daemon/src/setup_maker.rs
@@ -70,6 +70,7 @@ impl Actor {
             self.order.clone(),
             self.quantity,
             CfdState::contract_setup(),
+            self.taker_id,
         );
 
         let (sender, receiver) = mpsc::unbounded();

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -162,6 +162,8 @@ async fn main() -> Result<()> {
         tokio::fs::create_dir_all(&data_dir).await?;
     }
 
+    let maker_identity = Identity::new(opts.maker_id);
+
     let seed = Seed::initialize(&data_dir.join("taker_seed")).await?;
 
     let bitcoin_network = opts.network.bitcoin_network();
@@ -238,6 +240,7 @@ async fn main() -> Result<()> {
         HEARTBEAT_INTERVAL * 2,
         Duration::from_secs(10),
         projection_actor.clone(),
+        maker_identity,
     )
     .await?;
 
@@ -259,7 +262,7 @@ async fn main() -> Result<()> {
     tasks.add(connect(
         maker_online_status_feed_receiver.clone(),
         connection_actor_addr,
-        Identity::new(opts.maker_id),
+        maker_identity,
         possible_addresses,
     ));
 

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -292,6 +292,7 @@ impl Taker {
             config.heartbeat_timeout,
             Duration::from_secs(10),
             projection_actor,
+            maker_identity,
         )
         .await
         .unwrap();

--- a/maker-frontend/src/components/Types.tsx
+++ b/maker-frontend/src/components/Types.tsx
@@ -50,6 +50,8 @@ export interface Cfd {
     state_transition_timestamp: number;
     details: CfdDetails;
     expiry_timestamp: number;
+
+    counterparty: string;
 }
 
 export interface CfdDetails {

--- a/taker-frontend/src/types.ts
+++ b/taker-frontend/src/types.ts
@@ -59,6 +59,8 @@ export interface Cfd {
     state_transition_timestamp: number;
     details: CfdDetails;
     expiry_timestamp: number;
+
+    counterparty: string;
 }
 
 export interface CfdDetails {


### PR DESCRIPTION
Disclaimer: This resets the database! - i.e. it drops `cfd_states` and `cfds` and re-creates them. 

Since there are no users this does not matter, but for those how were testing on mainnet ( @klochowicz ): Remaining open will be committed + cet from the maker side.