### PR TITLE
Emit ContractSetupProposed event as soon as setup_contract actors are started

### DIFF
--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -154,3 +154,16 @@ pub async fn handle_oracle_attestation(
 
     Ok(())
 }
+
+/// Necessary precondition to start contract setup protocol
+pub async fn propose_contract_setup(
+    order_id: OrderId,
+    db: &SqlitePool,
+    process_manager: &xtra::Address<process_manager::Actor>,
+) -> Result<()> {
+    let mut conn = db.acquire().await?;
+    let cfd = load_cfd(order_id, &mut conn).await?;
+    let event = cfd.propose_contract_setup()?;
+    apply_event(process_manager, event).await?;
+    Ok(())
+}

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -134,7 +134,11 @@ impl Cfd {
                     ..self
                 }
             }
-            ContractSetupStarted | ContractSetupFailed | OfferRejected | RolloverRejected => {
+            ContractSetupProposed
+            | ContractSetupStarted { .. }
+            | ContractSetupFailed
+            | OfferRejected
+            | RolloverRejected => {
                 Self::default() // all false / empty
             }
             LockConfirmed => Self {

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -291,7 +291,13 @@ impl Cfd {
         // First, try to set state based on event.
         use CfdEvent::*;
         let (state, actions) = match event.event {
-            ContractSetupStarted => {
+            ContractSetupProposed => {
+                // Don't display profit for contracts that are not yet created.
+                self.profit_btc = None;
+                self.profit_percent = None;
+                (CfdState::PendingSetup, vec![])
+            }
+            ContractSetupStarted { .. } => {
                 // Don't display profit for contracts that are not yet created.
                 self.profit_btc = None;
                 self.profit_percent = None;
@@ -661,7 +667,9 @@ impl From<Order> for CfdOrder {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum CfdState {
-    PendingSetup,
+    // this one should allow for "accept" action
+    PendingSetup, // TODO: change to Offered?
+    // this one should *not* allow for that action
     ContractSetup,
     Rejected,
     PendingOpen,

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -48,14 +48,19 @@ use maia::spending_tx_sighash;
 use maia::Announcement;
 use maia::PartyParams;
 use maia::PunishParams;
+use serde::Deserialize;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::ops::RangeInclusive;
 use std::time::Duration;
 use xtra::prelude::MessageChannel;
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct SetupParams {
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
     margin: Amount,
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
     counterparty_margin: Amount,
     counterparty_identity: Identity,
     price: Price,


### PR DESCRIPTION
In order to represent states adequately in the UI, we need to differentiate
between the proposed contract setup (the order got requested by the taker) and
the actual contract setup protocol (the order got accepted by the maker, so the
protocol is started).