### PR TITLE
Populate minimal opening fee in the projection

### DIFF
--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -640,6 +640,7 @@ impl Default for FundingRate {
 pub struct FundingFee(u64);
 
 impl FundingFee {
+    /// Value in satoshis
     pub fn as_u64(&self) -> u64 {
         self.0
     }
@@ -649,6 +650,12 @@ impl Default for FundingFee {
     fn default() -> Self {
         Self::new(Amount::ZERO, FundingRate(Decimal::ZERO), 1)
             .expect("hard-coded values to be valid")
+    }
+}
+
+impl From<FundingFee> for Amount {
+    fn from(funding_fee: FundingFee) -> Self {
+        Self::from_sat(funding_fee.as_u64())
     }
 }
 


### PR DESCRIPTION
Unfortunately, a Cfd offer from the maker is not enough to adequately calculate
opening fees, as we need quantity to do that.

For the time being, opt for calculating the fees for the min_quantity.
The total expected fees can be easily estimated by the user from that (or the UI
could even do a simple multiplication by `quantity / min_quantity`).

Another simpler approach could be the UI displaying:
    "opening fees from xxx for min_quantity"