### PR TITLE
Accumulate funding fees stored in the CfdEvents

### DIFF
--- a/daemon/migrations/20220121052945_add_opening_fee.sql
+++ b/daemon/migrations/20220121052945_add_opening_fee.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    cfds
+ADD
+    COLUMN opening_fee NOT NULL DEFAULT '0';

--- a/daemon/migrations/20220124063030_add_initial_funding_rate.sql
+++ b/daemon/migrations/20220124063030_add_initial_funding_rate.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    cfds
+ADD
+    COLUMN initial_funding_rate NOT NULL DEFAULT '0';

--- a/daemon/sqlx-data.json
+++ b/daemon/sqlx-data.json
@@ -24,8 +24,8 @@
       ]
     }
   },
-  "e8a672355cd8c799b6291ccb629837dcd3a3fa9d3954bb78d22ba98e99674341": {
-    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: crate::model::cfd::OrderId\",\n                position as \"position: crate::model::Position\",\n                initial_price as \"initial_price: crate::model::Price\",\n                leverage as \"leverage: crate::model::Leverage\",\n                settlement_time_interval_hours,\n                quantity_usd as \"quantity_usd: crate::model::Usd\",\n                counterparty_network_identity as \"counterparty_network_identity: crate::model::Identity\",\n                role as \"role: crate::model::cfd::Role\"\n            from\n                cfds\n            where\n                cfds.uuid = $1\n            ",
+  "adb69ad1009b9096072f0357b6db27d89b6a6e47b8a820f2e1ce6a0966d5fca1": {
+    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: crate::model::cfd::OrderId\",\n                position as \"position: crate::model::Position\",\n                initial_price as \"initial_price: crate::model::Price\",\n                leverage as \"leverage: crate::model::Leverage\",\n                settlement_time_interval_hours,\n                quantity_usd as \"quantity_usd: crate::model::Usd\",\n                counterparty_network_identity as \"counterparty_network_identity: crate::model::Identity\",\n                role as \"role: crate::model::cfd::Role\",\n                opening_fee as \"opening_fee: crate::model::OpeningFee\",\n                initial_funding_rate as \"initial_funding_rate: crate::model::FundingRate\"\n            from\n                cfds\n            where\n                cfds.uuid = $1\n            ",
     "describe": {
       "columns": [
         {
@@ -72,6 +72,16 @@
           "name": "role: crate::model::cfd::Role",
           "ordinal": 8,
           "type_info": "Text"
+        },
+        {
+          "name": "opening_fee: crate::model::OpeningFee",
+          "ordinal": 9,
+          "type_info": "Null"
+        },
+        {
+          "name": "initial_funding_rate: crate::model::FundingRate",
+          "ordinal": 10,
+          "type_info": "Null"
         }
       ],
       "parameters": {
@@ -79,6 +89,8 @@
       },
       "nullable": [
         true,
+        false,
+        false,
         false,
         false,
         false,

--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -85,6 +85,8 @@ pub async fn load_cfd(order_id: OrderId, conn: &mut PoolConnection<Sqlite>) -> R
             counterparty_network_identity,
             role,
             quantity_usd,
+            opening_fee,
+            initial_funding_rate,
         },
         events,
     ) = db::load_cfd(order_id, conn).await?;
@@ -97,6 +99,8 @@ pub async fn load_cfd(order_id: OrderId, conn: &mut PoolConnection<Sqlite>) -> R
         quantity_usd,
         counterparty_network_identity,
         role,
+        opening_fee,
+        initial_funding_rate,
         events,
     );
     Ok(cfd)

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -21,6 +21,7 @@ use connection::ConnectionStatus;
 use futures::future::RemoteHandle;
 use maia::secp256k1_zkp::schnorrsig;
 use model::FundingRate;
+use model::OpeningFee;
 use sqlx::SqlitePool;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -236,6 +237,7 @@ where
         max_quantity: Usd,
         fee_rate: Option<u32>,
         funding_rate: Option<FundingRate>,
+        opening_fee: Option<OpeningFee>,
     ) -> Result<()> {
         self.cfd_actor
             .send(maker_cfd::NewOrder {
@@ -244,6 +246,7 @@ where
                 max_quantity,
                 tx_fee_rate: fee_rate.unwrap_or(1),
                 funding_rate: funding_rate.unwrap_or_default(),
+                opening_fee: opening_fee.unwrap_or_default(),
             })
             .await??;
 

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -14,6 +14,7 @@ use crate::model::cfd::RolloverProposal;
 use crate::model::cfd::SettlementProposal;
 use crate::model::FundingRate;
 use crate::model::Identity;
+use crate::model::OpeningFee;
 use crate::model::Position;
 use crate::model::Price;
 use crate::model::Usd;
@@ -81,6 +82,7 @@ pub struct NewOrder {
     pub max_quantity: Usd,
     pub tx_fee_rate: u32,
     pub funding_rate: FundingRate,
+    pub opening_fee: OpeningFee,
 }
 
 #[derive(Debug)]
@@ -508,6 +510,7 @@ where
             max_quantity,
             tx_fee_rate,
             funding_rate,
+            opening_fee,
         } = msg;
 
         let oracle_event_id = oracle::next_announcement_after(
@@ -523,6 +526,7 @@ where
             self.settlement_interval,
             tx_fee_rate,
             funding_rate,
+            opening_fee,
         )?;
 
         // 1. Update actor state to current order

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -764,11 +764,7 @@ impl Cfd {
             self.quantity,
             self.leverage,
             n_payouts,
-            FundingFee::new(
-                self.margin(),
-                self.initial_funding_rate,
-                SETTLEMENT_INTERVAL.whole_hours(),
-            )?,
+            self.total_funding_fees.clone(),
         )?;
 
         let payout = {
@@ -813,11 +809,7 @@ impl Cfd {
             self.quantity,
             self.leverage,
             n_payouts,
-            FundingFee::new(
-                self.counterparty_margin(),
-                self.funding_rate,
-                SETTLEMENT_INTERVAL.whole_hours(),
-            )?,
+            self.total_funding_fees,
         )?;
 
         let payout = {

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -50,6 +50,8 @@ use time::OffsetDateTime;
 use uuid::adapter::Hyphenated;
 use uuid::Uuid;
 
+use super::OpeningFee;
+
 pub const CET_TIMELOCK: u32 = 12;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, sqlx::Type)]
