### PR TITLE
Bump xtra to latest HEAD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,6 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "derivative",
  "derive_more",
  "futures",
  "hex",
@@ -692,17 +691,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
  "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
  "quote",
  "syn",
 ]
@@ -3898,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "xtra"
 version = "0.6.0"
-source = "git+https://github.com/comit-network/xtra#15fdd524f2ed3ac94acfc92e21d5f285a485c23d"
+source = "git+https://github.com/comit-network/xtra#b90ffec9c1b27fea1210379cb4a0df3f7f0c77e1"
 dependencies = [
  "async-trait",
  "barrage",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -11,7 +11,6 @@ bdk = { version = "0.16", default-features = false, features = ["electrum"] }
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.0.13", features = ["derive"] }
-derivative = "2"
 derive_more = { version = "0.99.17", default-features = false, features = ["display"] }
 futures = { version = "0.3", default-features = false }
 hex = "0.4"

--- a/daemon/src/address_map.rs
+++ b/daemon/src/address_map.rs
@@ -2,7 +2,6 @@ use crate::xtra_ext::ActorName;
 use anyhow::Result;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::fmt;
 use std::hash::Hash;
 use xtra::Address;
 use xtra::Handler;
@@ -110,12 +109,6 @@ where
     A: 'static,
 {
     type Result = ();
-}
-
-impl<A> fmt::Debug for Stopping<A> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Stopping").finish()
-    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/daemon/src/auto_rollover.rs
+++ b/daemon/src/auto_rollover.rs
@@ -152,11 +152,9 @@ where
 
 /// Message sent to ourselves at an interval to check if rollover can
 /// be triggered for any of the CFDs in the database.
-#[derive(Debug)]
 pub struct AutoRollover;
 
 /// Message used to trigger rollover internally within the `auto_rollover::Actor`
 ///
 /// This helps us trigger rollover in the tests unconditionally of time.
-#[derive(Debug)]
 pub struct Rollover(pub OrderId);

--- a/daemon/src/collab_settlement_maker.rs
+++ b/daemon/src/collab_settlement_maker.rs
@@ -24,13 +24,8 @@ pub struct Actor {
     n_payouts: usize,
 }
 
-#[derive(Debug)]
 pub struct Accepted;
-
-#[derive(Debug)]
 pub struct Rejected;
-
-#[derive(Debug)]
 pub struct Initiated {
     pub sig_taker: Signature,
 }

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -397,7 +397,7 @@ impl Actor {
             }
             Some(unexpected_message) => {
                 bail!(
-                    "Unexpected message {unexpected_message:?} from maker {maker_identity}"
+                    "Unexpected message {unexpected_message} from maker {maker_identity}"
                 )
             }
             None => {

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -22,7 +22,6 @@ use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use bdk::bitcoin::Amount;
-use derivative::Derivative;
 use futures::SinkExt;
 use futures::StreamExt;
 use futures::TryStreamExt;
@@ -158,19 +157,16 @@ pub struct Actor {
     rollover_actors: AddressMap<OrderId, rollover_taker::Actor>,
 }
 
-#[derive(Debug)]
 pub struct Connect {
     pub maker_identity: Identity,
     pub maker_addr: SocketAddr,
 }
 
-#[derive(Debug)]
 pub struct MakerStreamMessage {
     pub item: Result<wire::MakerToTaker>,
 }
 
 /// Private message to measure the current pulse (i.e. check when we received the last heartbeat).
-#[derive(Debug)]
 struct MeasurePulse;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -196,33 +192,24 @@ pub enum ConnectionCloseReason {
 /// `setup_taker::Actor` is included so that the `connection::Actor`
 /// knows where to forward the contract setup messages from the maker
 /// about this particular order.
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct TakeOrder {
     pub order_id: OrderId,
     pub quantity: Usd,
-    #[derivative(Debug = "ignore")]
     pub address: xtra::Address<setup_taker::Actor>,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct ProposeSettlement {
     pub order_id: OrderId,
     pub timestamp: Timestamp,
     pub taker: Amount,
     pub maker: Amount,
     pub price: Price,
-    #[derivative(Debug = "ignore")]
     pub address: xtra::Address<collab_settlement_taker::Actor>,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct ProposeRollover {
     pub order_id: OrderId,
     pub timestamp: Timestamp,
-    #[derivative(Debug = "ignore")]
     pub address: xtra::Address<rollover_taker::Actor>,
 }
 

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -40,37 +40,24 @@ use xtra::prelude::*;
 use xtra::Actor as _;
 use xtra_productivity::xtra_productivity;
 
-#[derive(Debug)]
 pub struct AcceptOrder {
     pub order_id: OrderId,
 }
-
-#[derive(Debug)]
 pub struct RejectOrder {
     pub order_id: OrderId,
 }
-
-#[derive(Debug)]
 pub struct AcceptSettlement {
     pub order_id: OrderId,
 }
-
-#[derive(Debug)]
 pub struct RejectSettlement {
     pub order_id: OrderId,
 }
-
-#[derive(Debug)]
 pub struct AcceptRollover {
     pub order_id: OrderId,
 }
-
-#[derive(Debug)]
 pub struct RejectRollover {
     pub order_id: OrderId,
 }
-
-#[derive(Debug)]
 pub struct NewOrder {
     pub price: Price,
     pub min_quantity: Usd,
@@ -80,17 +67,14 @@ pub struct NewOrder {
     pub opening_fee: OpeningFee,
 }
 
-#[derive(Debug)]
 pub struct TakerConnected {
     pub id: Identity,
 }
 
-#[derive(Debug)]
 pub struct TakerDisconnected {
     pub id: Identity,
 }
 
-#[derive(Debug)]
 pub struct FromTaker {
     pub taker_id: Identity,
     pub msg: wire::TakerToMaker,

--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -26,7 +26,6 @@ use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use async_trait::async_trait;
-use derivative::Derivative;
 use futures::SinkExt;
 use futures::StreamExt;
 use futures::TryStreamExt;
@@ -39,7 +38,6 @@ use tokio_util::codec::Framed;
 use xtra::prelude::*;
 use xtra_productivity::xtra_productivity;
 
-#[derive(Debug)]
 pub struct BroadcastOrder(pub Option<Order>);
 
 /// Message sent from the `setup_maker::Actor` to the
@@ -50,12 +48,9 @@ pub struct BroadcastOrder(pub Option<Order>);
 /// `setup_maker::Actor` is included so that the
 /// `maker_inc_connections::Actor` knows where to forward the contract
 /// setup messages from the taker about this particular order.
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct ConfirmOrder {
     pub taker_id: Identity,
     pub order_id: OrderId,
-    #[derivative(Debug = "ignore")]
     pub address: xtra::Address<setup_maker::Actor>,
 }
 
@@ -71,35 +66,27 @@ pub mod settlement {
     /// `maker_inc_connections::Actor` knows where to forward the
     /// collaborative settlement messages from the taker about this
     /// particular order.
-    #[derive(Debug)]
     pub struct Response {
         pub taker_id: Identity,
         pub order_id: OrderId,
         pub decision: Decision,
     }
 
-    #[derive(Derivative)]
-    #[derivative(Debug)]
     pub enum Decision {
         Accept {
-            #[derivative(Debug = "ignore")]
             address: xtra::Address<collab_settlement_maker::Actor>,
         },
         Reject,
     }
 }
 
-#[derive(Debug)]
 pub struct TakerMessage {
     pub taker_id: Identity,
     pub msg: wire::MakerToTaker,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct RegisterRollover {
     pub order_id: OrderId,
-    #[derivative(Debug = "ignore")]
     pub address: xtra::Address<rollover_maker::Actor>,
 }
 
@@ -246,7 +233,6 @@ impl Actor {
     }
 }
 
-#[derive(Debug)]
 struct SendHeartbeat(Identity);
 
 #[derive(Debug, thiserror::Error)]
@@ -525,20 +511,14 @@ async fn upgrade(
     Ok(())
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 struct ConnectionReady {
-    #[derivative(Debug = "ignore")]
     read: wire::Read<wire::TakerToMaker, wire::MakerToTaker>,
-    #[derivative(Debug = "ignore")]
     write: wire::Write<wire::TakerToMaker, wire::MakerToTaker>,
     identity: Identity,
 }
 
-#[derive(Debug)]
 struct ReadFail(Identity);
 
-#[derive(Debug)]
 struct ListenerFailed {
     error: anyhow::Error,
 }

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -1660,7 +1660,7 @@ pub enum Completed<P, E> {
     },
 }
 
-impl<P: fmt::Debug, E: fmt::Debug> xtra::Message for Completed<P, E>
+impl<P, E> xtra::Message for Completed<P, E>
 where
     P: Send + 'static,
     E: Send + 'static,

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -43,13 +43,11 @@ use xtra_productivity::xtra_productivity;
 
 const FINALITY_CONFIRMATIONS: u32 = 1;
 
-#[derive(Debug)]
 pub struct StartMonitoring {
     pub id: OrderId,
     pub params: MonitorParams,
 }
 
-#[derive(Debug)]
 pub struct CollaborativeSettlement {
     pub order_id: OrderId,
     pub tx: (Txid, Script),
@@ -57,7 +55,7 @@ pub struct CollaborativeSettlement {
 
 // TODO: The design of this struct causes a lot of marshalling und unmarshelling that is quite
 // unnecessary. Should be taken apart so we can handle all cases individually!
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct MonitorParams {
     lock: (Txid, Descriptor<PublicKey>),
     commit: (Txid, Descriptor<PublicKey>),
@@ -67,13 +65,11 @@ pub struct MonitorParams {
     event_id: BitMexPriceEventId,
 }
 
-#[derive(Debug)]
 pub struct TryBroadcastTransaction {
     pub tx: Transaction,
     pub kind: TransactionKind,
 }
 
-#[derive(Debug)]
 pub enum TransactionKind {
     Lock,
     Commit,
@@ -131,7 +127,6 @@ struct RpcError {
     message: String,
 }
 
-#[derive(Debug)]
 pub struct Sync;
 
 // TODO: Send messages to the projection actor upon finality events so we send out updates.
@@ -739,7 +734,7 @@ impl MonitorParams {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct Cet {
     txid: Txid,
     script: Script,
@@ -1018,7 +1013,6 @@ where
 }
 
 // TODO: Re-model this by tearing apart `MonitorParams`.
-#[derive(Debug)]
 struct ReinitMonitoring {
     id: OrderId,
 

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -32,10 +32,8 @@ pub struct Actor {
     db: sqlx::SqlitePool,
 }
 
-#[derive(Debug)]
 pub struct Sync;
 
-#[derive(Debug)]
 pub struct MonitorAttestation {
     pub event_id: BitMexPriceEventId,
 }

--- a/daemon/src/process_manager.rs
+++ b/daemon/src/process_manager.rs
@@ -22,7 +22,6 @@ pub struct Actor {
     monitor_attestation: Box<dyn MessageChannel<oracle::MonitorAttestation>>,
 }
 
-#[derive(Debug)]
 pub struct Event(cfd::Event);
 
 impl Event {

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -52,12 +52,10 @@ use xtra_productivity::xtra_productivity;
 
 /// Store the latest state of `T` for display purposes
 /// (replaces previously stored values)
-#[derive(Debug)]
 pub struct Update<T>(pub T);
 
 /// Message indicating that the Cfds in the projection need to be reloaded, as at
 /// least one of the Cfds has changed.
-#[derive(Debug)]
 pub struct CfdsChanged;
 
 pub struct Actor {

--- a/daemon/src/rollover_maker.rs
+++ b/daemon/src/rollover_maker.rs
@@ -34,21 +34,17 @@ use xtra_productivity::xtra_productivity;
 
 /// Upon accepting Rollover maker sends the current estimated transaction fee and
 /// funding rate
-#[derive(Debug)]
 pub struct AcceptRollover {
     pub tx_fee_rate: TxFeeRate,
     pub funding_rate: FundingRate,
 }
 
-#[derive(Debug)]
 pub struct RejectRollover;
 
-#[derive(Debug)]
 pub struct ProtocolMsg(pub wire::RolloverMsg);
 
 /// Message sent from the spawned task to `rollover_taker::Actor` to
 /// notify that rollover has finished successfully.
-#[derive(Debug)]
 struct RolloverSucceeded {
     dlc: Dlc,
     funding_fee: FundingFee,
@@ -56,7 +52,6 @@ struct RolloverSucceeded {
 
 /// Message sent from the spawned task to `rollover_maker::Actor` to
 /// notify that rollover has failed.
-#[derive(Debug)]
 struct RolloverFailed {
     error: anyhow::Error,
 }

--- a/daemon/src/rollover_taker.rs
+++ b/daemon/src/rollover_taker.rs
@@ -329,7 +329,6 @@ impl Actor {
 /// Message sent from the `connection::Actor` to the
 /// `rollover_taker::Actor` to notify that the maker has accepted the
 /// rollover proposal.
-#[derive(Debug)]
 pub struct RolloverAccepted {
     pub oracle_event_id: BitMexPriceEventId,
     pub tx_fee_rate: TxFeeRate,
@@ -339,12 +338,10 @@ pub struct RolloverAccepted {
 /// Message sent from the `connection::Actor` to the
 /// `rollover_taker::Actor` to notify that the maker has rejected the
 /// rollover proposal.
-#[derive(Debug)]
 pub struct RolloverRejected;
 
 /// Message sent from the spawned task to `rollover_taker::Actor` to
 /// notify that rollover has finished successfully.
-#[derive(Debug)]
 struct RolloverSucceeded {
     dlc: Dlc,
     funding_fee: FundingFee,
@@ -352,7 +349,6 @@ struct RolloverSucceeded {
 
 /// Message sent from the spawned task to `rollover_taker::Actor` to
 /// notify that rollover has failed.
-#[derive(Debug)]
 struct RolloverFailed {
     error: anyhow::Error,
 }
@@ -361,7 +357,6 @@ struct RolloverFailed {
 /// notify that the timeout has been reached.
 ///
 /// It is up to the actor to reason whether or not the protocol has progressed since then.
-#[derive(Debug)]
 struct MakerResponseTimeoutReached {
     timeout: Duration,
 }

--- a/daemon/src/setup_maker.rs
+++ b/daemon/src/setup_maker.rs
@@ -272,18 +272,15 @@ impl xtra::Actor for Actor {
 /// Message sent from the `maker_cfd::Actor` to the
 /// `setup_maker::Actor` to inform that the maker user has accepted
 /// the taker order request from the taker.
-#[derive(Debug)]
 pub struct Accepted;
 
 /// Message sent from the `maker_cfd::Actor` to the
 /// `setup_maker::Actor` to inform that the maker user has rejected
 /// the taker order request from the taker.
-#[derive(Debug)]
 pub struct Rejected;
 
 /// Message sent from the spawned task to `setup_maker::Actor` to
 /// notify that the contract setup has finished successfully.
-#[derive(Debug)]
 struct SetupSucceeded {
     order_id: OrderId,
     dlc: Dlc,
@@ -291,7 +288,6 @@ struct SetupSucceeded {
 
 /// Message sent from the spawned task to `setup_maker::Actor` to
 /// notify that the contract setup has failed.
-#[derive(Debug)]
 struct SetupFailed {
     order_id: OrderId,
     error: anyhow::Error,

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -195,13 +195,11 @@ impl xtra::Actor for Actor {
 /// Message sent from the `connection::Actor` to the
 /// `setup_taker::Actor` to notify that the order taken was accepted
 /// by the maker.
-#[derive(Debug)]
 pub struct Accepted;
 
 /// Message sent from the `connection::Actor` to the
 /// `setup_taker::Actor` to notify that the order taken was rejected
 /// by the maker.
-#[derive(Debug)]
 pub struct Rejected {
     /// Used to indicate whether the rejection stems from the order ID
     /// not being recognised by the maker.
@@ -210,7 +208,6 @@ pub struct Rejected {
 
 /// Message sent from the spawned task to `setup_taker::Actor` to
 /// notify that the contract setup has finished successfully.
-#[derive(Debug)]
 struct SetupSucceeded {
     order_id: OrderId,
     dlc: Dlc,
@@ -218,7 +215,6 @@ struct SetupSucceeded {
 
 /// Message sent from the spawned task to `setup_taker::Actor` to
 /// notify that the contract setup has failed.
-#[derive(Debug)]
 struct SetupFailed {
     order_id: OrderId,
     error: anyhow::Error,

--- a/daemon/src/supervisor.rs
+++ b/daemon/src/supervisor.rs
@@ -7,7 +7,6 @@ use std::fmt;
 use std::panic::AssertUnwindSafe;
 use xtra::Address;
 use xtra::Context;
-use xtra::Message;
 use xtra_productivity::xtra_productivity;
 
 /// A supervising actor reacts to messages from the actor it is supervising and restarts it based on
@@ -31,7 +30,7 @@ struct Metrics {
 impl<T, R> Actor<T, R>
 where
     T: xtra::Actor,
-    R: fmt::Display + fmt::Debug + 'static,
+    R: fmt::Display + 'static,
 {
     /// Construct a new supervisor.
     ///
@@ -82,18 +81,18 @@ where
 impl<T, R> xtra::Actor for Actor<T, R>
 where
     T: xtra::Actor,
-    R: fmt::Display + fmt::Debug + 'static,
+    R: fmt::Display + 'static,
 {
     async fn started(&mut self, ctx: &mut Context<Self>) {
         self.spawn_new(ctx);
     }
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl<T, R> Actor<T, R>
 where
     T: xtra::Actor,
-    R: fmt::Display + fmt::Debug + 'static,
+    R: fmt::Display + 'static,
 {
     pub fn handle(&mut self, msg: Stopped<R>, ctx: &mut Context<Self>) {
         let actor = T::name();
@@ -112,7 +111,7 @@ where
 impl<T, R> Actor<T, R>
 where
     T: xtra::Actor,
-    R: fmt::Display + fmt::Debug + 'static,
+    R: fmt::Display + 'static,
 {
     pub fn handle(&mut self, _: GetMetrics) -> Metrics {
         self.metrics
@@ -123,7 +122,7 @@ where
 impl<T, R> xtra::Handler<Panicked> for Actor<T, R>
 where
     T: xtra::Actor,
-    R: fmt::Display + fmt::Debug + 'static,
+    R: fmt::Display + 'static,
 {
     async fn handle(&mut self, msg: Panicked, ctx: &mut Context<Self>) {
         let actor = T::name();
@@ -143,17 +142,11 @@ where
 ///
 /// The given `reason` will be passed to the `restart_policy` configured in the supervisor. If it
 /// yields `true`, a new instance of the actor will be spawned.
-#[derive(Debug)]
 pub struct Stopped<R> {
     pub reason: R,
 }
 
-impl<R: fmt::Debug + Send + 'static> Message for Stopped<R> {
-    type Result = ();
-}
-
 /// Module private message to notify ourselves that an actor panicked.
-#[derive(Debug)]
 struct Panicked {
     pub error: Box<dyn Any + Send>,
 }
@@ -167,7 +160,6 @@ impl xtra::Message for Panicked {
 /// Currently private because it is a feature only used for testing. If we want to expose metrics
 /// about the supervisor, we should look into creating a [`tracing::Subscriber`] that processes the
 /// events we are emitting.
-#[derive(Debug)]
 struct GetMetrics;
 
 #[cfg(test)]
@@ -231,7 +223,6 @@ mod tests {
         supervisor: Address<Actor<Self, String>>,
     }
 
-    #[derive(Debug)]
     struct Shutdown;
 
     #[async_trait]
@@ -257,7 +248,6 @@ mod tests {
         _supervisor: Address<Actor<Self, String>>,
     }
 
-    #[derive(Debug)]
     struct Panic;
 
     impl xtra::Actor for PanickingActor {}

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -26,16 +26,13 @@ use xtra::prelude::*;
 use xtra::Actor as _;
 use xtra_productivity::xtra_productivity;
 
-#[derive(Debug)]
 pub struct CurrentOrder(pub Option<Order>);
 
-#[derive(Debug)]
 pub struct TakeOffer {
     pub order_id: OrderId,
     pub quantity: Usd,
 }
 
-#[derive(Debug)]
 pub struct ProposeSettlement {
     pub order_id: OrderId,
     pub current_price: Price,

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -198,7 +198,6 @@ impl xtra::Actor for Actor {
     }
 }
 
-#[derive(Debug)]
 pub struct BuildPartyParams {
     pub amount: Amount,
     pub identity_pk: PublicKey,
@@ -206,15 +205,12 @@ pub struct BuildPartyParams {
 }
 
 /// Private message to trigger a sync.
-#[derive(Debug)]
 struct Sync;
 
-#[derive(Debug)]
 pub struct Sign {
     pub psbt: PartiallySignedTransaction,
 }
 
-#[derive(Debug)]
 pub struct Withdraw {
     pub amount: Option<Amount>,
     pub fee: Option<FeeRate>,

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -112,12 +112,6 @@ pub enum TakerToMaker {
     },
 }
 
-impl fmt::Debug for TakerToMaker {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self}")
-    }
-}
-
 impl fmt::Display for TakerToMaker {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -161,12 +155,6 @@ pub enum MakerToTaker {
         order_id: OrderId,
         msg: maker_to_taker::Settlement,
     },
-}
-
-impl fmt::Debug for MakerToTaker {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self}")
-    }
 }
 
 pub mod maker_to_taker {
@@ -322,12 +310,6 @@ impl fmt::Display for SetupMsg {
     }
 }
 
-impl fmt::Debug for SetupMsg {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self}")
-    }
-}
-
 impl SetupMsg {
     pub fn try_into_msg0(self) -> Result<Msg0> {
         if let Self::Msg0(v) = self {
@@ -479,12 +461,6 @@ impl fmt::Display for RolloverMsg {
             RolloverMsg::Msg2(_) => write!(f, "Msg2"),
             RolloverMsg::Msg3(_) => write!(f, "Msg3"),
         }
-    }
-}
-
-impl fmt::Debug for RolloverMsg {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self}")
     }
 }
 


### PR DESCRIPTION
The latest commit relaxes the `Debug` requirement and instead uses `std::any::type_name` to log the offending message.

This is a more systematic solution than https://github.com/itchysats/itchysats/pull/1276.