### PR TITLE
Remove solved TODO

### DIFF
--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -417,7 +417,6 @@ pub async fn roll_over(
     let maker_lock_amount = dlc.maker_lock_amount;
     let taker_lock_amount = dlc.taker_lock_amount;
     let payouts = HashMap::from_iter([(
-        // TODO : we want to support multiple announcements
         Announcement {
             id: announcement.id.to_string(),
             nonce_pks: announcement.nonce_pks.clone(),


### PR DESCRIPTION
We support multiple announcements in the sense that `maia` takes payouts indexed by announcements. We just have to use it in
`itchysats`. I'm not sure if there is an issue for using it in `itchysats`, but we could create one if it's something that we want to do.