### PR TITLE
Use async messages for actors with circular dependencies

### DIFF
--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -535,7 +535,7 @@ where
 
         // 3. Inform connected takers
         self.takers
-            .send(maker_inc_connections::BroadcastOrder(Some(order)))
+            .send_async_safe(maker_inc_connections::BroadcastOrder(Some(order)))
             .await?;
 
         Ok(())


### PR DESCRIPTION
The `maker_cfd::Actor` and `maker_inc_connections::Actor` have a
dependency on each other. As a result, it might be possible that either
of them send a message to each other and thus create a deadlock because
neither of the message handlers can complete. For both, broadcasting a
new order and informing about a new taker, we don't need to wait for the
result so we can simply use async messaging here which might resolve
this deadlock.

Fixes #1261.