### PR TITLE
Improve "No liquidity" alert from the maker

### DIFF
--- a/taker-frontend/src/components/Trade.tsx
+++ b/taker-frontend/src/components/Trade.tsx
@@ -149,8 +149,8 @@ export default function Trade({
         }
         if (!orderId) {
             alertBox = <AlertBox
-                title={"No liquidity!"}
-                description={"The maker you are connected has not create any offers"}
+                title={"No liquidity in maker!"}
+                description={"The maker you are connected has no active offers"}
             />;
         }
     }


### PR DESCRIPTION
Make it clear it's the *maker's* liquidity that has a problem, and fix the
grammar error by rephrasing.