### PR TITLE
Reduce usage of magic numbers

### DIFF
--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -337,8 +337,8 @@ pub fn dummy_price() -> Price {
 pub fn dummy_quote() -> Quote {
     Quote {
         timestamp: Timestamp::now(),
-        bid: Price::new(dec!(50_000)).expect("to not fail"),
-        ask: Price::new(dec!(50_000)).expect("to not fail"),
+        bid: dummy_price(),
+        ask: dummy_price(),
     }
 }
 


### PR DESCRIPTION
Within `dummy_quote`, we should be using `dummy_price`.