### PR TITLE
Fix wrong use of tracing macro

### DIFF
--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -59,7 +59,7 @@ impl State {
             }
         };
 
-        tracing::trace!(target = "wire", "Sending {}", msg_str);
+        tracing::trace!(target: "wire", "Sending {}", msg_str);
 
         write
             .send(msg)
@@ -381,7 +381,7 @@ impl Actor {
             }
         };
 
-        tracing::trace!(target = "wire", "Received {}", msg);
+        tracing::trace!(target: "wire", "Received {}", msg);
 
         match msg {
             wire::MakerToTaker::Heartbeat => {

--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -118,7 +118,7 @@ impl Connection {
     async fn send(&mut self, msg: wire::MakerToTaker) -> Result<()> {
         let msg_str = msg.to_string();
 
-        tracing::trace!(target = "wire", taker_id = %self.taker, "Sending {}", msg_str);
+        tracing::trace!(target: "wire", taker_id = %self.taker, "Sending {}", msg_str);
 
         self.write
             .send(msg)
@@ -384,7 +384,7 @@ impl Actor {
     async fn handle_msg_from_taker(&mut self, msg: FromTaker) -> Result<()> {
         let msg_str = msg.msg.to_string();
 
-        tracing::trace!(target = "wire", taker_id = %msg.taker_id, "Received {}", msg_str);
+        tracing::trace!(target: "wire", taker_id = %msg.taker_id, "Received {}", msg_str);
 
         use wire::TakerToMaker::*;
         match msg.msg {


### PR DESCRIPTION
To specify the target, we need to say `target:` otherwise it is picked
up as a field.