### PR TITLE
Introduce xtra_ext::SendInterval trait for periodic actor messages

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -2,4 +2,5 @@ disallowed-methods = [
   "xtra::Address::do_send_async", # discards the return value, possibly swallowing an error
   "xtra::Address::do_send", # discards the return value, possibly swallowing an error
   "xtra::message_channel::MessageChannel::do_send", # discards the return value, possibly swallowing an error
+  "xtra::Context::notify_interval", # does not wait for response from the previous handler, prefer `xtra_ext::Address::send_interval`
 ]

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -9,6 +9,7 @@ use crate::model::BitMexPriceEventId;
 use crate::oracle;
 use crate::oracle::Attestation;
 use crate::try_continue;
+use crate::xtra_ext::SendInterval;
 use crate::Tasks;
 use anyhow::Context;
 use anyhow::Result;
@@ -714,11 +715,9 @@ where
     Self: xtra::Handler<Sync>,
 {
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
-        let fut = ctx
-            .notify_interval(Duration::from_secs(20), || Sync)
-            .expect("we just started");
-
-        self.tasks.add(fut);
+        let this = ctx.address().expect("we are alive");
+        self.tasks
+            .add(this.send_interval(Duration::from_secs(20), || Sync));
     }
 }
 

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -5,6 +5,7 @@ use crate::model::BitMexPriceEventId;
 use crate::tokio_ext;
 use crate::try_continue;
 use crate::xtra_ext::LogFailure;
+use crate::xtra_ext::SendInterval;
 use crate::Tasks;
 use anyhow::Context;
 use anyhow::Result;
@@ -324,11 +325,9 @@ impl From<Announcement> for maia::Announcement {
 #[async_trait]
 impl xtra::Actor for Actor {
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
-        let fut = ctx
-            .notify_interval(std::time::Duration::from_secs(5), || Sync)
-            .expect("we just started");
-
-        self.tasks.add(fut);
+        let this = ctx.address().expect("we are alive");
+        self.tasks
+            .add(this.send_interval(std::time::Duration::from_secs(5), || Sync));
     }
 }
 

--- a/daemon/src/xtra_ext.rs
+++ b/daemon/src/xtra_ext.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use std::fmt;
+use std::time::Duration;
 use xtra::address;
 use xtra::message_channel;
 use xtra::Actor;
@@ -48,5 +49,44 @@ where
         }
 
         Ok(())
+    }
+}
+
+#[async_trait]
+pub trait SendInterval<A, M>
+where
+    M: Message,
+    A: xtra::Handler<M>,
+{
+    /// Similar to xtra::Context::notify_interval, however it uses `send`
+    /// instead of `do_send` under the hood.
+    /// The crucial difference is that this function waits until previous
+    /// handler returns before scheduling a new one, thus preventing them from
+    /// piling up.
+    /// As a bonus, this function is non-fallible.
+    async fn send_interval<F>(self, duration: Duration, constructor: F)
+    where
+        F: Send + Sync + Fn() -> M,
+        M: Message<Result = ()>,
+        A: xtra::Handler<M>;
+}
+
+#[async_trait]
+impl<A, M> SendInterval<A, M> for address::Address<A>
+where
+    M: Message,
+    A: xtra::Handler<M>,
+{
+    async fn send_interval<F>(self, duration: Duration, constructor: F)
+    where
+        F: Send + Sync + Fn() -> M,
+    {
+        while self.send(constructor()).await.is_ok() {
+            tokio::time::sleep(duration).await
+        }
+        tracing::warn!(
+            "Task for periodically sending message {} stopped because actor shut down",
+            std::any::type_name::<M>()
+        );
     }
 }


### PR DESCRIPTION
Stateless periodic messages (e.g. sync) should not be queued. If for some
reason, the actor blocks before handling a message, standard behaviour of
xtra (via `xtra::Context::notify_interval`) results in piling up many
messages, which then would be handled one after another, which is not the
desired behaviour.

Meanwhile, calling `send_interval()` will only schedule another message when the
previous one was handled.

Ban usage of `xtra::Context::notify_interval` via clippy lint.

Fixes #1042