### PR TITLE
Add taker http basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The new payout transactions spend from the same lock transaction, so the rollover happens off-chain.
   In case a maker rejects a rollover request from a taker the old oracle price event and payout transactions stay in place.
 - Changed username for HTTP authentication to `itchysats`
+- Add taker HTTP basic authentication:
+  When starting the taker, an additional argument (`--password`) can be passed in which will be used for HTTP authentication.
 
 ## [0.3.0] - 2021-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The previous payout transactions are invalidated.
   The new payout transactions spend from the same lock transaction, so the rollover happens off-chain.
   In case a maker rejects a rollover request from a taker the old oracle price event and payout transactions stay in place.
+- Changed username for HTTP authentication to `itchysats`
 
 ## [0.3.0] - 2021-12-09
 

--- a/daemon/src/auth.rs
+++ b/daemon/src/auth.rs
@@ -28,17 +28,17 @@ pub enum Error {
 }
 
 #[derive(PartialEq)]
-pub struct Password([u8; 32]);
+pub struct Password(String);
 
 impl From<[u8; 32]> for Password {
     fn from(bytes: [u8; 32]) -> Self {
-        Self(bytes)
+        Self(hex::encode(bytes))
     }
 }
 
 impl fmt::Display for Password {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        self.0.fmt(f)
     }
 }
 
@@ -46,10 +46,7 @@ impl FromStr for Password {
     type Err = FromHexError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut bytes = [0u8; 32];
-        hex::decode_to_slice(s, &mut bytes)?;
-
-        Ok(Self(bytes))
+        Ok(Self(s.to_string()))
     }
 }
 

--- a/daemon/src/auth.rs
+++ b/daemon/src/auth.rs
@@ -15,6 +15,7 @@ use std::str::FromStr;
 pub struct Authenticated {}
 
 pub const USERNAME: &str = "itchysats";
