### PR TITLE
Enable `INFO` as the general log level

### DIFF
--- a/daemon/src/logger.rs
+++ b/daemon/src/logger.rs
@@ -13,6 +13,11 @@ pub fn init(level: LevelFilter, json_format: bool) -> Result<()> {
     let is_terminal = atty::is(atty::Stream::Stderr);
 
     let filter = EnvFilter::from_default_env()
+        .add_directive("info".parse()?)
+        .add_directive("sqlx=warn".parse()?) // sqlx logs all queries on INFO
+        .add_directive("bdk::blockchain::script_sync=off".parse()?) // bdk logs duration of sync on INFO
+        .add_directive("bdk::wallet=off".parse()?) // bdk logs derivation of addresses on INFO
+        .add_directive("_=off".parse()?) // rocket logs headers on INFO and uses `_` as the log target for it?
         .add_directive(format!("taker={level}").parse()?)
         .add_directive(format!("maker={level}").parse()?)
         .add_directive(format!("daemon={level}").parse()?)


### PR DESCRIPTION
Silence some other modules as part of this.

Without this, we are not going to see warnings such as https://github.com/comit-network/xtra/commit/15fdd524f2ed3ac94acfc92e21d5f285a485c23d.