### PR TITLE
Set `PendingClose` after proposal is accepted

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -329,7 +329,7 @@ impl Cfd {
             CollaborativeSettlementProposalAccepted => {
                 self.pending_settlement_proposal_price = None;
 
-                self.state = CfdState::IncomingSettlementProposal;
+                self.state = CfdState::PendingClose;
             }
             CollaborativeSettlementCompleted {
                 spend_tx,


### PR DESCRIPTION
Otherwise we will expose accept/reject buttons in the UI although
it has already been accepted.