### PR TITLE
Simplify CFD read model of projection actor

### DIFF
--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -433,16 +433,16 @@ pub struct Cfd {
     // dynamic (based on events)
     dlc: Option<Dlc>,
 
-    /// Holds the decrypted CET transaction once it is available in the CFD lifecycle
+    /// Holds the decrypted CET transaction if we have previously emitted it as part of an event.
     ///
-    /// Only `Some` in case we receive the attestation after the CET timelock expiry.
-    /// This does _not_ imply that the transaction is actually confirmed.
+    /// There is not guarantee that the transaction is confirmed if this is set to `Some`.
+    /// However, if this is set to `Some`, there is no need to re-emit it as part of another event.
     cet: Option<Transaction>,
 
-    /// Holds the decrypted commit transaction once it is available in the CFD lifecycle
+    /// Holds the decrypted commit transaction if we have previously emitted it as part of an event.
     ///
-    /// Only `Some` in case we receive the attestation before the CET timelock expiry.
-    /// This does _not_ imply that the transaction is actually confirmed.
+    /// There is not guarantee that the transaction is confirmed if this is set to `Some`.
+    /// However, if this is set to `Some`, there is no need to re-emit it as part of another event.
     commit_tx: Option<Transaction>,
 
     collaborative_settlement_spend_tx: Option<Transaction>,

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -407,11 +407,13 @@ impl Cfd {
                 self.profit_btc = profit_btc;
                 self.profit_percent = profit_percent;
 
-                self.details.tx_url_list.push(TxUrl::new(
-                    commit_tx.txid(),
-                    network,
-                    TxLabel::Commit,
-                ));
+                if let Some(commit_tx) = commit_tx {
+                    self.details.tx_url_list.push(TxUrl::new(
+                        commit_tx.txid(),
+                        network,
+                        TxLabel::Commit,
+                    ));
+                }
 
                 // Only allow committing once the oracle attested.
                 (CfdState::PendingCommit, vec![])

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -435,8 +435,7 @@ impl Cfd {
                 self.profit_btc = profit_btc;
                 self.profit_percent = profit_percent;
 
-                // Only allow committing once the oracle attested.
-                (CfdState::PendingCet, vec![CfdAction::Commit])
+                (CfdState::PendingCet, vec![])
             }
             ManualCommit { tx } => {
                 self.details


### PR DESCRIPTION
Almost a pure refactor. One tiny change in when we emit commit tx.

I started out with using `HashSet`s instead of `Vec` which prevents duplicates by default and ended up refactoring the entire function to be composed of multiple pure functions. Strictly speaking, we no longer need the `HashSet`s now because we are not modifying the set but always replacing the entire collection. We could thus revert the change to a `HashSet` but I think it is overall the more suited data structure. Open to discuss though.