### PR TITLE
Move wallet info into table

### DIFF
--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -22,7 +22,7 @@ import Footer from "./components/Footer";
 import History from "./components/History";
 import Nav from "./components/NavBar";
 import Trade from "./components/Trade";
-import { Wallet, WalletInfoBar } from "./components/Wallet";
+import { Wallet } from "./components/Wallet";
 import { BXBTData, Cfd, ConnectionStatus, intoCfd, intoOrder, isClosed, Order, WalletInfo } from "./types";
 import { useEventSource } from "./useEventSource";
 import useLatestEvent from "./useLatestEvent";
@@ -111,7 +111,6 @@ export const App = () => {
                             <Center marginTop={20}>
                                 <VStack>
                                     {connectionStatus}
-                                    <WalletInfoBar walletInfo={walletInfo} />
                                 </VStack>
                             </Center>
                             <VStack divider={<StackDivider borderColor="gray.500" />} spacing={4}>

--- a/taker-frontend/src/components/Trade.tsx
+++ b/taker-frontend/src/components/Trade.tsx
@@ -251,17 +251,19 @@ export default function Trade({
                                         <ModalBody>
                                             <Table variant="striped" colorScheme="gray" size="sm">
                                                 <TableCaption>
-                                                    {`By submitting, ₿${btcToOpenPosition} will be locked on-chain in a contract.`}
+                                                    <HStack>
+                                                        <Text>
+                                                            By submitting
+                                                        </Text>
+                                                        <Text as={"b"}>
+                                                            ₿${btcToOpenPosition}
+                                                        </Text>
+                                                        <Text>
+                                                            will be locked on-chain in a contract.
+                                                        </Text>
+                                                    </HStack>
                                                 </TableCaption>
                                                 <Tbody>
-                                                    <Tr>
-                                                        <Td><Text as={"b"}>Your Margin</Text></Td>
-                                                        <Td><BitcoinAmount btc={margin} /></Td>
-                                                    </Tr>
-                                                    <Tr>
-                                                        <Td><Text as={"b"}>Opening Fee</Text></Td>
-                                                        <Td><BitcoinAmount btc={openingFee} /></Td>
-                                                    </Tr>
                                                     <Tr>
                                                         <Td><Text as={"b"}>Leverage</Text></Td>
                                                         <Td>{leverage}</Td>
@@ -280,6 +282,14 @@ export default function Trade({
                                                             <Td>Hourly @ {fundingRateHourly}%</Td>
                                                         </Tr>
                                                     </Tooltip>
+                                                    <Tr>
+                                                        <Td><Text as={"b"}>Margin</Text></Td>
+                                                        <Td><BitcoinAmount btc={margin} /></Td>
+                                                    </Tr>
+                                                    <Tr>
+                                                        <Td><Text as={"b"}>Opening Fee</Text></Td>
+                                                        <Td><BitcoinAmount btc={openingFee} /></Td>
+                                                    </Tr>
                                                 </Tbody>
                                             </Table>
                                         </ModalBody>

--- a/taker-frontend/src/components/Trade.tsx
+++ b/taker-frontend/src/components/Trade.tsx
@@ -1,3 +1,4 @@
+import { ExternalLinkIcon } from "@chakra-ui/icons";
 import { BoxProps } from "@chakra-ui/layout";
 import {
     Box,
@@ -11,6 +12,7 @@ import {
     Grid,
     GridItem,
     HStack,
+    IconButton,
     InputGroup,
     InputLeftAddon,
     Modal,
@@ -35,8 +37,6 @@ import {
     Tbody,
     Td,
     Text,
-    Tfoot,
-    Th,
     Tooltip,
     Tr,
     useColorModeValue,
@@ -46,6 +46,7 @@ import {
 import { motion } from "framer-motion";
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { CfdOrderRequestPayload, ConnectionStatus } from "../types";
 import usePostRequest from "../usePostRequest";
 import AlertBox from "./AlertBox";
@@ -215,8 +216,7 @@ export default function Trade({
                     <GridItem colSpan={1}>
                         <OpeningDetails
                             margin={margin}
-                            openingFee={openingFee}
-                            marginAndOpeningFee={btcToOpenPosition}
+                            walletBalance={walletBalance}
                         />
                     </GridItem>
                     <GridItem colSpan={1}>
@@ -380,31 +380,35 @@ function Leverage({ leverage }: LeverageProps) {
 
 interface OpeningDetailsProps {
     margin: number;
-    openingFee: number;
-    marginAndOpeningFee: number;
+    walletBalance: number;
 }
 
-function OpeningDetails({ margin, marginAndOpeningFee, openingFee }: OpeningDetailsProps) {
+function OpeningDetails({ margin, walletBalance }: OpeningDetailsProps) {
+    const navigate = useNavigate();
     return (
         <Table variant="simple">
             <Tbody>
                 <Tr>
-                    <Td>Your Margin</Td>
+                    <Td>Required Margin</Td>
                     <Td isNumeric><BitcoinAmount btc={margin} /></Td>
                 </Tr>
                 <Tr>
-                    <Td>Opening Fee</Td>
-                    <Td isNumeric><BitcoinAmount btc={openingFee} /></Td>
+                    <Td>
+                        <HStack>
+                            <Text>Available Balance</Text>
+                            <IconButton
+                                variant={"unstyled"}
+                                aria-label="Go to wallet"
+                                icon={<ExternalLinkIcon />}
+                                onClick={() => navigate("/wallet")}
+                            />
+                        </HStack>
+                    </Td>
+                    <Td isNumeric>
+                        <BitcoinAmount btc={walletBalance} />
+                    </Td>
                 </Tr>
             </Tbody>
-            <Tfoot>
-                <Tr>
-                    <Th fontSize={"md"} textTransform={"none"}>
-                        Required to open position
-                    </Th>
-                    <Th fontSize={"md"} isNumeric><BitcoinAmount btc={marginAndOpeningFee} /></Th>
-                </Tr>
-            </Tfoot>
         </Table>
     );
 }

--- a/taker-frontend/src/components/Wallet.tsx
+++ b/taker-frontend/src/components/Wallet.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, CopyIcon, ExternalLinkIcon } from "@chakra-ui/icons";
+import { CheckIcon, CopyIcon } from "@chakra-ui/icons";
 import {
     Box,
     Button,
@@ -26,7 +26,6 @@ import {
 } from "@chakra-ui/react";
 import * as React from "react";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { WalletInfo, WithdrawRequest } from "../types";
 import usePostRequest from "../usePostRequest";
 import Timestamp from "./Timestamp";
@@ -173,28 +172,4 @@ export default function Wallet(
     );
 }
 
-const WalletInfoBar = ({
-    walletInfo,
-}: WalletProps) => {
-    const { balance } = walletInfo || {};
-    const navigate = useNavigate();
-
-    return (
-        <HStack>
-            <Text align={"left"} as="b">Wallet Balance:</Text>
-            <Skeleton isLoaded={balance != null}>
-                <HStack>
-                    <Text>{balance} BTC</Text>
-                    <IconButton
-                        variant={"unstyled"}
-                        aria-label="Go to wallet"
-                        icon={<ExternalLinkIcon />}
-                        onClick={() => navigate("/wallet")}
-                    />
-                </HStack>
-            </Skeleton>
-        </HStack>
-    );
-};
-
-export { Wallet, WalletInfoBar };
+export { Wallet };


### PR DESCRIPTION
Part of some ui-changes I was working on the plane: 

I think it's nicer if the wallet balance is part of the table and not at the top.

![image](https://user-images.githubusercontent.com/224613/151270554-2c74aa39-5af9-44c1-83fa-1d358e7d818e.png)
