### PR TITLE
Refuse to accept 2nd connection of already connected taker

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -104,6 +104,29 @@ impl Tasks {
         let handle = f.spawn_with_handle();
         self.0.push(handle);
     }
+
+    /// Spawn a fallible task on the runtime and remembers the handle.
+    ///
+    /// The task will be stopped if this instance of [`Tasks`] goes out of scope.
+    /// If the task fails, the `err_handler` will be invoked.
+    pub fn add_fallible<E, EF>(
+        &mut self,
+        f: impl Future<Output = Result<(), E>> + Send + 'static,
+        err_handler: impl FnOnce(E) -> EF + Send + 'static,
+    ) where
+        E: Send + 'static,
+        EF: Future<Output = ()> + Send + 'static,
+    {
+        let fut = async move {
+            match f.await {
+                Ok(()) => {}
+                Err(err) => err_handler(err).await,
+            }
+        };
+
+        let handle = fut.spawn_with_handle();
+        self.0.push(handle);
+    }
 }
 
 pub struct MakerActorSystem<O, W> {

--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -198,7 +198,6 @@ impl Actor {
         );
 
         let noise_priv_key = self.noise_priv_key.clone();
-        let heartbeat_interval = self.heartbeat_interval;
 
         self.tasks.add(async move {
             let mut tasks = Tasks::default();
@@ -211,13 +210,15 @@ impl Actor {
 
                 match new_connection {
                     Ok((stream, address)) => {
-                        tasks.add(setup_new_connection(
-                            this.clone(),
-                            noise_priv_key.clone(),
-                            heartbeat_interval,
-                            stream,
-                            address,
-                        ));
+                        let upgrade = upgrade(stream, noise_priv_key.clone(), this.clone());
+
+                        tasks
+                            .add_fallible(
+                                upgrade,
+                                move |e| async move {
+                                    tracing::warn!(address = %address, "Failed to upgrade incoming connection: {:#}", e);
+                                }
+                            );
                     }
                     Err(error) => {
                         let _ = this.send(ListenerFailed { error }).await;
@@ -317,16 +318,71 @@ impl Actor {
         self.drop_taker_connection(&taker_id).await;
     }
 
-    async fn handle_connection_ready(&mut self, msg: ConnectionReady) {
-        let connection = msg.0;
+    async fn handle_connection_ready(
+        &mut self,
+        msg: ConnectionReady,
+        ctx: &mut xtra::Context<Self>,
+    ) {
+        let ConnectionReady {
+            mut read,
+            write,
+            identity,
+        } = msg;
+        let this = ctx.address().expect("we are alive");
+
+        if self.connections.contains_key(&identity) {
+            tracing::warn!(
+                "Refusing to accept 2nd connection from already connected taker {}!",
+                identity
+            );
+            return;
+        }
 
         let _ = self
             .taker_connected_channel
-            .send(maker_cfd::TakerConnected {
-                id: connection.taker,
-            })
+            .send(maker_cfd::TakerConnected { id: identity })
             .await;
-        self.connections.insert(connection.taker, connection);
+
+        let mut tasks = Tasks::default();
+        tasks.add({
+            let this = this.clone();
+
+            async move {
+                while let Ok(Some(msg)) = read.try_next().await {
+                    let res = this
+                        .send(FromTaker {
+                            taker_id: identity,
+                            msg,
+                        })
+                        .await;
+
+                    if res.is_err() {
+                        break;
+                    }
+                }
+
+                let _ = this.send(ReadFail(identity)).await;
+            }
+        });
+        tasks.add({
+            let this = this.clone();
+            let heartbeat_interval = self.heartbeat_interval;
+
+            async move {
+                while let Ok(()) = this.send(SendHeartbeat(identity)).await {
+                    tokio::time::sleep(heartbeat_interval).await;
+                }
+            }
+        });
+
+        self.connections.insert(
+            identity,
+            Connection {
+                taker: identity,
+                write,
+                _tasks: tasks,
+            },
+        );
     }
 
     async fn handle_listener_failed(&mut self, msg: ListenerFailed, ctx: &mut xtra::Context<Self>) {
@@ -402,69 +458,14 @@ impl Actor {
     }
 }
 
-/// Sets up a new connection on the given stream including all relevant background tasks like
-/// heartbeat and reading messages from the stream.
-async fn setup_new_connection(
-    this: Address<Actor>,
-    noise_priv_key: x25519_dalek::StaticSecret,
-    heartbeat_interval: Duration,
-    stream: TcpStream,
-    address: SocketAddr,
-) {
-    let (mut read, write, taker_id) = match upgrade(stream, noise_priv_key).await {
-        Ok((read, write, identity)) => (read, write, identity),
-        Err(e) => {
-            tracing::warn!(address = %address, "Failed to upgrade incoming connection: {:#}", e);
-            return;
-        }
-    };
-
-    let mut tasks = Tasks::default();
-    tasks.add({
-        let this = this.clone();
-
-        async move {
-            while let Ok(Some(msg)) = read.try_next().await {
-                let res = this.send(FromTaker { taker_id, msg }).await;
-
-                if res.is_err() {
-                    break;
-                }
-            }
-
-            let _ = this.send(ReadFail(taker_id)).await;
-        }
-    });
-    tasks.add({
-        let this = this.clone();
-
-        async move {
-            while let Ok(()) = this.send(SendHeartbeat(taker_id)).await {
-                tokio::time::sleep(heartbeat_interval).await;
-            }
-        }
-    });
-
-    let _ = this
-        .send(ConnectionReady(Connection {
-            _tasks: tasks,
-            taker: taker_id,
-            write,
-        }))
-        .await;
-}
-
 /// Upgrades a TCP stream to an encrypted transport, checking the network version in the process.
 ///
 /// Both IO operations, upgrading to noise and checking the version are gated by a timeout.
 async fn upgrade(
     mut stream: TcpStream,
     noise_priv_key: x25519_dalek::StaticSecret,
-) -> Result<(
-    wire::Read<wire::TakerToMaker, wire::MakerToTaker>,
-    wire::Write<wire::TakerToMaker, wire::MakerToTaker>,
-    Identity,
-)> {
+    this: xtra::Address<Actor>,
+) -> Result<()> {
     let taker_address = stream.peer_addr().context("Failed to get peer address")?;
 
     tracing::info!(%taker_address, "Upgrade new connection");
@@ -510,10 +511,22 @@ async fn upgrade(
 
     tracing::info!(taker_id = %taker_id, %taker_address, "Connection upgrade successful");
 
-    Ok((read, write, taker_id))
+    let _ = this
+        .send(ConnectionReady {
+            read,
+            write,
+            identity: taker_id,
+        })
+        .await;
+
+    Ok(())
 }
 
-struct ConnectionReady(Connection);
+struct ConnectionReady {
+    read: wire::Read<wire::TakerToMaker, wire::MakerToTaker>,
+    write: wire::Write<wire::TakerToMaker, wire::MakerToTaker>,
+    identity: Identity,
+}
 
 struct ReadFail(Identity);
 

--- a/daemon/src/tokio_ext.rs
+++ b/daemon/src/tokio_ext.rs
@@ -29,7 +29,8 @@ pub trait FutureExt: Future + Sized {
     /// The task will be stopped when the handle gets dropped.
     fn spawn_with_handle(self) -> RemoteHandle<Self::Output>
     where
-        Self: Future<Output = ()> + Send + Any + 'static;
+        Self: Send + Any + 'static,
+        Self::Output: Send;
 }
 
 impl<F> FutureExt for F
@@ -40,12 +41,13 @@ where
         timeout(duration, self)
     }
 
-    fn spawn_with_handle(self) -> RemoteHandle<()>
+    fn spawn_with_handle(self) -> RemoteHandle<F::Output>
     where
-        Self: Future<Output = ()> + Send + Any + 'static,
+        Self: Send + Any + 'static,
+        F::Output: Send,
     {
         debug_assert!(
-            TypeId::of::<RemoteHandle<()>>() != self.type_id(),
+            TypeId::of::<RemoteHandle<Self::Output>>() != self.type_id(),
             "RemoteHandle<()> is a handle to already spawned task",
         );
 


### PR DESCRIPTION
Noticed that we currently don't check for existing connections of the same taker.

Introduce a utility on `Tasks` to make it easier to run fallible futures in the background.
I've split this out of https://github.com/itchysats/itchysats/pull/851 which is not quite done yet in the hope that these two things are pretty non-controversial!