### PR TITLE
Use the correct separator to highlight the output

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -928,7 +928,7 @@ impl TxUrl {
 
     /// Highlight particular transaction output in the TxUrl
     fn with_output_index(mut self, index: u32) -> Self {
-        self.url.push_str(&("#".to_string() + &index.to_string()));
+        self.url.push_str(&format!(":{index}"));
         self
     }
 


### PR DESCRIPTION
Now we are actually highlighting the output:

![image](https://user-images.githubusercontent.com/5486389/150464051-218016f7-ac89-4a33-9ea9-47b380514fd7.png)
