### PR TITLE
Rename database function for loading CFDs

### DIFF
--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -77,7 +77,7 @@ where
 {
     let order_id = event.order_id();
 
-    let mut cfd = db::load_cfd_by_order_id(order_id, conn).await?;
+    let mut cfd = db::load_cfd(order_id, conn).await?;
 
     if cfd.handle_monitoring_event(event)?.is_none() {
         // early exit if there was not state change
@@ -112,7 +112,7 @@ pub async fn handle_commit<W>(
 where
     W: xtra::Handler<wallet::TryBroadcastTransaction>,
 {
-    let mut cfd = db::load_cfd_by_order_id(order_id, conn).await?;
+    let mut cfd = db::load_cfd(order_id, conn).await?;
 
     let signed_commit_tx = cfd.commit_tx()?;
 

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -147,10 +147,7 @@ async fn load_latest_cfd_state(
     Ok(latest_cfd_state_in_db)
 }
 
-pub async fn load_cfd_by_order_id(
-    order_id: OrderId,
-    conn: &mut PoolConnection<Sqlite>,
-) -> Result<Cfd> {
+pub async fn load_cfd(order_id: OrderId, conn: &mut PoolConnection<Sqlite>) -> Result<Cfd> {
     let row = sqlx::query!(
         r#"
         with state as (
@@ -310,7 +307,7 @@ mod tests {
         let mut conn = setup_test_db().await;
 
         let cfd = Cfd::dummy().insert(&mut conn).await;
-        let loaded = load_cfd_by_order_id(cfd.id(), &mut conn).await.unwrap();
+        let loaded = load_cfd(cfd.id(), &mut conn).await.unwrap();
 
         assert_eq!(cfd, loaded)
     }
@@ -322,8 +319,8 @@ mod tests {
         let cfd1 = Cfd::dummy().insert(&mut conn).await;
         let cfd2 = Cfd::dummy().insert(&mut conn).await;
 
-        let loaded_1 = load_cfd_by_order_id(cfd1.id(), &mut conn).await.unwrap();
-        let loaded_2 = load_cfd_by_order_id(cfd2.id(), &mut conn).await.unwrap();
+        let loaded_1 = load_cfd(cfd1.id(), &mut conn).await.unwrap();
+        let loaded_2 = load_cfd(cfd2.id(), &mut conn).await.unwrap();
 
         assert_eq!(cfd1, loaded_1);
         assert_eq!(cfd2, loaded_2);


### PR DESCRIPTION
With the removal of the order from the DB, we are loading a CFD by
its ID which just happens to be the order id but that is no longer
relevant at this stage.