### PR TITLE
Profit based on actual payout if the payout is known

### DIFF
--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -53,10 +53,6 @@ impl Usd {
         self.0.to_u64().context("could not fit decimal into u64")
     }
 
-    pub fn try_into_f64(&self) -> Result<f64> {
-        self.0.to_f64().context("Could not fit decimal into f64")
-    }
-
     #[must_use]
     pub fn into_decimal(self) -> Decimal {
         self.0
@@ -145,10 +141,6 @@ impl InversePrice {
 
     pub fn try_into_u64(&self) -> Result<u64> {
         self.0.to_u64().context("Could not fit decimal into u64")
-    }
-
-    pub fn try_into_f64(&self) -> Result<f64> {
-        self.0.to_f64().context("Could not fit decimal into f64")
     }
 }
 

--- a/maker-frontend/src/components/Types.tsx
+++ b/maker-frontend/src/components/Types.tsx
@@ -42,8 +42,9 @@ export interface Cfd {
 
     margin: number;
 
-    profit_btc: number;
-    profit_in_percent: number;
+    profit_btc?: number;
+    profit_in_percent?: number;
+    payout?: number;
 
     state: State;
     actions: Action[];
@@ -55,7 +56,6 @@ export interface Cfd {
 
 export interface CfdDetails {
     tx_url_list: Tx[];
-    payout?: number;
 }
 
 export interface Tx {

--- a/maker-frontend/src/components/cfdtables/CfdTable.tsx
+++ b/maker-frontend/src/components/cfdtables/CfdTable.tsx
@@ -103,7 +103,6 @@ export function CfdTable(
                         <Box>
                             <VStack>
                                 {txs}
-                                {details.payout && <Box>Payout: {details.payout}</Box>}
                                 {expiry_timestamp && <HStack>
                                     <Text>Expires on:</Text>
                                     <Timestamp timestamp={expiry_timestamp} />
@@ -162,6 +161,11 @@ export function CfdTable(
             {
                 Header: "Unrealized P/L %",
                 accessor: "profit_in_percent",
+                isNumeric: true,
+            },
+            {
+                Header: "Payout",
+                accessor: "payout",
                 isNumeric: true,
             },
             {

--- a/taker-frontend/src/components/History.tsx
+++ b/taker-frontend/src/components/History.tsx
@@ -62,6 +62,7 @@ interface CfdDetailsProps {
 const CfdDetails = ({ cfd, connectedToMaker, displayCloseButton }: CfdDetailsProps) => {
     const initialPrice = `$${cfd.initial_price.toLocaleString()}`;
     const margin = `₿${Math.round((cfd.margin) * 1_000_000) / 1_000_000}`;
+    const payout = `₿${Math.round((cfd.payout ? cfd.payout : 0) * 1_000_000) / 1_000_000}`;
     const liquidationPrice = `$${cfd.liquidation_price}`;
     const contracts = `${cfd.quantity_usd}`;
 
@@ -123,8 +124,8 @@ const CfdDetails = ({ cfd, connectedToMaker, displayCloseButton }: CfdDetailsPro
                         <Tr textColor={useColorModeValue(profitColors[0], profitColors[1])}>
                             <Td><Text as={"b"}>Payout</Text></Td>
                             <Td textAlign="right">
-                                <Skeleton isLoaded={cfd.profit_btc != null}>
-                                    <Payout profitBtc={cfd.profit_btc!} margin={cfd.margin} />
+                                <Skeleton isLoaded={cfd.payout != null}>
+                                    {payout}
                                 </Skeleton>
                             </Td>
                         </Tr>
@@ -196,19 +197,6 @@ const CfdDetails = ({ cfd, connectedToMaker, displayCloseButton }: CfdDetailsPro
         </HStack>
     );
 };
-
-interface PayoutProps {
-    profitBtc: number;
-    margin: number;
-}
-
-function Payout({ profitBtc, margin }: PayoutProps) {
-    let payoutBtc = Math.round((margin + profitBtc) * 1_000_000) / 1_000_000;
-
-    return <Text>
-        ₿{payoutBtc}
-    </Text>;
-}
 
 interface TxIconProps {
     tx?: Tx;

--- a/taker-frontend/src/types.ts
+++ b/taker-frontend/src/types.ts
@@ -60,6 +60,7 @@ export interface Cfd {
 
     profit_btc?: number;
     profit_percent?: number;
+    payout?: number;
 
     state: State;
     details: CfdDetails;
@@ -76,7 +77,6 @@ export function isClosed(cfd: Cfd): boolean {
 
 export interface CfdDetails {
     tx_url_list: Tx[];
-    payout?: number;
 }
 
 export interface Tx {


### PR DESCRIPTION
Prior to adding the fees on top of the profit and loss calculation I thought it's probably a good idea to finally fix some tech debt. 

The profit and loss should always be based on the payout, and if we know the specific payout we should use that instead of calculating from a price. 