### PR TITLE
Populate next funding event in the projection

### DIFF
--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -302,7 +302,7 @@ pub fn next_announcement_after(timestamp: OffsetDateTime) -> Result<BitMexPriceE
     Ok(BitMexPriceEventId::with_20_digits(adjusted))
 }
 
-fn ceil_to_next_hour(original: OffsetDateTime) -> Result<OffsetDateTime, anyhow::Error> {
+pub fn ceil_to_next_hour(original: OffsetDateTime) -> Result<OffsetDateTime, anyhow::Error> {
     let timestamp = original.add(1.hours());
     let exact_hour = Time::from_hms(timestamp.hour(), 0, 0)
         .context("Could not adjust time for next announcement")?;


### PR DESCRIPTION
Move the field from order to cfd - we don't know the next funding event in the
order, as it hasn't been taken yet.

Estimate the value based on the next full hour from the latest contract setup or
rollover completion.

In fullness of time, these events should probably communicate when the next
rollover will happen.