### PR TITLE
Extend and clean up the top-bar

### DIFF
--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -90,6 +90,7 @@ export const App = () => {
                 connectedToMaker={connectedToMaker}
                 fundingRate={fundingRateHourly}
                 nextFundingEvent={nextFundingEvent}
+                referencePrice={referencePrice}
             />
             <Box textAlign="center" padding={3} bg={useColorModeValue("gray.50", "gray.800")}>
                 <Routes>


### PR DESCRIPTION
Add the reference price including tooltip & link to oracle outcome explorer.
Combine the funding event time and rate.
Add color to maker status.

Set min-widths so the text does not jump around due to resizing based on text.

looks: 

![image](https://user-images.githubusercontent.com/5557790/150747280-34e8b27d-7ddb-4921-94be-d341f52ee9ef.png)
