### PR TITLE
Fix title when closing CFD

### DIFF
--- a/taker-frontend/src/components/CloseButton.tsx
+++ b/taker-frontend/src/components/CloseButton.tsx
@@ -83,7 +83,7 @@ export default function CloseButton({ cfd, request, status, buttonTitle, isForce
                             }}
                             isLoading={status}
                         >
-                            {buttonTitle}
+                            {buttonTitle} Position
                         </Button>
                     </PopoverFooter>
                 </PopoverContent>

--- a/taker-frontend/src/components/History.tsx
+++ b/taker-frontend/src/components/History.tsx
@@ -81,14 +81,14 @@ const CfdDetails = ({ cfd, connectedToMaker, displayCloseButton }: CfdDetailsPro
             request={settle}
             status={isSettling}
             cfd={cfd}
-            buttonTitle="Close Position"
+            buttonTitle="Close"
             isForceCloseButton={false}
         />
         : <CloseButton
             request={commit}
             status={isCommiting}
             cfd={cfd}
-            buttonTitle="Force Close Position"
+            buttonTitle="Force-close"
             isForceCloseButton={true}
         />;
 


### PR DESCRIPTION
Now we display "Close your position" or "Force-close your position" at the top. And the actual buttons are still called either "Close Position" or "Force-close Position".

Old:

![positionposition](https://user-images.githubusercontent.com/9418575/150465485-1ba9b14f-a7e1-4fbf-9793-13c45b5d95da.PNG)

New:

![position](https://user-images.githubusercontent.com/9418575/150465498-38b3ada7-0760-4cee-98d8-39d1a4ca1e0d.PNG)

