### PR TITLE
Make oracle and monitor actor load CFDs from DB

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -249,11 +249,11 @@ async fn main() -> Result<()> {
         db.clone(),
         wallet.clone(),
         oracle,
-        |cfds, channel| oracle::Actor::new(cfds, channel, SETTLEMENT_INTERVAL),
+        |channel| oracle::Actor::new(db.clone(), channel, SETTLEMENT_INTERVAL),
         {
-            |channel, cfds| {
+            |channel| {
                 let electrum = opts.network.electrum().to_string();
-                monitor::Actor::new(electrum, channel, cfds)
+                monitor::Actor::new(db.clone(), electrum, channel)
             }
         },
         |channel0, channel1, channel2| {

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -243,11 +243,11 @@ async fn main() -> Result<()> {
         wallet.clone(),
         oracle,
         identity_sk,
-        |cfds, channel| oracle::Actor::new(cfds, channel, SETTLEMENT_INTERVAL),
+        |channel| oracle::Actor::new(db.clone(), channel, SETTLEMENT_INTERVAL),
         {
-            |channel, cfds| {
+            |channel| {
                 let electrum = opts.network.electrum().to_string();
-                monitor::Actor::new(electrum, channel, cfds)
+                monitor::Actor::new(db.clone(), electrum, channel)
             }
         },
         N_PAYOUTS,

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -162,8 +162,8 @@ impl Maker {
             db.clone(),
             wallet_addr,
             config.oracle_pk,
-            |_, _| oracle,
-            |_, _| async { Ok(monitor) },
+            |_| async { Ok(oracle) },
+            |_| async { Ok(monitor) },
             |channel0, channel1, channel2| {
                 maker_inc_connections::Actor::new(
                     channel0,
@@ -297,8 +297,8 @@ impl Taker {
             wallet_addr,
             config.oracle_pk,
             identity_sk,
-            |_, _| oracle,
-            |_, _| async { Ok(monitor) },
+            |_| async { Ok(oracle) },
+            |_| async { Ok(monitor) },
             config.n_payouts,
             config.heartbeat_timeout,
             Duration::from_secs(10),


### PR DESCRIPTION
With event sourcing, these actors will use a different model. Passing
them the DB connection directly now makes this change easier.