### PR TITLE
Pass in funding rate in daily percentage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,7 @@ dependencies = [
  "ndarray_einsum_beta",
  "num",
  "pretty_assertions",
+ "proptest",
  "rand 0.6.5",
  "reqwest",
  "rocket",
@@ -2013,6 +2014,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error",
+ "rand 0.8.4",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,7 +2060,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi 0.3.9",
 ]
 
@@ -2206,6 +2230,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -61,6 +61,7 @@ path = "src/maker.rs"
 mockall = "0.11.0"
 mockall_derive = "0.11.0"
 pretty_assertions = "1"
+proptest = { version = "1", default-features = false, features = ["std"] }
 serde_test = "1"
 time = { version = "0.3", features = ["std"] }
 

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -1,5 +1,7 @@
 use crate::maker_inc_connections::NoConnection;
 use crate::model::BitMexPriceEventId;
+use crate::model::FundingFee;
+use crate::model::FundingRate;
 use crate::model::Identity;
 use crate::model::InversePrice;
 use crate::model::Leverage;
@@ -424,6 +426,7 @@ pub struct Cfd {
     id: OrderId,
     position: Position,
     initial_price: Price,
+    funding_rate: FundingRate,
     leverage: Leverage,
     settlement_interval: Duration,
     quantity: Usd,
@@ -502,6 +505,7 @@ impl Cfd {
             during_contract_setup: false,
             during_rollover: false,
             settlement_proposal: None,
+            funding_rate: FundingRate::new(Decimal::ZERO).expect("be valid"),
         }
     }
 
@@ -640,7 +644,8 @@ impl Cfd {
                 self.leverage,
                 self.refund_timelock_in_blocks(),
                 1, // TODO: Where should I get the fee rate from?
-            ),
+                self.funding_rate,
+            )?,
         ))
     }
 
@@ -665,6 +670,16 @@ impl Cfd {
             return Err(RolloverError::WrongRole);
         }
 
+        // TODO: Adjust for total paid fees
+        let margin_minus_total_fees = self.margin();
+
+        // TODO: Calculate the time from the last rollover, don't just assume
+        // it's up-to-date
+        let hours_to_charge = 1;
+
+        let funding_fee =
+            FundingFee::new(margin_minus_total_fees, self.funding_rate, hours_to_charge)?;
+
         Ok((
             Event::new(self.id, CfdEvent::RolloverAccepted),
             RolloverParams::new(
@@ -673,6 +688,7 @@ impl Cfd {
                 self.leverage,
                 self.refund_timelock_in_blocks(),
                 1, // TODO: Where should I get the fee rate from?
+                funding_fee,
             ),
             self.dlc.as_ref().ok_or(RolloverError::NoDlc)?.clone(),
             self.settlement_interval,
@@ -692,6 +708,12 @@ impl Cfd {
 
         self.can_rollover()?;
 
+        // TODO: Taker should take this from the maker, optionally calculate and verify
+        // whether they match
+        let hours_to_charge = 1;
+
+        let funding_fee = FundingFee::new(self.margin(), self.funding_rate, hours_to_charge)?;
+
         Ok((
             self.event(CfdEvent::RolloverAccepted),
             RolloverParams::new(
@@ -700,6 +722,7 @@ impl Cfd {
                 self.leverage,
                 self.refund_timelock_in_blocks(),
                 1, // TODO: Where should I get the fee rate from?
+                funding_fee,
             ),
             self.dlc.as_ref().ok_or(RolloverError::NoDlc)?.clone(),
         ))
@@ -742,6 +765,11 @@ impl Cfd {
             self.quantity,
             self.leverage,
             n_payouts,
+            FundingFee::new(
+                self.margin(),
+                self.funding_rate,
+                SETTLEMENT_INTERVAL.whole_hours(),
+            )?,
         )?;
 
         let payout = {


### PR DESCRIPTION
Hourly rollovers are charged a fraction of the daily amount, based on the current funding rate, e.g. `1/24 * 0.002`.

Note: Unit tests for calculating funding rates are coming in subsequent PR, as well as missing functionality. I'll open a separate issue to track the remaining backend issues.