### PR TITLE
Increase heartbeat timeout in debug mode

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -74,7 +74,7 @@ pub mod xtra_ext;
 // Increasing the value for debug mode makes sure that we don't cause problems
 // when testing / CI, whilst the release can still detect status faster
 pub const HEARTBEAT_INTERVAL: std::time::Duration =
-    Duration::from_secs(if cfg!(debug_assertions) { 45 } else { 5 });
+    Duration::from_secs(if cfg!(debug_assertions) { 75 } else { 5 });
 
 pub const N_PAYOUTS: usize = 200;
 


### PR DESCRIPTION
Address sporadic test failures due to hitting this timeout in contract setup test.