### PR TITLE
Restore pending orders in the maker UI

### DIFF
--- a/maker-frontend/src/components/Types.tsx
+++ b/maker-frontend/src/components/Types.tsx
@@ -143,6 +143,8 @@ export class State {
     public getGroup(): StateGroupKey {
         switch (this.key) {
             case StateKey.PENDING_SETUP:
+                return StateGroupKey.PENDING_ORDER;
+
             case StateKey.CONTRACT_SETUP:
                 return StateGroupKey.OPENING;
 


### PR DESCRIPTION
Seems like a tiny regression slipped in (I tried to set up a cfd locally and it was impossible)