### PR TITLE
Move counterparty identity into SetupParams

### DIFF
--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -545,7 +545,7 @@ impl Cfd {
         self.collaborative_settlement_finality || self.cet_finality || self.refund_finality
     }
 
-    pub fn start_contract_setup(&self) -> Result<(SetupParams, Identity)> {
+    pub fn start_contract_setup(&self) -> Result<SetupParams> {
         if self.version > 0 {
             bail!("Start contract not allowed in version {}", self.version)
         }
@@ -564,17 +564,15 @@ impl Cfd {
             }
         };
 
-        Ok((
-            SetupParams::new(
-                margin,
-                counterparty_margin,
-                self.initial_price,
-                self.quantity,
-                self.leverage,
-                self.refund_timelock_in_blocks(),
-                1, // TODO: Where should I get the fee rate from?
-            ),
+        Ok(SetupParams::new(
+            margin,
+            counterparty_margin,
             self.counterparty_network_identity,
+            self.initial_price,
+            self.quantity,
+            self.leverage,
+            self.refund_timelock_in_blocks(),
+            1, // TODO: Where should I get the fee rate from?
         ))
     }
 

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -3,6 +3,7 @@ use crate::model::cfd::Dlc;
 use crate::model::cfd::RevokedCommit;
 use crate::model::cfd::Role;
 use crate::model::cfd::CET_TIMELOCK;
+use crate::model::Identity;
 use crate::model::Leverage;
 use crate::model::Price;
 use crate::model::Usd;
@@ -56,6 +57,7 @@ use xtra::prelude::MessageChannel;
 pub struct SetupParams {
     margin: Amount,
     counterparty_margin: Amount,
+    counterparty_identity: Identity,
     price: Price,
     quantity: Usd,
     leverage: Leverage,
@@ -64,9 +66,11 @@ pub struct SetupParams {
 }
 
 impl SetupParams {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         margin: Amount,
         counterparty_margin: Amount,
+        counterparty_identity: Identity,
         price: Price,
         quantity: Usd,
         leverage: Leverage,
@@ -76,12 +80,17 @@ impl SetupParams {
         Self {
             margin,
             counterparty_margin,
+            counterparty_identity,
             price,
             quantity,
             leverage,
             refund_timelock,
             fee_rate,
         }
+    }
+
+    pub fn counterparty_identity(&self) -> Identity {
+        self.counterparty_identity
     }
 }
 

--- a/daemon/src/setup_maker.rs
+++ b/daemon/src/setup_maker.rs
@@ -87,12 +87,13 @@ impl Actor {
         // the spawned contract setup task
         self.setup_msg_sender = Some(sender);
 
-        let (setup_params, identity) = self.cfd.start_contract_setup()?;
+        let setup_params = self.cfd.start_contract_setup()?;
+        let taker_id = setup_params.counterparty_identity();
 
         let contract_future = setup_contract::new(
             self.taker.sink().with(move |msg| {
                 future::ok(maker_inc_connections::TakerMessage {
-                    taker_id: identity,
+                    taker_id,
                     msg: wire::MakerToTaker::Protocol { order_id, msg },
                 })
             }),

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -65,7 +65,7 @@ impl Actor {
         let order_id = self.cfd.id();
         tracing::info!(%order_id, "Order got accepted");
 
-        let (setup_params, _) = self.cfd.start_contract_setup()?;
+        let setup_params = self.cfd.start_contract_setup()?;
         let (sender, receiver) = mpsc::unbounded::<SetupMsg>();
         // store the writing end to forward messages from the maker to
         // the spawned contract setup task


### PR DESCRIPTION
If it's needed by contract setup, then it should be part of the setup params. It's an implementation detail from the model's perspective that one side doesn't really use it.