### PR TITLE
Update default blockstream electrum url

### DIFF
--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -66,7 +66,7 @@ enum Network {
     /// Run on mainnet.
     Mainnet {
         /// URL to the electrum backend to use for the wallet.
-        #[clap(long, default_value = "ssl://electrum.blockstream.info:50002")]
+        #[clap(long, default_value = "ssl://blockstream.info:700")]
         electrum: String,
 
         #[clap(subcommand)]
@@ -75,7 +75,7 @@ enum Network {
     /// Run on testnet.
     Testnet {
         /// URL to the electrum backend to use for the wallet.
-        #[clap(long, default_value = "ssl://electrum.blockstream.info:60002")]
+        #[clap(long, default_value = "ssl://blockstream.info:993")]
         electrum: String,
 
         #[clap(subcommand)]

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -78,7 +78,7 @@ fn parse_x25519_pubkey(s: &str) -> Result<x25519_dalek::PublicKey> {
 enum Network {
     Mainnet {
         /// URL to the electrum backend to use for the wallet.
-        #[clap(long, default_value = "ssl://electrum.blockstream.info:50002")]
+        #[clap(long, default_value = "ssl://blockstream.info:700")]
         electrum: String,
 
         #[clap(subcommand)]
@@ -86,7 +86,7 @@ enum Network {
     },
     Testnet {
         /// URL to the electrum backend to use for the wallet.
-        #[clap(long, default_value = "ssl://electrum.blockstream.info:60002")]
+        #[clap(long, default_value = "ssl://blockstream.info:993")]
         electrum: String,
 
         #[clap(subcommand)]


### PR DESCRIPTION
It appears our URLs are not what is recommended.
See: https://blog.blockstream.com/en-esplora-and-other-alternatives-to-electrumx/

According to https://github.com/comit-network/xmr-btc-swap/pull/866 connection to these servers should be more stable.  