@@ -107,7 +109,7 @@ pub enum Origin {
 }
 
 /// Role in the Cfd
-#[derive(Debug, Copy, Clone, PartialEq, sqlx::Type)]
+#[derive(Debug, Copy, Clone, PartialEq, sqlx::Type, Serialize, Deserialize)]
 pub enum Role {
     Maker,
     Taker,
@@ -156,6 +158,7 @@ pub struct Order {
 
     pub tx_fee_rate: u32,
     pub funding_rate: FundingRate,
+    pub opening_fee: OpeningFee,
 }
 
 impl Order {
@@ -169,6 +172,7 @@ impl Order {
         settlement_interval: Duration,
         tx_fee_rate: u32,
         funding_rate: FundingRate,
+        opening_fee: OpeningFee,
     ) -> Result<Self> {
         let leverage = Leverage::new(2)?;
         let liquidation_price = calculate_long_liquidation_price(leverage, price);
@@ -188,6 +192,7 @@ impl Order {
             oracle_event_id,
             tx_fee_rate,
             funding_rate,
+            opening_fee,
         })
     }
 }
@@ -280,6 +285,7 @@ pub enum CfdEvent {
     RolloverRejected,
     RolloverCompleted {
         dlc: Dlc,
+        funding_fee: FundingFee,
     },
     RolloverFailed,
 
@@ -394,14 +400,16 @@ pub struct Cfd {
     id: OrderId,
     position: Position,
     initial_price: Price,
-    funding_rate: FundingRate,
+    initial_funding_rate: FundingRate,
     leverage: Leverage,
     settlement_interval: Duration,
     quantity: Usd,
     counterparty_network_identity: Identity,
     role: Role,
-
+    opening_fee: OpeningFee,
     // dynamic (based on events)
+    total_funding_fees: FundingFee,
+
     dlc: Option<Dlc>,
 
     /// Holds the decrypted CET transaction if we have previously emitted it as part of an event.
@@ -448,7 +456,19 @@ impl Cfd {
         role: Role,
         quantity: Usd,
         counterparty_network_identity: Identity,
+        opening_fee: OpeningFee,
+        initial_funding_rate: FundingRate,
     ) -> Self {
+        let long_initial_margin = calculate_long_margin(initial_price, quantity, leverage);
+        // TODO: Use FundingFee::default() if we don't want to charge funding fees
+        // based on quantity for the first settlement interval.
+        let funding_fees = FundingFee::new(
+            long_initial_margin,
+            initial_funding_rate,
+            SETTLEMENT_INTERVAL.whole_hours(),
+        )
+        .expect("values stored in db to be sane");
+
         Cfd {
             version: 0,
             id,
@@ -459,6 +479,8 @@ impl Cfd {
             quantity,
             counterparty_network_identity,
             role,
+            initial_funding_rate,
+            opening_fee,
             dlc: None,
             cet: None,
             commit_tx: None,
@@ -474,7 +496,7 @@ impl Cfd {
             during_contract_setup: false,
             during_rollover: false,
             settlement_proposal: None,
-            funding_rate: FundingRate::new(Decimal::ZERO).expect("be valid"),
+            total_funding_fees: funding_fees.with_opening_fee(opening_fee),
         }
     }
 
@@ -495,6 +517,8 @@ impl Cfd {
             role,
             quantity,
             counterparty_network_identity,
+            order.opening_fee,
+            order.funding_rate,
         )
     }
 
@@ -509,6 +533,8 @@ impl Cfd {
         quantity: Usd,
         counterparty_network_identity: Identity,
         role: Role,
+        opening_fee: OpeningFee,
+        initial_funding_rate: FundingRate,
         events: Vec<Event>,
     ) -> Self {
         let cfd = Self::new(
@@ -520,6 +546,8 @@ impl Cfd {
             role,
             quantity,
             counterparty_network_identity,
+            opening_fee,
+            initial_funding_rate,
         );
         events.into_iter().fold(cfd, Cfd::apply)
     }
@@ -615,7 +643,7 @@ impl Cfd {
                 self.leverage,
                 self.refund_timelock_in_blocks(),
                 1, // TODO: Where should I get the fee rate from?
-                self.funding_rate,
+                self.total_funding_fees.clone(),
             )?,
         ))
     }
@@ -639,15 +667,19 @@ impl Cfd {
             bail!("Can only accept proposal as a maker");
         }
 
-        // TODO: Adjust for total paid fees
+        // TODO: Adjust for total paid fees - do we still need to do that if we
+        // tally up the fees???
         let margin_minus_total_fees = self.margin();
 
         // TODO: Calculate the time from the last rollover, don't just assume
         // it's up-to-date
         let hours_to_charge = 1;
 
-        let funding_fee =
-            FundingFee::new(margin_minus_total_fees, self.funding_rate, hours_to_charge)?;
+        let funding_fee = FundingFee::new(
+            margin_minus_total_fees,
+            self.initial_funding_rate,
+            hours_to_charge,
+        )?;
 
         Ok((
             Event::new(self.id, CfdEvent::RolloverAccepted),
@@ -657,7 +689,7 @@ impl Cfd {
                 self.leverage,
                 self.refund_timelock_in_blocks(),
                 1, // TODO: Where should I get the fee rate from?
-                funding_fee,
+                self.total_funding_fees + funding_fee,
             ),
             self.dlc.clone().context("No DLC present")?,
             self.settlement_interval,
@@ -679,7 +711,8 @@ impl Cfd {
         // whether they match
         let hours_to_charge = 1;
 
-        let funding_fee = FundingFee::new(self.margin(), self.funding_rate, hours_to_charge)?;
+        let funding_fee =
+            FundingFee::new(self.margin(), self.initial_funding_rate, hours_to_charge)?;
 
         Ok((
             self.event(CfdEvent::RolloverAccepted),
@@ -733,7 +766,7 @@ impl Cfd {
             n_payouts,
             FundingFee::new(
                 self.margin(),
-                self.funding_rate,
+                self.initial_funding_rate,
                 SETTLEMENT_INTERVAL.whole_hours(),
             )?,
         )?;
@@ -851,10 +884,11 @@ impl Cfd {
     ) -> Result<Option<Event>, NoRolloverReason> {
         let event = match completed {
             Completed::Succeeded {
-                payload: (dlc, _), ..
+                payload: (dlc, funding_fee, _),
+                ..
             } => {
                 self.can_rollover()?;
-                CfdEvent::RolloverCompleted { dlc }
+                CfdEvent::RolloverCompleted { dlc, funding_fee }
             }
             Completed::Rejected { reason, .. } => {
                 tracing::info!(order_id = %self.id, "Rollover was rejected: {:#}", reason);
@@ -1076,6 +1110,14 @@ impl Cfd {
         self.role
     }
 
+    pub fn initial_funding_rate(&self) -> FundingRate {
+        self.initial_funding_rate
+    }
+
+    pub fn opening_fee(&self) -> OpeningFee {
+        self.opening_fee
+    }
+
     pub fn sign_collaborative_settlement_taker(
         &self,
         proposal: &SettlementProposal,
@@ -1118,9 +1160,10 @@ impl Cfd {
                 self.during_rollover = true;
             }
             RolloverAccepted => {}
-            RolloverCompleted { dlc } => {
+            RolloverCompleted { dlc, funding_fee } => {
                 self.dlc = Some(dlc);
                 self.during_rollover = false;
+                self.total_funding_fees = self.total_funding_fees + funding_fee;
             }
             RolloverFailed { .. } => {
                 self.during_rollover = false;
@@ -1649,7 +1692,7 @@ pub type SetupCompleted = Completed<(Dlc, marker::Setup), anyhow::Error>;
 
 /// Message sent from a rollover actor to the
 /// cfd actor to notify that the rollover has finished (contract got updated).
-pub type RolloverCompleted = Completed<(Dlc, marker::Rollover), anyhow::Error>;
+pub type RolloverCompleted = Completed<(Dlc, FundingFee, marker::Rollover), anyhow::Error>;
 
 pub type CollaborativeSettlementCompleted = Completed<CollaborativeSettlement, anyhow::Error>;
 
@@ -1662,11 +1705,11 @@ impl Completed<(Dlc, marker::Setup), anyhow::Error> {
     }
 }
 
-impl Completed<(Dlc, marker::Rollover), anyhow::Error> {
-    pub fn succeeded(order_id: OrderId, dlc: Dlc) -> Self {
+impl Completed<(Dlc, FundingFee, marker::Rollover), anyhow::Error> {
+    pub fn succeeded(order_id: OrderId, dlc: Dlc, funding_fee: FundingFee) -> Self {
         Self::Succeeded {
             order_id,
-            payload: (dlc, marker::Rollover),
+            payload: (dlc, funding_fee, marker::Rollover),
         }
     }
 }
@@ -2254,6 +2297,7 @@ mod tests {
                 time::Duration::hours(24),
                 1,
                 FundingRate::default(),
+                OpeningFee::default(),
             )
             .unwrap()
         }

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -208,7 +208,7 @@ impl Cfd {
                 cet: None,
                 commit_tx: None,
             },
-            RolloverCompleted { dlc } => {
+            RolloverCompleted { dlc, .. } => {
                 Self {
                     params: Some(MonitorParams::new(dlc)),
                     monitor_lock_finality: false, // Lock is already final after rollover.

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -80,8 +80,8 @@ struct Cfd {
 impl Cfd {
     fn apply(self, event: Event) -> Self {
         let settlement_event_id = match event.event {
-            CfdEvent::ContractSetupCompleted { dlc } => dlc.settlement_event_id,
-            CfdEvent::RolloverCompleted { dlc } => dlc.settlement_event_id,
+            CfdEvent::ContractSetupCompleted { dlc, .. } => dlc.settlement_event_id,
+            CfdEvent::RolloverCompleted { dlc, .. } => dlc.settlement_event_id,
             // TODO: There might be a few cases where we do not need to monitor the attestation,
             // e.g. when we already agreed to collab. settle. Ignoring it for now
             // because I don't want to think about it and it doesn't cause much harm to do the

--- a/daemon/src/process_manager.rs
+++ b/daemon/src/process_manager.rs
@@ -65,7 +65,7 @@ impl Actor {
         // 2. Post process event
         use CfdEvent::*;
         match event.event {
-            ContractSetupCompleted { dlc } => {
+            ContractSetupCompleted { dlc, .. } => {
                 tracing::info!("Setup complete, publishing on chain now");
 
                 let lock_tx = dlc.lock.0.clone();
@@ -162,7 +162,7 @@ impl Actor {
                 // Nothing to do: The commit transaction has already been published but the timelock
                 // hasn't expired yet. We just need to wait.
             }
-            RolloverCompleted { dlc } => {
+            RolloverCompleted { dlc, .. } => {
                 tracing::info!(order_id=%event.id, "Rollover complete");
 
                 self.start_monitoring

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -714,10 +714,9 @@ pub struct CfdOrder {
 
     /// Fee charged by the maker for opening a position
     ///
-    /// Note: It's the minimum possible fee, we cannot calculate the exact
-    /// amount until we know the quantity taken by the taker
+    /// Note: It's a flat fee on top of the fee calculated based on funding rate
     #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc::opt")]
-    pub opening_fee_per_parcel: Option<Amount>,
+    pub opening_fee: Option<Amount>,
 
     /// The interest as annualized percentage
     ///
@@ -781,8 +780,7 @@ impl From<Order> for CfdOrder {
                 .whole_seconds()
                 .try_into()
                 .expect("settlement_time_interval_hours is always positive number"),
-            // TODO: replace this dummy value
-            opening_fee_per_parcel: Some(Amount::ZERO),
+            opening_fee: Some(Amount::from_sat(order.opening_fee.to_u64())),
             funding_rate_annualized_percent: AnnualisedFundingRate::from(order.funding_rate)
                 .to_string(),
             funding_rate_hourly_percent: HourlyFundingRate::from(order.funding_rate).to_string(),

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -999,7 +999,7 @@ impl From<FundingRate> for HourlyFundingRate {
 
 impl fmt::Display for HourlyFundingRate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.round_dp(2).fmt(f)
+        self.0.round_dp(4).fmt(f)
     }
 }
 

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -12,7 +12,6 @@ use crate::model::cfd::Event;
 use crate::model::cfd::OrderId;
 use crate::model::cfd::Origin;
 use crate::model::cfd::Role;
-use crate::model::FundingFee;
 use crate::model::FundingRate;
 use crate::model::Identity;
 use crate::model::Leverage;
@@ -162,7 +161,7 @@ pub struct Cfd {
     ///
     /// Includes the opening fee and all fees that were already charged.
     #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
-    pub accumulated_fees: Amount,
+    pub accumulated_fees: SignedAmount,
 
     pub leverage: Leverage,
     pub trading_pair: TradingPair,
@@ -177,6 +176,7 @@ pub struct Cfd {
     pub margin: Amount,
     #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
     pub margin_counterparty: Amount,
+    pub role: Role,
 
     /// Projected or final profit amount
     #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc::opt")]
@@ -276,6 +276,7 @@ impl Cfd {
             quantity_usd,
             counterparty_network_identity,
             role,
+            opening_fee,
             ..
         }: db::Cfd,
         latest_quote: Option<bitmex_price_feed::Quote>,
@@ -320,7 +321,7 @@ impl Cfd {
         Self {
             order_id: id,
             initial_price,
-            accumulated_fees: Amount::from_sat(123456), // FIXME: calculate
+            accumulated_fees: opening_fee.amount_for(role),
             leverage,
             trading_pair: TradingPair::BtcUsd,
             position,
@@ -328,6 +329,7 @@ impl Cfd {
             quantity_usd,
             margin,
             margin_counterparty,
+            role,
 
             // By default, we assume profit should be based on the latest price!
             profit_btc: profit_btc_latest_price,
@@ -364,8 +366,11 @@ impl Cfd {
             OfferRejected => {
                 self.state = CfdState::Rejected;
             }
-            RolloverCompleted { dlc } => {
+            RolloverCompleted { dlc, funding_fee } => {
                 self.aggregated.latest_dlc = Some(dlc);
+                self.accumulated_fees
+                    .checked_add(funding_fee.amount_for(self.role))
+                    .expect("addition to work");
 
                 self.state = CfdState::Open;
             }
@@ -776,25 +781,12 @@ impl From<Order> for CfdOrder {
                 .whole_seconds()
                 .try_into()
                 .expect("settlement_time_interval_hours is always positive number"),
-            // XXX: We cannot calculate full fee here, best we can do is to give
-            // minimal fee
-            opening_fee_per_parcel: calculate_min_opening_fee(&order),
+            // TODO: replace this dummy value
+            opening_fee_per_parcel: Some(Amount::ZERO),
             funding_rate_annualized_percent: AnnualisedFundingRate::from(order.funding_rate)
                 .to_string(),
             funding_rate_hourly_percent: HourlyFundingRate::from(order.funding_rate).to_string(),
         }
-    }
-}
-
-fn calculate_min_opening_fee(order: &Order) -> Option<Amount> {
-    if let Ok(fee) = FundingFee::new(
-        calculate_long_margin(order.price, order.min_quantity, order.leverage),
-        order.funding_rate,
-        order.settlement_interval.whole_hours(),
-    ) {
-        Some(fee.into())
-    } else {
-        None
     }
 }
 

--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -4,6 +4,7 @@ use daemon::auth::Authenticated;
 use daemon::model::cfd::OrderId;
 use daemon::model::FundingRate;
 use daemon::model::Identity;
+use daemon::model::OpeningFee;
 use daemon::model::Price;
 use daemon::model::Usd;
 use daemon::model::WalletInfo;
@@ -99,6 +100,7 @@ pub struct CfdNewOrderRequest {
     pub max_quantity: Usd,
     pub tx_fee_rate: Option<u32>,
     pub funding_rate: Option<FundingRate>,
+    pub opening_fee: Option<OpeningFee>,
 }
 
 #[rocket::post("/order/sell", data = "<order>")]
@@ -114,6 +116,7 @@ pub async fn post_sell_order(
             order.max_quantity,
             order.tx_fee_rate,
             order.funding_rate,
+            order.opening_fee,
         )
         .await
         .map_err(|e| {

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -4,7 +4,6 @@ use crate::model::cfd::RevokedCommit;
 use crate::model::cfd::Role;
 use crate::model::cfd::CET_TIMELOCK;
 use crate::model::FundingFee;
-use crate::model::FundingRate;
 use crate::model::Identity;
 use crate::model::Leverage;
 use crate::model::Price;
@@ -23,7 +22,6 @@ use crate::wire::RolloverMsg1;
 use crate::wire::RolloverMsg2;
 use crate::wire::RolloverMsg3;
 use crate::wire::SetupMsg;
-use crate::SETTLEMENT_INTERVAL;
 use anyhow::Context;
 use anyhow::Result;
 use bdk::bitcoin::secp256k1::schnorrsig;
@@ -84,7 +82,7 @@ impl SetupParams {
         leverage: Leverage,
         refund_timelock: u32,
         tx_fee_rate: u32,
-        funding_rate: FundingRate,
+        funding_fee: FundingFee,
     ) -> Result<Self> {
         Ok(Self {
             margin,
@@ -95,7 +93,7 @@ impl SetupParams {
             leverage,
             refund_timelock,
             tx_fee_rate,
-            funding_fee: FundingFee::new(margin, funding_rate, SETTLEMENT_INTERVAL.whole_hours())?,
+            funding_fee,
         })
     }
 
@@ -404,6 +402,10 @@ impl RolloverParams {
             funding_fee,
         }
     }
+
+    pub fn funding_fee(&self) -> &FundingFee {
+        &self.funding_fee
+    }
 }
 
 pub async fn roll_over(
@@ -452,7 +454,7 @@ pub async fn roll_over(
             rollover_params.quantity,
             rollover_params.leverage,
             n_payouts,
-            rollover_params.funding_fee,
+            rollover_params.funding_fee.clone(),
         )?,
     )]);
 

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -13,6 +13,7 @@ use crate::harness::Maker;
 use crate::harness::MakerConfig;
 use crate::harness::Taker;
 use crate::harness::TakerConfig;
+use bdk::bitcoin::Amount;
 use daemon::connection::ConnectionStatus;
 use daemon::model::cfd::calculate_long_margin;
 use daemon::model::cfd::OrderId;
@@ -74,9 +75,9 @@ fn assert_eq_order(mut published: CfdOrder, received: CfdOrder) {
 
     assert_eq!(published, received);
 
-    // dummy order does not have any funding fees
-    assert_eq!(received.funding_rate_annualized_percent, "0.00");
-    assert_eq!(received.funding_rate_hourly_percent, "0.00");
+    // Hard-coded to match the dummy_new_order()
+    assert_eq!(received.opening_fee.unwrap(), Amount::from_sat(2));
+    assert_eq!(received.funding_rate_hourly_percent, "0.001");
 }
 
 #[tokio::test]

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -3,6 +3,7 @@ use crate::harness::mocks::price_feed::PriceFeedActor;
 use crate::harness::mocks::wallet::WalletActor;
 use crate::schnorrsig;
 use ::bdk::bitcoin::Network;
+use bdk::bitcoin::Amount;
 use daemon::auto_rollover;
 use daemon::bitmex_price_feed::Quote;
 use daemon::connection::connect;
@@ -347,8 +348,8 @@ pub fn dummy_new_order() -> maker_cfd::NewOrder {
         min_quantity: Usd::new(dec!(5)),
         max_quantity: Usd::new(dec!(100)),
         tx_fee_rate: 1,
-        funding_rate: FundingRate::default(),
-        opening_fee: OpeningFee::default(),
+        funding_rate: FundingRate::new(dec!(0.024)).unwrap(),
+        opening_fee: OpeningFee::new(Amount::from_sat(2)),
     }
 }
 

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -14,6 +14,7 @@ use daemon::model::cfd::OrderId;
 use daemon::model::cfd::Role;
 use daemon::model::FundingRate;
 use daemon::model::Identity;
+use daemon::model::OpeningFee;
 use daemon::model::Price;
 use daemon::model::Timestamp;
 use daemon::model::Usd;
@@ -347,6 +348,7 @@ pub fn dummy_new_order() -> maker_cfd::NewOrder {
         max_quantity: Usd::new(dec!(100)),
         tx_fee_rate: 1,
         funding_rate: FundingRate::default(),
+        opening_fee: OpeningFee::default(),
     }
 }
 

--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -53,7 +53,7 @@ export const App = () => {
     const parcelSize = parseOptionalNumber(order?.parcel_size) || 0;
     const liquidationPrice = parseOptionalNumber(order?.liquidation_price);
     const marginPerParcel = order?.margin_per_parcel || 0;
-    const openingFeePerParcel = order?.opening_fee_per_parcel || 0;
+    const openingFee = order?.opening_fee || 0;
     const fundingRateAnnualized = order?.funding_rate_annualized_percent || "0";
 
     const fundingRateHourly = order
@@ -127,7 +127,7 @@ export const App = () => {
                                     leverage={order?.leverage}
                                     liquidationPrice={liquidationPrice}
                                     walletBalance={walletInfo ? walletInfo.balance : 0}
-                                    openingFeePerParcel={openingFeePerParcel}
+                                    openingFeePerParcel={openingFee}
                                     fundingRateAnnualized={fundingRateAnnualized}
                                     fundingRateHourly={fundingRateHourly || "0"}
                                 />

--- a/taker-frontend/src/types.ts
+++ b/taker-frontend/src/types.ts
@@ -22,7 +22,7 @@ export interface Order {
     creation_timestamp: number;
     settlement_time_interval_in_secs: number;
 
-    opening_fee_per_parcel: number;
+    opening_fee: number;
     funding_rate_annualized_percent: string; // e.g. "18.5" (does not include % char)
     funding_rate_hourly_percent: string; // e.g. "0.002345" (does not include % char)
 }


### PR DESCRIPTION
- Split fees into OpeningFee and FundingFee
- Store FundingFee in CfdEvents,
- Store FundingRate inside FundingFee,
- accumulate funding fees by summing up fees stored in cfd events,
- ensure that funding fees presented in the maker are the inverse of taker's,

Fixes  #1131