### PR TITLE
Improve log output

### DIFF
--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -116,9 +116,14 @@ impl State {
             return false;
         }
 
-        tracing::warn!(
-            "Disconnecting due to lack of heartbeat. Last heartbeat: {:?}",
-            self.last_heartbeat()
+        let heartbeat_timestamp = self
+            .last_heartbeat()
+            .map(|heartbeat| heartbeat.to_string())
+            .unwrap_or_else(|| "None".to_owned());
+        let seconds_since_heartbeat = duration_since_last_heartbeat.as_secs();
+        tracing::warn!(%seconds_since_heartbeat,
+            %heartbeat_timestamp,
+            "Disconnecting due to lack of heartbeat",
         );
 
         *self = State::Disconnected;


### PR DESCRIPTION
Imho old log message was unreadable : 

```
2022-01-28 21:34:41  WARN daemon::connection: Disconnecting due to lack of heartbeat. Last heartbeat: Some(OffsetDateTime { utc_datetime: PrimitiveDateTime { date: Date { year: 2022, ordinal: 28 }, time: Time { hour: 21, minute: 34, second: 21, nanosecond: 367012000 } }, offset: UtcOffset { hours: 0, minutes: 0, seconds: 0 } })
```

New log says something like: 

```
2022-01-28 21:50:25  WARN daemon::connection: Disconnecting due to lack of heartbeat. Last heartbeat was 22 seconds ago. At 2022-01-28 21:50:02.99517 +00:00:00
```

