### PR TITLE
Small fix for UI tx-list decision logic

### DIFF
--- a/taker-frontend/src/components/History.tsx
+++ b/taker-frontend/src/components/History.tsx
@@ -18,7 +18,7 @@ import {
     VStack,
 } from "@chakra-ui/react";
 import * as React from "react";
-import { Cfd, ConnectionStatus, isClosed, Tx, TxLabel } from "../types";
+import { Cfd, ConnectionStatus, isClosed, StateKey, Tx, TxLabel } from "../types";
 import usePostRequest from "../usePostRequest";
 import CloseButton from "./CloseButton";
 
@@ -170,7 +170,7 @@ const CfdDetails = ({ cfd, connectedToMaker, displayCloseButton }: CfdDetailsPro
                                 <Td><Text>Refund</Text></Td>
                                 <Td><TxIcon tx={txRefund} /></Td>
                             </Tr>
-                            : txCommit || !connectedToMaker.online
+                            : txCommit || (cfd.state.key === StateKey.OPEN && !connectedToMaker.online)
                             ? <>
                                 <Tr>
                                     <Td><Text>Force</Text></Td>


### PR DESCRIPTION

`Force + Payout` when disconnected is only relevant in `Open`.
Otherwise collaborativly closed positions will not be shown correctly when disconnected from the maker.