### PR TITLE
Add clippy lint for spotting dbg! macro

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
 #![warn(clippy::disallowed_method)]
+#![warn(clippy::dbg_macro)] // should be used only as a temporary debugging tool
 use crate::bitcoin::Txid;
 use crate::model::cfd::Order;
 use crate::model::cfd::OrderId;


### PR DESCRIPTION
We should never commit this macro, it's for temporary usage.