### PR TITLE
Scan for the next 1000 addresses

### DIFF
--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -115,7 +115,7 @@ impl Actor {
 
     fn sync_internal(&mut self) -> Result<WalletInfo> {
         self.wallet
-            .sync(NoopProgress, None)
+            .sync(NoopProgress, Some(1000))
             .context("Failed to sync wallet")?;
 
         let balance = self.wallet.get_balance()?;


### PR DESCRIPTION
Fixes #965.

Seems to be an usptream bug: https://github.com/bitcoindevkit/bdk/issues/521.