### PR TITLE
Serialize expiry_timestamp in Cfd

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -506,6 +506,7 @@ pub struct Cfd {
 
     pub details: CfdDetails,
 
+    #[serde(with = "::time::serde::timestamp::option")]
     pub expiry_timestamp: Option<OffsetDateTime>,
 
     pub counterparty: Identity,


### PR DESCRIPTION
resolves #888

The automation needs this field to know when to close positions.