### PR TITLE
Add ContractSetupStarted Cfd event

### DIFF
--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -1,5 +1,6 @@
 use crate::db;
 use crate::model::cfd::Cfd;
+use crate::model::cfd::Event;
 use crate::model::cfd::OrderId;
 use crate::monitor;
 use crate::oracle;
@@ -87,6 +88,21 @@ pub async fn load_cfd(order_id: OrderId, conn: &mut PoolConnection<Sqlite>) -> R
         events,
     );
     Ok(cfd)
+}
+
+pub async fn apply_event(
+    process_manager: &xtra::Address<process_manager::Actor>,
+    event: Event,
+) -> Result<()> {
+    // FIXME: Failing to apply an event is a serious error and should not result
+    // in Ok() return from this function
+    if let Err(e) = process_manager
+        .send(process_manager::Event::new(event.clone()))
+        .await?
+    {
+        tracing::error!("Sending event to process manager failed: {:#}", e);
+    }
+    Ok(())
 }
 
 pub async fn handle_commit(

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -133,7 +133,8 @@ impl Cfd {
                     ..self
                 }
             }
-            CfdEvent::ContractSetupFailed
+            CfdEvent::ContractSetupStarted
+            | CfdEvent::ContractSetupFailed
             | CfdEvent::OfferRejected
             | CfdEvent::RolloverRejected => {
                 Self::default() // all false / empty

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -290,6 +290,13 @@ impl Cfd {
     ) -> Self {
         // First, try to set state based on event.
         let (state, actions) = match event.event {
+            CfdEvent::ContractSetupStarted => {
+                // Don't display profit for contracts that are not yet created.
+                self.profit_btc = None;
+                self.profit_percent = None;
+
+                (CfdState::ContractSetup, vec![])
+            }
             CfdEvent::ContractSetupCompleted { dlc } => {
                 self.details.tx_url_list.push(TxUrl::new(
                     dlc.lock.0.txid(),
@@ -653,6 +660,7 @@ impl From<Order> for CfdOrder {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum CfdState {
     PendingSetup,
+    ContractSetup,
     Rejected,
     PendingOpen,
     Open,
@@ -800,6 +808,8 @@ mod tests {
 
         let json = serde_json::to_string(&CfdState::PendingSetup).unwrap();
         assert_eq!(json, "\"PendingSetup\"");
+        let json = serde_json::to_string(&CfdState::ContractSetup).unwrap();
+        assert_eq!(json, "\"ContractSetup\"");
         let json = serde_json::to_string(&CfdState::Rejected).unwrap();
         assert_eq!(json, "\"Rejected\"");
         let json = serde_json::to_string(&CfdState::PendingOpen).unwrap();

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -284,7 +284,9 @@ where
             .address()
             .expect("actor to be able to give address to itself");
         let (addr, fut) = setup_taker::Actor::new(
-            (cfd, self.n_payouts),
+            self.db.clone(),
+            self.process_manager_actor.clone(),
+            (cfd.id(), cfd.quantity(), self.n_payouts),
             (self.oracle_pk, announcement),
             &self.wallet,
             &self.wallet,

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -116,6 +116,9 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
     taker.mocks.mock_wallet_sign_and_broadcast().await;
 
     maker.accept_take_request(received.clone()).await;
+    assert_next_state!(CfdState::ContractSetup, maker, taker, received.id);
+
+    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     assert_next_state!(CfdState::PendingOpen, maker, taker, received.id);
 
     deliver_event!(maker, taker, Event::LockFinality(received.id));
@@ -288,6 +291,9 @@ async fn start_from_open_cfd_state(announcement: oracle::Announcement) -> (Maker
     taker.mocks.mock_wallet_sign_and_broadcast().await;
 
     maker.accept_take_request(received.clone()).await;
+    assert_next_state!(CfdState::ContractSetup, maker, taker, received.id);
+
+    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     assert_next_state!(CfdState::PendingOpen, maker, taker, received.id);
 
     deliver_event!(maker, taker, Event::LockFinality(received.id));

--- a/maker-frontend/src/components/Types.tsx
+++ b/maker-frontend/src/components/Types.tsx
@@ -70,7 +70,9 @@ export class State {
     public getLabel(): string {
         switch (this.key) {
             case StateKey.PENDING_SETUP:
-                return "Setting up";
+                return "Offered";
+            case StateKey.CONTRACT_SETUP:
+                return "Contract Setup";
             case StateKey.REJECTED:
                 return "Rejected";
             case StateKey.PENDING_OPEN:
@@ -125,6 +127,7 @@ export class State {
                 return orange;
 
             case StateKey.PENDING_SETUP:
+            case StateKey.CONTRACT_SETUP:
             case StateKey.OUTGOING_SETTLEMENT_PROPOSAL:
             case StateKey.INCOMING_SETTLEMENT_PROPOSAL:
             case StateKey.INCOMING_ROLL_OVER_PROPOSAL:
@@ -140,6 +143,7 @@ export class State {
     public getGroup(): StateGroupKey {
         switch (this.key) {
             case StateKey.PENDING_SETUP:
+            case StateKey.CONTRACT_SETUP:
                 return StateGroupKey.OPENING;
 
             case StateKey.PENDING_OPEN:
@@ -182,6 +186,7 @@ export enum Action {
 
 const enum StateKey {
     PENDING_SETUP = "PendingSetup",
+    CONTRACT_SETUP = "ContractSetup",
     REJECTED = "Rejected",
     PENDING_OPEN = "PendingOpen",
     OPEN = "Open",

--- a/taker-frontend/src/types.ts
+++ b/taker-frontend/src/types.ts
@@ -87,7 +87,9 @@ export class State {
     public getLabel(): string {
         switch (this.key) {
             case StateKey.PENDING_SETUP:
-                return "Setting up";
+                return "Offered";
+            case StateKey.CONTRACT_SETUP:
+                return "Contract Setup";
             case StateKey.REJECTED:
                 return "Rejected";
             case StateKey.PENDING_OPEN:
@@ -142,6 +144,7 @@ export class State {
                 return orange;
 
             case StateKey.PENDING_SETUP:
+            case StateKey.CONTRACT_SETUP:
             case StateKey.OUTGOING_SETTLEMENT_PROPOSAL:
             case StateKey.INCOMING_SETTLEMENT_PROPOSAL:
             case StateKey.INCOMING_ROLL_OVER_PROPOSAL:
@@ -157,6 +160,7 @@ export class State {
     public getGroup(): StateGroupKey {
         switch (this.key) {
             case StateKey.PENDING_SETUP:
+            case StateKey.CONTRACT_SETUP:
                 return StateGroupKey.OPENING;
 
             case StateKey.PENDING_OPEN:
@@ -187,6 +191,7 @@ export class State {
 
 export const enum StateKey {
     PENDING_SETUP = "PendingSetup",
+    CONTRACT_SETUP = "ContractSetup",
     REJECTED = "Rejected",
     PENDING_OPEN = "PendingOpen",
     OPEN = "Open",


### PR DESCRIPTION
Allow reasoning about started contract setup, to be able to constrain available
actions and present the Cfd state in the UI.

Reinstate the ContractSetup UI state, both in the frontend and in the actor tests.

I wasn't sure about accessing db in `started()`, so opted for now for returning the event along with `SetupParams`. Happy to change that if deemed to be wrong.