### PR TITLE
Handle negative rate in fee calculation

### DIFF
--- a/daemon/src/model.rs
+++ b/daemon/src/model.rs
@@ -821,11 +821,13 @@ pub fn calculate_funding_fee(
             .context("can't establish a fraction")?
     };
 
-    let funding_fee =
-        (Decimal::from(margin.as_sat()) * funding_rate.to_decimal() * fraction_of_funding_period)
-            .round_dp_with_strategy(0, rust_decimal::RoundingStrategy::AwayFromZero)
-            .to_u64()
-            .context("Failed to represent as u64")?;
+    let funding_fee = Decimal::from(margin.as_sat())
+        * funding_rate.to_decimal().abs()
+        * fraction_of_funding_period;
+    let funding_fee = funding_fee
+        .round_dp_with_strategy(0, rust_decimal::RoundingStrategy::AwayFromZero)
+        .to_u64()
+        .context("Failed to represent as u64")?;
 
     Ok(FundingFee::new(Amount::from_sat(funding_fee), funding_rate))
 }

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -2258,6 +2258,20 @@ mod tests {
         assert!(matches!(cannot_roll_over, NoRolloverReason::Final))
     }
 
+    #[test]
+    fn can_calculate_funding_fee_with_negative_funding_rate() {
+        let funding_rate = FundingRate::new(Decimal::NEGATIVE_ONE).unwrap();
+        let funding_fee = calculate_funding_fee(
+            Amount::ONE_BTC,
+            funding_rate,
+            SETTLEMENT_INTERVAL.whole_hours(),
+        )
+        .unwrap();
+
+        assert_eq!(funding_fee.fee, Amount::ONE_BTC);
+        assert_eq!(funding_fee.rate, funding_rate);
+    }
+
     impl Event {
         fn dummy_open(event_id: BitMexPriceEventId) -> Vec<Self> {
             vec![


### PR DESCRIPTION
Since the `FundingRate` is constructed from a signed decimal type, we can have a negative `FundingRate`. With that in mind and since we are modelling the `FundingFee` as an absolute value, we must use the absolute value of the `FundingRate` when computing the `FundingFee`'s `fee` field.