### PR TITLE
Remove workaround for longer heartbeat interval in debug mode

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -69,12 +69,9 @@ pub mod wallet;
 pub mod wire;
 pub mod xtra_ext;
 
-// Certain operations (e.g. contract setup) take long time in debug mode,
-// causing us to lag behind in processing heartbeats.
-// Increasing the value for debug mode makes sure that we don't cause problems
-// when testing / CI, whilst the release can still detect status faster
-pub const HEARTBEAT_INTERVAL: std::time::Duration =
-    Duration::from_secs(if cfg!(debug_assertions) { 75 } else { 5 });
+/// Duration between the heartbeats sent by the maker, used by the taker to
+/// determine whether the maker is online.
+pub const HEARTBEAT_INTERVAL: std::time::Duration = Duration::from_secs(5);
 
 pub const N_PAYOUTS: usize = 200;
 

--- a/daemon/tests/harness/flow.rs
+++ b/daemon/tests/harness/flow.rs
@@ -9,7 +9,7 @@ use tokio::sync::watch;
 use tokio::time::sleep;
 
 /// Waiting time for the time on the watch channel before returning error
-const NEXT_WAIT_TIME: Duration = Duration::from_secs(if cfg!(debug_assertions) { 180 } else { 30 });
+const NEXT_WAIT_TIME: Duration = Duration::from_secs(if cfg!(debug_assertions) { 120 } else { 30 });
 
 /// Returns the first `Cfd` from both channels
 ///


### PR DESCRIPTION
Before contract setup was split into dedicated actors on each side, heartbeats
were not being delivered correctly and the taker would close the connection
half-way through contract setup.
This was especially noticeable in debug mode, as the contract setup could take even
~60 seconds to complete. A workaround was set in place (45s for heartbeat
interval, making it drop connection only after 90s, longer than contract setup).