### PR TITLE
Upgrade the network version to `2.0.0`

### DIFF
--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -43,7 +43,7 @@ pub struct Version(semver::Version);
 
 impl Version {
     pub fn current() -> Self {
-        Self(semver::Version::new(1, 0, 0))
+        Self(semver::Version::new(2, 0, 0))
     }
 }
 


### PR DESCRIPTION
resolves #1199 

`0.4.0` contains breaking changes.