### PR TITLE
Run all actor tests by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
       - uses: Swatinem/rust-cache@v1.3.0
       - run: cargo build --bins --tests
       - run: cargo test --workspace
-      # Ignored tests should be run on the CI
-      - run: cargo test --workspace -- --ignored
+      # Ignored tests that should be run on the CI - reenable if there are any
+      # - run: cargo test --workspace -- --ignored
       - name: Smoke test ${{ matrix.os }} binary
         shell: bash
         run: |

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -89,7 +89,6 @@ async fn taker_takes_order_and_maker_rejects() {
 }
 
 #[tokio::test]
-#[ignore = "expensive, runs on CI"]
 async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
     let _guard = init_tracing();
     let (mut maker, mut taker) = start_both().await;


### PR DESCRIPTION
Contract setup test is expensive, but it does not deserve special treatment
compared to collab and non-collab settlement tests, which take even longer.