### PR TITLE
Send Attestation message async

### DIFF
--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -252,15 +252,8 @@ impl Actor {
         self.ensure_having_announcements(self.announcement_lookahead, ctx);
         self.update_pending_attestations(ctx);
     }
-}
 
-#[derive(Debug, Clone, thiserror::Error)]
-#[error("Announcement {0} not found")]
-pub struct NoAnnouncement(pub BitMexPriceEventId);
-
-#[async_trait]
-impl xtra::Handler<NewAttestationFetched> for Actor {
-    async fn handle(&mut self, msg: NewAttestationFetched, _ctx: &mut xtra::Context<Self>) {
+    async fn handle_new_attestation_fetched(&mut self, msg: NewAttestationFetched) {
         let NewAttestationFetched { id, attestation } = msg;
 
         tracing::info!("Fetched new attestation for {id}");
@@ -269,6 +262,10 @@ impl xtra::Handler<NewAttestationFetched> for Actor {
         self.pending_attestations.remove(&id);
     }
 }
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("Announcement {0} not found")]
+pub struct NoAnnouncement(pub BitMexPriceEventId);
 
 pub fn next_announcement_after(timestamp: OffsetDateTime) -> Result<BitMexPriceEventId> {
     let adjusted = ceil_to_next_hour(timestamp)?;
@@ -348,10 +345,6 @@ impl xtra::Actor for Actor {
 }
 
 impl xtra::Message for Attestation {
-    type Result = ();
-}
-
-impl xtra::Message for NewAttestationFetched {
     type Result = ();
 }
 

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -208,17 +208,6 @@ impl Actor {
             )
         }
     }
-
-    async fn handle_new_attestation_fetched(
-        &mut self,
-        id: BitMexPriceEventId,
-        attestation: Attestation,
-    ) {
-        tracing::info!("Fetched new attestation for {id}");
-
-        let _ = self.attestation_channel.send(attestation).await;
-        self.pending_attestations.remove(&id);
-    }
 }
 
 #[xtra_productivity]
@@ -271,13 +260,13 @@ pub struct NoAnnouncement(pub BitMexPriceEventId);
 
 #[async_trait]
 impl xtra::Handler<NewAttestationFetched> for Actor {
-    async fn handle(
-        &mut self,
-        msg: NewAttestationFetched,
-        _ctx: &mut xtra::Context<Self>,
-    ) {
-        self.handle_new_attestation_fetched(msg.id, msg.attestation)
-            .await
+    async fn handle(&mut self, msg: NewAttestationFetched, _ctx: &mut xtra::Context<Self>) {
+        let NewAttestationFetched { id, attestation } = msg;
+
+        tracing::info!("Fetched new attestation for {id}");
+
+        let _ = self.attestation_channel.send(attestation).await;
+        self.pending_attestations.remove(&id);
     }
 }
 

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -258,7 +258,7 @@ impl Actor {
 
         tracing::info!("Fetched new attestation for {id}");
 
-        let _ = self.attestation_channel.send(attestation).await;
+        let _: Result<(), xtra::Disconnected> = self.attestation_channel.send(attestation).await;
         self.pending_attestations.remove(&id);
     }
 }

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -3,6 +3,7 @@ use crate::model::cfd::CfdEvent;
 use crate::model::cfd::Event;
 use crate::model::BitMexPriceEventId;
 use crate::try_continue;
+use crate::xtra_ext::SendAsyncSafe;
 use crate::xtra_ext::SendInterval;
 use crate::Tasks;
 use anyhow::Context;
@@ -258,7 +259,8 @@ impl Actor {
 
         tracing::info!("Fetched new attestation for {id}");
 
-        let _: Result<(), xtra::Disconnected> = self.attestation_channel.send(attestation).await;
+        let _: Result<(), xtra::Disconnected> =
+            self.attestation_channel.send_async_safe(attestation).await;
         self.pending_attestations.remove(&id);
     }
 }

--- a/daemon/src/xtra_ext.rs
+++ b/daemon/src/xtra_ext.rs
@@ -170,6 +170,17 @@ where
 }
 
 #[async_trait]
+impl<M> SendAsyncSafe<M, ()> for Box<dyn xtra::prelude::StrongMessageChannel<M>>
+where
+    M: xtra::Message<Result = ()>,
+{
+    async fn send_async_safe(&self, msg: M) -> Result<(), xtra::Disconnected> {
+        #[allow(clippy::disallowed_method)]
+        self.do_send(msg)
+    }
+}
+
+#[async_trait]
 impl<M, E> SendAsyncSafe<M, Result<(), E>> for Box<dyn xtra::prelude::MessageChannel<M>>
 where
     M: xtra::Message<Result = Result<(), E>>,


### PR DESCRIPTION
Latest testing revealed that we might be causing a deadlock here by waiting for this message to be delivered.