+pub const TAKER_DEFAULT_PASSWORD: &str = "onbrinkofsecondbailout";
 
 #[derive(Debug)]
 pub enum Error {

--- a/daemon/src/auth.rs
+++ b/daemon/src/auth.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 /// A request guard that can be included in handler definitions to enforce authentication.
 pub struct Authenticated {}
 
-pub const MAKER_USERNAME: &str = "maker";
+pub const USERNAME: &str = "itchysats";
 
 #[derive(Debug)]
 pub enum Error {
@@ -68,7 +68,7 @@ impl<'r> FromRequest<'r> for Authenticated {
             .await
             .map_failure(|(status, _)| (status, Error::MissingPassword)));
 
-        if basic_auth.username != MAKER_USERNAME {
+        if basic_auth.username != USERNAME {
             return Outcome::Failure((
                 Status::Unauthorized,
                 Error::UnknownUser(basic_auth.username),

--- a/daemon/src/maker.rs
+++ b/daemon/src/maker.rs
@@ -7,7 +7,7 @@ use bdk::FeeRate;
 use clap::Parser;
 use clap::Subcommand;
 use daemon::auth;
-use daemon::auth::MAKER_USERNAME;
+use daemon::auth::USERNAME;
 use daemon::bitmex_price_feed;
 use daemon::db;
 use daemon::logger;
@@ -199,7 +199,7 @@ async fn main() -> Result<()> {
 
     tracing::info!(
         "Authentication details: username='{}' password='{}', noise_public_key='{}'",
-        MAKER_USERNAME,
+        USERNAME,
         auth_password,
         hex::encode(identity_pk.to_bytes())
     );

--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -304,12 +304,15 @@ mod tests {
     /// Creates an "Authorization" header that matches the password above,
     /// in particular it has been created through:
     /// ```
-    /// base64(maker:hex("Now I'm feelin' so fly like a G6"))
+    /// let password = "Now I'm feelin' so fly like a G6".to_string();
+    /// let password_vec = password.as_bytes();
+    /// let password_hex = hex::encode(vec);
+    /// let basic_auth = base64::encode(&format!("{}:{}", "itchysats", password_hex));
     /// ```
     fn auth_header() -> Header<'static> {
         Header::new(
             "Authorization",
-            "Basic bWFrZXI6NGU2Zjc3MjA0OTI3NmQyMDY2NjU2NTZjNjk2ZTI3MjA3MzZmMjA2NjZjNzkyMDZjNjk2YjY1MjA2MTIwNDczNg==",
+            "Basic aXRjaHlzYXRzOjRlNmY3NzIwNDkyNzZkMjA2NjY1NjU2YzY5NmUyNzIwNzM2ZjIwNjY2Yzc5MjA2YzY5NmI2NTIwNjEyMDQ3MzY=",
         )
     }
 }

--- a/daemon/src/routes_taker.rs
+++ b/daemon/src/routes_taker.rs
@@ -1,5 +1,6 @@
 use bdk::bitcoin::Amount;
 use bdk::bitcoin::Network;
+use daemon::auth::Authenticated;
 use daemon::bitmex_price_feed;
 use daemon::connection::ConnectionStatus;
 use daemon::model::cfd::calculate_long_margin;
@@ -19,6 +20,7 @@ use daemon::TakerActorSystem;
 use http_api_problem::HttpApiProblem;
 use http_api_problem::StatusCode;
 use rocket::http::ContentType;
+use rocket::http::Header;
 use rocket::http::Status;
 use rocket::response::status;
 use rocket::response::stream::EventStream;
@@ -40,6 +42,7 @@ pub async fn feed(
     rx: &State<Feeds>,
     rx_wallet: &State<watch::Receiver<Option<WalletInfo>>>,
     rx_maker_status: &State<watch::Receiver<ConnectionStatus>>,
+    _auth: Authenticated,
 ) -> EventStream![] {
     let rx = rx.inner();
     let mut rx_cfds = rx.cfds.clone();
@@ -101,6 +104,7 @@ pub struct CfdOrderRequest {
 pub async fn post_order_request(
     cfd_order_request: Json<CfdOrderRequest>,
     taker: &State<Taker>,
+    _auth: Authenticated,
 ) -> Result<status::Accepted<()>, HttpApiProblem> {
     taker
         .take_offer(cfd_order_request.order_id, cfd_order_request.quantity)
@@ -120,6 +124,7 @@ pub async fn post_cfd_action(
     action: CfdAction,
     taker: &State<Taker>,
     feeds: &State<Feeds>,
+    _auth: Authenticated,
 ) -> Result<status::Accepted<()>, HttpApiProblem> {
     let result = match action {
         CfdAction::AcceptOrder
@@ -166,6 +171,7 @@ pub struct WalletReinitialiseRequest {
 pub async fn post_wallet_reinitialise(
     wallet_reinitialise_request: Json<WalletReinitialiseRequest>,
     taker: &State<Taker>,
+    _auth: Authenticated,
 ) -> Result<status::Accepted<()>, HttpApiProblem> {
     taker
         .reinitialise_wallet(&wallet_reinitialise_request.seed_words)
@@ -201,6 +207,7 @@ pub struct MarginResponse {
 #[rocket::post("/calculate/margin", data = "<margin_request>")]
 pub fn margin_calc(
     margin_request: Json<MarginRequest>,
+    _auth: Authenticated,
 ) -> Result<status::Accepted<Json<MarginResponse>>, HttpApiProblem> {
     let margin = calculate_long_margin(
         margin_request.price,
@@ -216,13 +223,13 @@ pub fn margin_calc(
 struct Asset;
 
 #[rocket::get("/assets/<file..>")]
-pub fn dist<'r>(file: PathBuf) -> impl Responder<'r, 'static> {
+pub fn dist<'r>(file: PathBuf, _auth: Authenticated) -> impl Responder<'r, 'static> {
     let filename = format!("assets/{}", file.display().to_string());
     Asset::get(&filename).into_response(file)
 }
 
 #[rocket::get("/<_paths..>", format = "text/html")]
-pub fn index<'r>(_paths: PathBuf) -> impl Responder<'r, 'static> {
+pub fn index<'r>(_paths: PathBuf, _auth: Authenticated) -> impl Responder<'r, 'static> {
     let asset = Asset::get("index.html").ok_or(Status::NotFound)?;
     Ok::<(ContentType, Cow<[u8]>), Status>((ContentType::HTML, asset.data))
 }
@@ -240,6 +247,7 @@ pub async fn post_withdraw_request(
     withdraw_request: Json<WithdrawRequest>,
     taker: &State<Taker>,
     network: &State<Network>,
+    _auth: Authenticated,
 ) -> Result<String, HttpApiProblem> {
     let amount =
         (withdraw_request.amount != bdk::bitcoin::Amount::ZERO).then(|| withdraw_request.amount);
@@ -258,4 +266,21 @@ pub async fn post_withdraw_request(
         })?;
 
     Ok(projection::to_mempool_url(txid, *network.inner()))
+}
+
+/// A "catcher" for all 401 responses, triggers the browser's basic auth implementation.
+#[rocket::catch(401)]
+pub fn unauthorized() -> PromptAuthentication {
+    PromptAuthentication {
+        inner: (),
+        www_authenticate: Header::new("WWW-Authenticate", r#"Basic charset="UTF-8"#),
+    }
+}
+
+/// A rocket responder that prompts the user to sign in to access the API.
+#[derive(rocket::Responder)]
+#[response(status = 401)]
+pub struct PromptAuthentication {
+    inner: (),
+    www_authenticate: Header<'static>,
 }


### PR DESCRIPTION
Resolves #609 

This is the first step to have authentication for the taker. 
For our current use of running the taker on umbrel this is sufficient. Eventually we might want to allow the user to change the password from inside of the application. 