### PR TITLE
Unify clippy.toml files

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -2,5 +2,6 @@ disallowed-methods = [
   { path = "xtra::Address::do_send_async", reason = "discards the return value, possibly swallowing an error" },
   { path = "xtra::Address::do_send", reason = "discards the return value, possibly swallowing an error" },
   { path = "xtra::message_channel::MessageChannel::do_send", reason = "discards the return value, possibly swallowing an error" },
-  { pant = "xtra::Context::notify_interval", reason = "does not wait for response from the previous handler, prefer `xtra_ext::Address::send_interval`" },
+  { path = "xtra::Context::notify_interval", reason = "does not wait for response from the previous handler, prefer `xtra_ext::Address::send_interval`" },
+  { path = "tokio::spawn", reason = "tasks can outlive the actor system, prefer spawn_with_handle()" },
 ]

--- a/daemon/clippy.toml
+++ b/daemon/clippy.toml
@@ -1,3 +1,0 @@
-disallowed-methods = [
-  { path = "tokio::spawn", reason = "tasks can outlive the actor system, prefer spawn_with_handle()" },
-]


### PR DESCRIPTION
Somehow we ended up with 2 places where we added clippy lints.
Preserve a single one at workspace level by merging contents of daemon-specific
one into it.