### PR TITLE
Align heartbeat variables in the taker

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -404,11 +404,16 @@ where
         tasks.add(cfd_actor_fut);
         tasks.add(auto_rollover_fut);
 
+        // Timeout happens when taker did not receive two consecutive heartbeats
+        let taker_heartbeat_timeout = maker_heartbeat_interval
+            .checked_mul(2)
+            .expect("not to overflow");
+
         tasks.add(connection_actor_ctx.run(connection::Actor::new(
             maker_online_status_feed_sender,
             &cfd_actor_addr,
             identity_sk,
-            maker_heartbeat_interval,
+            taker_heartbeat_timeout,
             connect_timeout,
         )));
 

--- a/daemon/src/taker.rs
+++ b/daemon/src/taker.rs
@@ -247,7 +247,7 @@ async fn main() -> Result<()> {
             }
         },
         N_PAYOUTS,
-        HEARTBEAT_INTERVAL * 2,
+        HEARTBEAT_INTERVAL,
         Duration::from_secs(10),
         projection_actor.clone(),
         maker_identity,

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -202,7 +202,7 @@ async fn taker_notices_lack_of_maker() {
         .with_dedicated_port(35123); // set a fixed port so the taker can reconnect
     let maker = Maker::start(&maker_config).await;
 
-    let taker_config = TakerConfig::default().with_heartbeat_timeout(short_interval * 2);
+    let taker_config = TakerConfig::default().with_heartbeat_interval(short_interval);
     let mut taker = Taker::start(&taker_config, maker.listen_addr, maker.identity).await;
 
     assert_eq!(
@@ -212,7 +212,7 @@ async fn taker_notices_lack_of_maker() {
 
     std::mem::drop(maker);
 
-    sleep(taker_config.heartbeat_timeout).await;
+    sleep(taker_config.heartbeat_interval).await;
 
     assert_eq!(
         ConnectionStatus::Offline { reason: None },
@@ -221,7 +221,7 @@ async fn taker_notices_lack_of_maker() {
 
     let _maker = Maker::start(&maker_config).await;
 
-    sleep(taker_config.heartbeat_timeout).await;
+    sleep(taker_config.heartbeat_interval).await;
 
     assert_eq!(
         ConnectionStatus::Online,
@@ -256,7 +256,7 @@ async fn start_from_open_cfd_state(announcement: oracle::Announcement) -> (Maker
     let mut maker =
         Maker::start(&MakerConfig::default().with_heartbeat_interval(heartbeat_interval)).await;
     let mut taker = Taker::start(
-        &TakerConfig::default().with_heartbeat_timeout(heartbeat_interval * 2),
+        &TakerConfig::default().with_heartbeat_interval(heartbeat_interval * 2),
         maker.listen_addr,
         maker.identity,
     )

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -97,14 +97,14 @@ impl Default for MakerConfig {
 pub struct TakerConfig {
     oracle_pk: schnorrsig::PublicKey,
     seed: Seed,
-    pub heartbeat_timeout: Duration,
+    pub heartbeat_interval: Duration,
     n_payouts: usize,
 }
 
 impl TakerConfig {
-    pub fn with_heartbeat_timeout(self, timeout: Duration) -> Self {
+    pub fn with_heartbeat_interval(self, timeout: Duration) -> Self {
         Self {
-            heartbeat_timeout: timeout,
+            heartbeat_interval: timeout,
             ..self
         }
     }
@@ -115,7 +115,7 @@ impl Default for TakerConfig {
         Self {
             oracle_pk: oracle_pk(),
             seed: Seed::default(),
-            heartbeat_timeout: HEARTBEAT_INTERVAL_FOR_TEST * 2,
+            heartbeat_interval: HEARTBEAT_INTERVAL_FOR_TEST,
             n_payouts: N_PAYOUTS_FOR_TEST,
         }
     }
@@ -296,7 +296,7 @@ impl Taker {
             |_| async { Ok(oracle) },
             |_| async { Ok(monitor) },
             config.n_payouts,
-            config.heartbeat_timeout,
+            config.heartbeat_interval,
             Duration::from_secs(10),
             projection_actor,
             maker_identity,


### PR DESCRIPTION
Both maker and taker actor systems are now constructed with the same heartbeat
interval variable.

Taker internally configures the heartbeat timeout as 2 * heartbeat_interval.
The heartbeat pulse (rate of checking whether timeout lapsed) is configured as
heartbeat_interval / 2. Beforehand, it was set to the same value as heartbeat
timeout, which could result in reporting a timeout even if it should not do so.

Adds more comments to describe all variables in use for future readers.