### PR TITLE
Release version 0.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "daemon"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daemon"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Hi @rishflab!
This PR was created in response to a manual trigger of the release workflow here: https://github.com/itchysats/itchysats/actions/runs/1657541026.
I've bumped the versions in the manifest files in this commit: 2726698786cb7a2384a4ac52f301d6c75a0f2f7b.
Merging this PR will create a GitHub release and publish the library to crates.io!