### PR TITLE
Introduce `command::Executor`

### DIFF
--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -118,24 +118,6 @@ pub async fn apply_event(
     Ok(())
 }
 
-pub async fn handle_commit(
-    order_id: OrderId,
-    conn: &mut PoolConnection<Sqlite>,
-    process_manager: &xtra::Address<process_manager::Actor>,
-) -> Result<()> {
-    let cfd = load_cfd(order_id, conn).await?;
-
-    let event = cfd.manual_commit_to_blockchain()?;
-    if let Err(e) = process_manager
-        .send(process_manager::Event::new(event.clone()))
-        .await?
-    {
-        tracing::error!("Sending event to process manager failed: {:#}", e);
-    }
-
-    Ok(())
-}
-
 pub async fn handle_oracle_attestation(
     attestation: oracle::Attestation,
     db: &SqlitePool,

--- a/daemon/src/command.rs
+++ b/daemon/src/command.rs
@@ -1,0 +1,47 @@
+use crate::cfd_actors::load_cfd;
+use crate::model::cfd::Cfd;
+use crate::model::cfd::Event;
+use crate::process_manager;
+use crate::OrderId;
+use anyhow::Context;
+use anyhow::Result;
+use xtra::Address;
+
+pub struct Executor {
+    db: sqlx::SqlitePool,
+    process_manager: Address<process_manager::Actor>,
+}
+
+impl Executor {
+    pub fn new(db: sqlx::SqlitePool, process_manager: Address<process_manager::Actor>) -> Self {
+        Self {
+            db,
+            process_manager,
+        }
+    }
+
+    pub async fn execute(
+        &self,
+        id: OrderId,
+        command: impl FnOnce(Cfd) -> Result<Event>,
+    ) -> Result<()> {
+        let mut connection = self
+            .db
+            .acquire()
+            .await
+            .context("Failed to acquire DB connection")?;
+        let cfd = load_cfd(id, &mut connection)
+            .await
+            .context("Failed to load CFD")?;
+
+        let event = command(cfd).context("Failed to execute command on CFD")?;
+
+        self.process_manager
+            .send(process_manager::Event::new(event))
+            .await
+            .context("ProcessManager is disconnected")?
+            .context("Failed to process new domain event")?;
+
+        Ok(())
+    }
+}

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -36,6 +36,7 @@ pub mod bitmex_price_feed;
 pub mod cfd_actors;
 pub mod collab_settlement_maker;
 pub mod collab_settlement_taker;
+pub mod command;
 pub mod connection;
 pub mod db;
 pub mod fan_out;

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -3,6 +3,7 @@ use crate::address_map::Stopping;
 use crate::cfd_actors;
 use crate::cfd_actors::insert_cfd_and_update_feed;
 use crate::collab_settlement_maker;
+use crate::command;
 use crate::maker_inc_connections;
 use crate::model::cfd::Cfd;
 use crate::model::cfd::Order;
@@ -92,6 +93,7 @@ pub struct Actor<O, T, W> {
     settlement_actors: AddressMap<OrderId, collab_settlement_maker::Actor>,
     oracle: Address<O>,
     connected_takers: HashSet<Identity>,
+    executor: command::Executor,
     n_payouts: usize,
     tasks: Tasks,
 }
@@ -110,12 +112,12 @@ impl<O, T, W> Actor<O, T, W> {
         n_payouts: usize,
     ) -> Self {
         Self {
-            db,
+            db: db.clone(),
             wallet,
             settlement_interval,
             oracle_pk,
             projection,
-            process_manager,
+            process_manager: process_manager.clone(),
             rollover_actors: AddressMap::default(),
             takers,
             current_order: None,
@@ -125,6 +127,7 @@ impl<O, T, W> Actor<O, T, W> {
             connected_takers: HashSet::new(),
             settlement_actors: AddressMap::default(),
             tasks: Tasks::default(),
+            executor: command::Executor::new(db, process_manager),
         }
     }
 
@@ -394,10 +397,9 @@ impl<O, T, W> Actor<O, T, W> {
     }
 
     async fn handle_commit(&mut self, msg: Commit) -> Result<()> {
-        let Commit { order_id } = msg;
-
-        let mut conn = self.db.acquire().await?;
-        cfd_actors::handle_commit(order_id, &mut conn, &self.process_manager).await?;
+        self.executor
+            .execute(msg.order_id, |cfd| cfd.manual_commit_to_blockchain())
+            .await?;
 
         Ok(())
     }

--- a/daemon/src/setup_maker.rs
+++ b/daemon/src/setup_maker.rs
@@ -34,7 +34,7 @@ use xtra_productivity::xtra_productivity;
 
 pub struct Actor {
     db: sqlx::SqlitePool,
-    process_manager_actor: Address<process_manager::Actor>,
+    process_manager: Address<process_manager::Actor>,
     order: Order,
     quantity: Usd,
     n_payouts: usize,
@@ -55,7 +55,7 @@ impl Actor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         db: sqlx::SqlitePool,
-        process_manager_actor: Address<process_manager::Actor>,
+        process_manager: Address<process_manager::Actor>,
         (order, quantity, n_payouts): (Order, Usd, usize),
         (oracle_pk, announcement): (schnorrsig::PublicKey, Announcement),
         build_party_params: &(impl MessageChannel<wallet::BuildPartyParams> + 'static),
@@ -73,7 +73,7 @@ impl Actor {
     ) -> Self {
         Self {
             db,
-            process_manager_actor,
+            process_manager,
             order,
             quantity,
             n_payouts,
@@ -102,7 +102,7 @@ impl Actor {
         let mut conn = self.db.acquire().await?;
         let cfd = load_cfd(order_id, &mut conn).await?;
         let (event, setup_params) = cfd.start_contract_setup()?;
-        apply_event(&self.process_manager_actor, event).await?;
+        apply_event(&self.process_manager, event).await?;
 
         let taker_id = setup_params.counterparty_identity();
 

--- a/daemon/src/setup_maker.rs
+++ b/daemon/src/setup_maker.rs
@@ -286,10 +286,6 @@ pub struct Accepted;
 /// the taker order request from the taker.
 pub struct Rejected;
 
-/// Message sent from the `setup_maker::Actor` to the
-/// `maker_cfd::Actor` to notify that the contract setup has started.
-pub struct Started(pub OrderId);
-
 /// Message sent from the spawned task to `setup_maker::Actor` to
 /// notify that the contract setup has finished successfully.
 pub struct SetupSucceeded {
@@ -302,8 +298,4 @@ pub struct SetupSucceeded {
 pub struct SetupFailed {
     order_id: OrderId,
     error: anyhow::Error,
-}
-
-impl xtra::Message for Started {
-    type Result = ();
 }

--- a/daemon/src/setup_maker.rs
+++ b/daemon/src/setup_maker.rs
@@ -288,14 +288,14 @@ pub struct Rejected;
 
 /// Message sent from the spawned task to `setup_maker::Actor` to
 /// notify that the contract setup has finished successfully.
-pub struct SetupSucceeded {
+struct SetupSucceeded {
     order_id: OrderId,
     dlc: Dlc,
 }
 
 /// Message sent from the spawned task to `setup_maker::Actor` to
 /// notify that the contract setup has failed.
-pub struct SetupFailed {
+struct SetupFailed {
     order_id: OrderId,
     error: anyhow::Error,
 }

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -140,29 +140,27 @@ impl Actor {
         Ok(())
     }
 
-    fn handle(&mut self, msg: SetupSucceeded, ctx: &mut xtra::Context<Self>) -> Result<()> {
-        self.on_completed
+    fn handle(&mut self, msg: SetupSucceeded, ctx: &mut xtra::Context<Self>) {
+        let _: Result<(), xtra::Disconnected> = self
+            .on_completed
             .send(SetupCompleted::succeeded(msg.order_id, msg.dlc))
             .log_failure("Failed to inform about contract setup completion")
-            .await?;
+            .await;
 
         ctx.stop();
-
-        Ok(())
     }
 
-    fn handle(&mut self, msg: SetupFailed, ctx: &mut xtra::Context<Self>) -> Result<()> {
-        self.on_completed
+    fn handle(&mut self, msg: SetupFailed, ctx: &mut xtra::Context<Self>) {
+        let _: Result<(), xtra::Disconnected> = self
+            .on_completed
             .send(SetupCompleted::Failed {
                 order_id: msg.order_id,
                 error: msg.error,
             })
             .log_failure("Failed to inform about contract setup failure")
-            .await?;
+            .await;
 
         ctx.stop();
-
-        Ok(())
     }
 }
 

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -204,14 +204,14 @@ pub struct Rejected {
 
 /// Message sent from the spawned task to `setup_taker::Actor` to
 /// notify that the contract setup has finished successfully.
-pub struct SetupSucceeded {
+struct SetupSucceeded {
     order_id: OrderId,
     dlc: Dlc,
 }
 
 /// Message sent from the spawned task to `setup_taker::Actor` to
 /// notify that the contract setup has failed.
-pub struct SetupFailed {
+struct SetupFailed {
     order_id: OrderId,
     error: anyhow::Error,
 }

--- a/daemon/src/tokio_ext.rs
+++ b/daemon/src/tokio_ext.rs
@@ -2,25 +2,10 @@ use futures::future::RemoteHandle;
 use futures::FutureExt as _;
 use std::any::Any;
 use std::any::TypeId;
-use std::fmt;
 use std::future::Future;
 use std::time::Duration;
 use tokio::time::timeout;
 use tokio::time::Timeout;
-
-pub fn spawn_fallible<F, E>(future: F)
-where
-    F: Future<Output = Result<(), E>> + Send + 'static,
-    E: fmt::Display,
-{
-    // we want to disallow calls to tokio::spawn outside FutureExt
-    #[allow(clippy::disallowed_method)]
-    tokio::spawn(async move {
-        if let Err(e) = future.await {
-            tracing::warn!("Task failed: {:#}", e);
-        }
-    });
-}
 
 pub trait FutureExt: Future + Sized {
     fn timeout(self, duration: Duration) -> Timeout<Self>;

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -1,6 +1,6 @@
 use crate::model::Timestamp;
 use crate::model::WalletInfo;
-use crate::tokio_ext::spawn_fallible;
+use crate::send_async_safe::SendAsyncSafe;
 use crate::xtra_ext::SendInterval;
 use crate::Tasks;
 use anyhow::bail;
@@ -157,15 +157,10 @@ impl Actor {
         )?;
 
         self.wallet = wallet;
-
         self.used_utxos.clear();
 
         let this = ctx.address().expect("self to be alive");
-
-        spawn_fallible::<_, anyhow::Error>(async move {
-            let _ = this.send(Sync).await?;
-            Ok(())
-        });
+        let _: Result<(), xtra::Disconnected> = this.send_async_safe(Sync).await;
 
         Ok(())
     }


### PR DESCRIPTION
I initially set out to https://github.com/itchysats/itchysats/issues/1035 and made so many improvements on the way that I figured I post them up as a separate PR.

This ended up primarily introducing a concept I called `command::Executor` which wraps the DB connection and the ProcessManager and allows us to easily execute a command against a CFD.

I've used it already for some things inside taker and maker CFD actor, then wanted to move the invocation of the command on the CFD for monitoring into the monitoring actor which triggered a refactor there. Couldn't quite finish that unfortunately because our tests still rely on being able to dispatch a monitoring event to the CFD actors!