### PR TITLE
Update TxFeeRate and FundingRate based on the current offer, even for rollovers

### DIFF
--- a/daemon/migrations/20220125051124_add_initial_tx_fee_rate.sql
+++ b/daemon/migrations/20220125051124_add_initial_tx_fee_rate.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    cfds
+ADD
+    COLUMN initial_tx_fee_rate NOT NULL DEFAULT '1';

--- a/daemon/sqlx-data.json
+++ b/daemon/sqlx-data.json
@@ -24,8 +24,8 @@
       ]
     }
   },
-  "adb69ad1009b9096072f0357b6db27d89b6a6e47b8a820f2e1ce6a0966d5fca1": {
-    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: crate::model::cfd::OrderId\",\n                position as \"position: crate::model::Position\",\n                initial_price as \"initial_price: crate::model::Price\",\n                leverage as \"leverage: crate::model::Leverage\",\n                settlement_time_interval_hours,\n                quantity_usd as \"quantity_usd: crate::model::Usd\",\n                counterparty_network_identity as \"counterparty_network_identity: crate::model::Identity\",\n                role as \"role: crate::model::cfd::Role\",\n                opening_fee as \"opening_fee: crate::model::OpeningFee\",\n                initial_funding_rate as \"initial_funding_rate: crate::model::FundingRate\"\n            from\n                cfds\n            where\n                cfds.uuid = $1\n            ",
+  "9de33832b4ae2eff5a2e3f97feca0b2586949bba2f606b3a2f504956fc37add3": {
+    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: crate::model::cfd::OrderId\",\n                position as \"position: crate::model::Position\",\n                initial_price as \"initial_price: crate::model::Price\",\n                leverage as \"leverage: crate::model::Leverage\",\n                settlement_time_interval_hours,\n                quantity_usd as \"quantity_usd: crate::model::Usd\",\n                counterparty_network_identity as \"counterparty_network_identity: crate::model::Identity\",\n                role as \"role: crate::model::cfd::Role\",\n                opening_fee as \"opening_fee: crate::model::OpeningFee\",\n                initial_funding_rate as \"initial_funding_rate: crate::model::FundingRate\",\n                initial_tx_fee_rate as \"initial_tx_fee_rate: crate::model::TxFeeRate\"\n            from\n                cfds\n            where\n                cfds.uuid = $1\n            ",
     "describe": {
       "columns": [
         {
@@ -82,6 +82,11 @@
           "name": "initial_funding_rate: crate::model::FundingRate",
           "ordinal": 10,
           "type_info": "Null"
+        },
+        {
+          "name": "initial_tx_fee_rate: crate::model::TxFeeRate",
+          "ordinal": 11,
+          "type_info": "Null"
         }
       ],
       "parameters": {
@@ -89,6 +94,7 @@
       },
       "nullable": [
         true,
+        false,
         false,
         false,
         false,

--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -87,6 +87,7 @@ pub async fn load_cfd(order_id: OrderId, conn: &mut PoolConnection<Sqlite>) -> R
             quantity_usd,
             opening_fee,
             initial_funding_rate,
+            initial_tx_fee_rate,
         },
         events,
     ) = db::load_cfd(order_id, conn).await?;
@@ -101,6 +102,7 @@ pub async fn load_cfd(order_id: OrderId, conn: &mut PoolConnection<Sqlite>) -> R
         role,
         opening_fee,
         initial_funding_rate,
+        initial_tx_fee_rate,
         events,
     );
     Ok(cfd)

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -492,12 +492,18 @@ impl Actor {
             wire::MakerToTaker::ConfirmRollover {
                 order_id,
                 oracle_event_id,
+                tx_fee_rate,
+                funding_rate,
             } => {
                 if self
                     .rollover_actors
                     .send(
                         &order_id,
-                        rollover_taker::RolloverAccepted { oracle_event_id },
+                        rollover_taker::RolloverAccepted {
+                            oracle_event_id,
+                            tx_fee_rate,
+                            funding_rate,
+                        },
                     )
                     .await
                     .is_err()

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -9,6 +9,7 @@ use crate::model::Leverage;
 use crate::model::OpeningFee;
 use crate::model::Position;
 use crate::model::Price;
+use crate::model::TxFeeRate;
 use crate::model::Usd;
 use anyhow::Context;
 use anyhow::Result;
@@ -110,8 +111,9 @@ pub async fn insert_cfd(cfd: &model::cfd::Cfd, conn: &mut PoolConnection<Sqlite>
             counterparty_network_identity,
             role,
             opening_fee,
-            initial_funding_rate
-        ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"#,
+            initial_funding_rate,
+            initial_tx_fee_rate
+        ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"#,
     )
     .bind(&cfd.id())
     .bind(&cfd.position())
@@ -123,6 +125,7 @@ pub async fn insert_cfd(cfd: &model::cfd::Cfd, conn: &mut PoolConnection<Sqlite>
     .bind(&cfd.role())
     .bind(&cfd.opening_fee())
     .bind(&cfd.initial_funding_rate())
+    .bind(&cfd.initial_tx_fee_rate())
     .execute(conn)
     .await?;
 
@@ -187,6 +190,7 @@ pub struct Cfd {
     pub role: Role,
     pub opening_fee: OpeningFee,
     pub initial_funding_rate: FundingRate,
+    pub initial_tx_fee_rate: TxFeeRate,
 }
 
 pub async fn load_cfd(id: OrderId, conn: &mut PoolConnection<Sqlite>) -> Result<(Cfd, Vec<Event>)> {
@@ -203,7 +207,8 @@ pub async fn load_cfd(id: OrderId, conn: &mut PoolConnection<Sqlite>) -> Result<
                 counterparty_network_identity as "counterparty_network_identity: crate::model::Identity",
                 role as "role: crate::model::cfd::Role",
                 opening_fee as "opening_fee: crate::model::OpeningFee",
-                initial_funding_rate as "initial_funding_rate: crate::model::FundingRate"
+                initial_funding_rate as "initial_funding_rate: crate::model::FundingRate",
+                initial_tx_fee_rate as "initial_tx_fee_rate: crate::model::TxFeeRate"
             from
                 cfds
             where
@@ -225,6 +230,7 @@ pub async fn load_cfd(id: OrderId, conn: &mut PoolConnection<Sqlite>) -> Result<
         role: cfd_row.role,
         opening_fee: cfd_row.opening_fee,
         initial_funding_rate: cfd_row.initial_funding_rate,
+        initial_tx_fee_rate: cfd_row.initial_tx_fee_rate,
     };
 
     let events = sqlx::query!(
@@ -285,6 +291,7 @@ mod tests {
     use crate::model::Position;
     use crate::model::Price;
     use crate::model::Timestamp;
+    use crate::model::TxFeeRate;
     use crate::model::Usd;
     use bdk::bitcoin::Amount;
     use pretty_assertions::assert_eq;
@@ -308,6 +315,7 @@ mod tests {
                 role,
                 opening_fee,
                 initial_funding_rate,
+                initial_tx_fee_rate,
             },
             _,
         ) = load_cfd(cfd.id(), &mut conn).await.unwrap();
@@ -325,6 +333,7 @@ mod tests {
         assert_eq!(cfd.role(), role);
         assert_eq!(cfd.opening_fee(), opening_fee);
         assert_eq!(cfd.initial_funding_rate(), initial_funding_rate);
+        assert_eq!(cfd.initial_tx_fee_rate(), initial_tx_fee_rate);
     }
 
     #[tokio::test]
@@ -392,6 +401,7 @@ mod tests {
                     .unwrap(),
                 OpeningFee::new(Amount::from_sat(2000)),
                 FundingRate::default(),
+                TxFeeRate::default(),
             )
         }
 

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -22,6 +22,7 @@ use futures::future::RemoteHandle;
 use maia::secp256k1_zkp::schnorrsig;
 use model::FundingRate;
 use model::OpeningFee;
+use model::TxFeeRate;
 use sqlx::SqlitePool;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -239,7 +240,7 @@ where
         price: Price,
         min_quantity: Usd,
         max_quantity: Usd,
-        fee_rate: Option<u32>,
+        fee_rate: Option<TxFeeRate>,
         funding_rate: Option<FundingRate>,
         opening_fee: Option<OpeningFee>,
     ) -> Result<()> {
@@ -248,7 +249,7 @@ where
                 price,
                 min_quantity,
                 max_quantity,
-                tx_fee_rate: fee_rate.unwrap_or(1),
+                tx_fee_rate: fee_rate.unwrap_or_default(),
                 funding_rate: funding_rate.unwrap_or_default(),
                 opening_fee: opening_fee.unwrap_or_default(),
             })

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -16,6 +16,7 @@ use crate::model::Identity;
 use crate::model::OpeningFee;
 use crate::model::Position;
 use crate::model::Price;
+use crate::model::TxFeeRate;
 use crate::model::Usd;
 use crate::monitor;
 use crate::oracle;
@@ -74,7 +75,7 @@ pub struct NewOrder {
     pub price: Price,
     pub min_quantity: Usd,
     pub max_quantity: Usd,
-    pub tx_fee_rate: u32,
+    pub tx_fee_rate: TxFeeRate,
     pub funding_rate: FundingRate,
     pub opening_fee: OpeningFee,
 }

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -383,9 +383,20 @@ impl<O, T, W> Actor<O, T, W> {
     }
 
     async fn handle_accept_rollover(&mut self, msg: AcceptRollover) -> Result<()> {
+        let order = self
+            .current_order
+            .as_ref()
+            .context("Cannot accept rollover without current offer, as we need up-to-date fees")?;
+
         if self
             .rollover_actors
-            .send(&msg.order_id, rollover_maker::AcceptRollover)
+            .send(
+                &msg.order_id,
+                rollover_maker::AcceptRollover {
+                    tx_fee_rate: order.tx_fee_rate,
+                    funding_rate: order.funding_rate,
+                },
+            )
             .await
             .is_err()
         {

--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -704,6 +704,49 @@ impl Default for OpeningFee {
 
 impl_sqlx_type_display_from_str!(OpeningFee);
 
+/// Transaction fee in satoshis per vbyte
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+pub struct TxFeeRate(u32);
+
+impl TxFeeRate {
+    pub fn new(fee_rate: u32) -> Self {
+        Self(fee_rate)
+    }
+
+    pub fn to_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<TxFeeRate> for bdk::FeeRate {
+    fn from(fee_rate: TxFeeRate) -> Self {
+        Self::from_sat_per_vb(fee_rate.to_u32() as f32)
+    }
+}
+
+impl Default for TxFeeRate {
+    fn default() -> Self {
+        Self(1u32)
+    }
+}
+
+impl fmt::Display for TxFeeRate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl str::FromStr for TxFeeRate {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let fee_sat = s.parse()?;
+        Ok(TxFeeRate(fee_sat))
+    }
+}
+
+impl_sqlx_type_display_from_str!(TxFeeRate);
+
 /// Fee paid contract setup / renewal(a fraction of it if rolling over)
 /// As the Cfd gets renewed, the struct keeps track of total fees as well as
 /// last fee paid along with the rate used to calculate it.

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -408,6 +408,7 @@ pub struct Cfd {
     counterparty_network_identity: Identity,
     role: Role,
     opening_fee: OpeningFee,
+    initial_tx_fee_rate: TxFeeRate,
     // dynamic (based on events)
     total_funding_fees: FundingFee,
 
@@ -459,6 +460,7 @@ impl Cfd {
         counterparty_network_identity: Identity,
         opening_fee: OpeningFee,
         initial_funding_rate: FundingRate,
+        initial_tx_fee_rate: TxFeeRate,
     ) -> Self {
         let long_initial_margin = calculate_long_margin(initial_price, quantity, leverage);
         // TODO: Use FundingFee::default() if we don't want to charge funding fees
@@ -482,6 +484,7 @@ impl Cfd {
             role,
             initial_funding_rate,
             opening_fee,
+            initial_tx_fee_rate,
             dlc: None,
             cet: None,
             commit_tx: None,
@@ -520,6 +523,7 @@ impl Cfd {
             counterparty_network_identity,
             order.opening_fee,
             order.funding_rate,
+            order.tx_fee_rate,
         )
     }
 
@@ -536,6 +540,7 @@ impl Cfd {
         role: Role,
         opening_fee: OpeningFee,
         initial_funding_rate: FundingRate,
+        initial_tx_fee_rate: TxFeeRate,
         events: Vec<Event>,
     ) -> Self {
         let cfd = Self::new(
@@ -549,6 +554,7 @@ impl Cfd {
             counterparty_network_identity,
             opening_fee,
             initial_funding_rate,
+            initial_tx_fee_rate,
         );
         events.into_iter().fold(cfd, Cfd::apply)
     }
@@ -643,7 +649,7 @@ impl Cfd {
                 self.quantity,
                 self.leverage,
                 self.refund_timelock_in_blocks(),
-                TxFeeRate::default(), // TODO: Where should I get the fee rate from?
+                self.initial_tx_fee_rate(),
                 self.total_funding_fees.clone(),
             )?,
         ))
@@ -1105,6 +1111,10 @@ impl Cfd {
 
     pub fn initial_funding_rate(&self) -> FundingRate {
         self.initial_funding_rate
+    }
+
+    pub fn initial_tx_fee_rate(&self) -> TxFeeRate {
+        self.initial_tx_fee_rate
     }
 
     pub fn opening_fee(&self) -> OpeningFee {

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -51,6 +51,7 @@ use uuid::adapter::Hyphenated;
 use uuid::Uuid;
 
 use super::OpeningFee;
+use super::TxFeeRate;
 
 pub const CET_TIMELOCK: u32 = 12;
 
@@ -156,7 +157,7 @@ pub struct Order {
     /// The maker includes this into the Order based on the Oracle announcement to be used.
     pub oracle_event_id: BitMexPriceEventId,
 
-    pub tx_fee_rate: u32,
+    pub tx_fee_rate: TxFeeRate,
     pub funding_rate: FundingRate,
     pub opening_fee: OpeningFee,
 }
@@ -170,7 +171,7 @@ impl Order {
         origin: Origin,
         oracle_event_id: BitMexPriceEventId,
         settlement_interval: Duration,
-        tx_fee_rate: u32,
+        tx_fee_rate: TxFeeRate,
         funding_rate: FundingRate,
         opening_fee: OpeningFee,
     ) -> Result<Self> {
@@ -642,7 +643,7 @@ impl Cfd {
                 self.quantity,
                 self.leverage,
                 self.refund_timelock_in_blocks(),
-                1, // TODO: Where should I get the fee rate from?
+                TxFeeRate::default(), // TODO: Where should I get the fee rate from?
                 self.total_funding_fees.clone(),
             )?,
         ))
@@ -688,7 +689,7 @@ impl Cfd {
                 self.quantity,
                 self.leverage,
                 self.refund_timelock_in_blocks(),
-                1, // TODO: Where should I get the fee rate from?
+                TxFeeRate::default(), // TODO: Where should I get the fee rate from?
                 self.total_funding_fees + funding_fee,
             ),
             self.dlc.clone().context("No DLC present")?,
@@ -721,7 +722,7 @@ impl Cfd {
                 self.quantity,
                 self.leverage,
                 self.refund_timelock_in_blocks(),
-                1, // TODO: Where should I get the fee rate from?
+                TxFeeRate::default(), // TODO: Where should I get the fee rate from?
                 funding_fee,
             ),
             self.dlc.clone().context("No DLC present")?,
@@ -2287,7 +2288,7 @@ mod tests {
                 Origin::Ours,
                 dummy_event_id(),
                 time::Duration::hours(24),
-                1,
+                TxFeeRate::default(),
                 FundingRate::default(),
                 OpeningFee::default(),
             )

--- a/daemon/src/routes_maker.rs
+++ b/daemon/src/routes_maker.rs
@@ -6,6 +6,7 @@ use daemon::model::FundingRate;
 use daemon::model::Identity;
 use daemon::model::OpeningFee;
 use daemon::model::Price;
+use daemon::model::TxFeeRate;
 use daemon::model::Usd;
 use daemon::model::WalletInfo;
 use daemon::oracle;
@@ -98,7 +99,7 @@ pub struct CfdNewOrderRequest {
     // always 1 USD
     pub min_quantity: Usd,
     pub max_quantity: Usd,
-    pub tx_fee_rate: Option<u32>,
+    pub tx_fee_rate: Option<TxFeeRate>,
     pub funding_rate: Option<FundingRate>,
     pub opening_fee: Option<OpeningFee>,
 }

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -7,6 +7,7 @@ use crate::model::FundingFee;
 use crate::model::Identity;
 use crate::model::Leverage;
 use crate::model::Price;
+use crate::model::TxFeeRate;
 use crate::model::Usd;
 use crate::oracle;
 use crate::payout_curve;
@@ -67,7 +68,7 @@ pub struct SetupParams {
     quantity: Usd,
     leverage: Leverage,
     refund_timelock: u32,
-    tx_fee_rate: u32,
+    tx_fee_rate: TxFeeRate,
     funding_fee: FundingFee,
 }
 
@@ -81,7 +82,7 @@ impl SetupParams {
         quantity: Usd,
         leverage: Leverage,
         refund_timelock: u32,
-        tx_fee_rate: u32,
+        tx_fee_rate: TxFeeRate,
         funding_fee: FundingFee,
     ) -> Result<Self> {
         Ok(Self {
@@ -186,7 +187,7 @@ pub async fn new(
                 (CET_TIMELOCK, setup_params.refund_timelock),
                 payouts,
                 sk,
-                setup_params.tx_fee_rate,
+                setup_params.tx_fee_rate.to_u32(),
             )
         }
     })
@@ -380,7 +381,7 @@ pub struct RolloverParams {
     quantity: Usd,
     leverage: Leverage,
     refund_timelock: u32,
-    fee_rate: u32,
+    fee_rate: TxFeeRate,
     funding_fee: FundingFee,
 }
 
@@ -390,7 +391,7 @@ impl RolloverParams {
         quantity: Usd,
         leverage: Leverage,
         refund_timelock: u32,
-        fee_rate: u32,
+        fee_rate: TxFeeRate,
         funding_fee: FundingFee,
     ) -> Self {
         Self {
@@ -505,7 +506,7 @@ pub async fn roll_over(
                 (CET_TIMELOCK, rollover_params.refund_timelock),
                 payouts,
                 sk,
-                rollover_params.fee_rate,
+                rollover_params.fee_rate.to_u32(),
             )
         }
     })

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -1,4 +1,5 @@
 use crate::model::Timestamp;
+use crate::model::TxFeeRate;
 use crate::model::WalletInfo;
 use crate::xtra_ext::SendInterval;
 use crate::Tasks;
@@ -126,11 +127,9 @@ impl Actor {
             fee_rate,
         }: BuildPartyParams,
     ) -> Result<PartyParams> {
-        let psbt = self.wallet.build_lock_tx(
-            amount,
-            &mut self.used_utxos,
-            FeeRate::from_sat_per_vb(fee_rate as f32),
-        )?;
+        let psbt = self
+            .wallet
+            .build_lock_tx(amount, &mut self.used_utxos, fee_rate.into())?;
 
         Ok(PartyParams {
             lock_psbt: psbt,
@@ -203,7 +202,7 @@ impl xtra::Actor for Actor {
 pub struct BuildPartyParams {
     pub amount: Amount,
     pub identity_pk: PublicKey,
-    pub fee_rate: u32,
+    pub fee_rate: TxFeeRate,
 }
 
 /// Private message to trigger a sync.

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -1,8 +1,10 @@
 use crate::model::cfd::Order;
 use crate::model::cfd::OrderId;
 use crate::model::BitMexPriceEventId;
+use crate::model::FundingRate;
 use crate::model::Price;
 use crate::model::Timestamp;
+use crate::model::TxFeeRate;
 use crate::model::Usd;
 use crate::noise::NOISE_MAX_MSG_LEN;
 use crate::noise::NOISE_TAG_LEN;
@@ -145,6 +147,8 @@ pub enum MakerToTaker {
     ConfirmRollover {
         order_id: OrderId,
         oracle_event_id: BitMexPriceEventId,
+        tx_fee_rate: TxFeeRate,
+        funding_rate: FundingRate,
     },
     RejectRollover(OrderId),
     Settlement {

--- a/daemon/tests/happy_path.rs
+++ b/daemon/tests/happy_path.rs
@@ -231,6 +231,9 @@ async fn rollover_an_open_cfd() {
     let (mut maker, mut taker, order_id) =
         start_from_open_cfd_state(oracle_data.announcement()).await;
 
+    // Maker needs to have an active offer in order to accept rollover
+    maker.publish_order(dummy_new_order()).await;
+
     taker.trigger_rollover(order_id).await;
 
     wait_next_state!(

--- a/daemon/tests/harness/mod.rs
+++ b/daemon/tests/harness/mod.rs
@@ -18,6 +18,7 @@ use daemon::model::Identity;
 use daemon::model::OpeningFee;
 use daemon::model::Price;
 use daemon::model::Timestamp;
+use daemon::model::TxFeeRate;
 use daemon::model::Usd;
 use daemon::projection;
 use daemon::projection::Cfd;
@@ -347,7 +348,7 @@ pub fn dummy_new_order() -> maker_cfd::NewOrder {
         price: dummy_price(),
         min_quantity: Usd::new(dec!(5)),
         max_quantity: Usd::new(dec!(100)),
-        tx_fee_rate: 1,
+        tx_fee_rate: TxFeeRate::new(1),
         funding_rate: FundingRate::new(dec!(0.024)).unwrap(),
         opening_fee: OpeningFee::new(Amount::from_sat(2)),
     }


### PR DESCRIPTION
- Store TxFeeRate from the order and use it during contract setup, 
- update TxFeeRate with rollover based on the current offer,
- update FundingRate with rollover based on the current offer

Fixes #1094