### PR TITLE
Recover wallet from 256bit string through REST endpoint

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -332,7 +332,8 @@ where
     W: xtra::Handler<wallet::BuildPartyParams>
         + xtra::Handler<wallet::Sign>
         + xtra::Handler<wallet::TryBroadcastTransaction>
-        + xtra::Handler<wallet::Withdraw>,
+        + xtra::Handler<wallet::Withdraw>
+        + xtra::Handler<wallet::Reinitialise>,
 {
     #[allow(clippy::too_many_arguments)]
     pub async fn new<FM, FO>(
@@ -453,6 +454,14 @@ where
                 amount,
                 address,
                 fee: Some(fee_rate),
+            })
+            .await?
+    }
+
+    pub async fn reinitialise_wallet(&self, seed_words: &str) -> Result<()> {
+        self.wallet_actor_addr
+            .send(wallet::Reinitialise {
+                seed_words: seed_words.to_string(),
             })
             .await?
     }

--- a/daemon/src/routes_taker.rs
+++ b/daemon/src/routes_taker.rs
@@ -158,6 +158,28 @@ pub async fn post_cfd_action(
     Ok(status::Accepted(None))
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct WalletReinitialiseRequest {
+    pub seed_words: String,
+}
+
+#[rocket::post("/wallet/reinitialise", data = "<wallet_reinitialise_request>")]
+pub async fn post_wallet_reinitialise(
+    wallet_reinitialise_request: Json<WalletReinitialiseRequest>,
+    taker: &State<Taker>,
+) -> Result<status::Accepted<()>, HttpApiProblem> {
+    taker
+        .reinitialise_wallet(&wallet_reinitialise_request.seed_words)
+        .await
+        .map_err(|e| {
+            HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .title("Wallet recover request failed")
+                .detail(e.to_string())
+        })?;
+
+    Ok(status::Accepted(None))
+}
+
 #[rocket::get("/alive")]
 pub fn get_health_check() {}
 

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -289,6 +289,7 @@ async fn main() -> Result<()> {
                 routes_taker::margin_calc,
                 routes_taker::post_cfd_action,
                 routes_taker::post_withdraw_request,
+                routes_taker::post_wallet_reinitialise,
             ],
         )
         .mount(

--- a/daemon/tests/harness/mocks/wallet.rs
+++ b/daemon/tests/harness/mocks/wallet.rs
@@ -41,6 +41,9 @@ impl WalletActor {
     async fn handle(&mut self, msg: wallet::Withdraw) -> Result<Txid> {
         self.mock.lock().await.withdraw(msg)
     }
+    async fn handle(&mut self, msg: wallet::Reinitialise) -> Result<()> {
+        self.mock.lock().await.reinitialise(msg)
+    }
 }
 
 #[automock]
@@ -58,6 +61,10 @@ pub trait Wallet {
     }
 
     fn withdraw(&mut self, _msg: wallet::Withdraw) -> Result<Txid> {
+        unreachable!("mockall will reimplement this method")
+    }
+
+    fn reinitialise(&mut self, _msg: wallet::Reinitialise) -> Result<()> {
         unreachable!("mockall will reimplement this method")
     }
 }


### PR DESCRIPTION
The choice of using a 256 bit string is temporary. This will be replaced
in favour of a 24 word seed phrase which will be used to create the
seed (BIP39).

This PR was exploratory. I will merge it after #909.

will squash after approval