### PR TITLE
Use new clippy `disallowed_methods` syntax

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,6 +1,6 @@
 disallowed-methods = [
-  "xtra::Address::do_send_async", # discards the return value, possibly swallowing an error
-  "xtra::Address::do_send", # discards the return value, possibly swallowing an error
-  "xtra::message_channel::MessageChannel::do_send", # discards the return value, possibly swallowing an error
-  "xtra::Context::notify_interval", # does not wait for response from the previous handler, prefer `xtra_ext::Address::send_interval`
+  { path = "xtra::Address::do_send_async", reason = "discards the return value, possibly swallowing an error" },
+  { path = "xtra::Address::do_send", reason = "discards the return value, possibly swallowing an error" },
+  { path = "xtra::message_channel::MessageChannel::do_send", reason = "discards the return value, possibly swallowing an error" },
+  { pant = "xtra::Context::notify_interval", reason = "does not wait for response from the previous handler, prefer `xtra_ext::Address::send_interval`" },
 ]

--- a/daemon/clippy.toml
+++ b/daemon/clippy.toml
@@ -1,3 +1,3 @@
 disallowed-methods = [
-  "tokio::spawn", # tasks can outlive the actor system, prefer spawn_with_handle()
+  { path = "tokio::spawn", reason = "tasks can outlive the actor system, prefer spawn_with_handle()" },
 ]


### PR DESCRIPTION
More clear in TOML file, hopefully will give better error messages as well.