### PR TITLE
Disable incremental builds on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - 'staging'
       - 'master'
 
+env:
+  CARGO_INCREMENTAL: 0
+
 jobs:
   formatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We don't use incremental builds on the CI - the premise is that it should
faster without it.