### PR TITLE
Revert "Avoid concurrent connections to database"

### DIFF
--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -17,7 +17,6 @@ use futures::future::BoxFuture;
 use futures::FutureExt;
 use sqlx::migrate::MigrateError;
 use sqlx::pool::PoolConnection;
-use sqlx::pool::PoolOptions;
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::Sqlite;
 use sqlx::SqlitePool;
@@ -31,14 +30,12 @@ use time::Duration;
 /// new one is created.
 pub fn connect(path: PathBuf) -> BoxFuture<'static, Result<SqlitePool>> {
     async move {
-        let pool = PoolOptions::new()
-            .max_connections(1)
-            .connect_with(
-                SqliteConnectOptions::new()
-                    .create_if_missing(true)
-                    .filename(&path),
-            )
-            .await?;
+        let pool = SqlitePool::connect_with(
+            SqliteConnectOptions::new()
+                .create_if_missing(true)
+                .filename(&path),
+        )
+        .await?;
 
         let path_display = path.display();
 


### PR DESCRIPTION
This reverts commit 09917c8dc37e6cc9f2e79e0bdedb975ea41052c2.

Limiting connection to 1 rendered the master branch unusable. Reverting until we
find a proper fix.