### PR TITLE
Cache expensive CFD events to avoid deserialising them from JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-rwlock"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261803dcc39ba9e72760ba6e16d0199b1eef9fc44e81bffabbebb9f5aea3906c"
+dependencies = [
+ "async-mutex",
+ "event-listener",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +364,38 @@ name = "cache-padded"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+
+[[package]]
+name = "cached"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4dfac631a8e77b2f327f7852bb6172771f5279c4512efe79fad6067b37be3d"
+dependencies = [
+ "async-mutex",
+ "async-rwlock",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "hashbrown",
+ "once_cell",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "725f434d6da2814b989bd905c62ca28a9383feff7440210dc279665fbbbc9511"
+dependencies = [
+ "cached_proc_macro_types",
+ "darling",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "catty"
@@ -613,6 +664,7 @@ dependencies = [
  "atty",
  "bdk",
  "bytes",
+ "cached",
  "chrono",
  "clap",
  "derivative",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -9,6 +9,7 @@ async-trait = "0.1.52"
 atty = "0.2"
 bdk = { version = "0.16", default-features = false, features = ["electrum"] }
 bytes = "1"
+cached = { version = "0.30.0", default-features = false, features = ["proc_macro"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.0.13", features = ["derive"] }
 derivative = "2"


### PR DESCRIPTION
Examining the maker with a flamegraph showed that we have been using ~50% CPU on
deserialising CFD events from JSON.

Using `cached` crate reduced that number significantly (to ~8%). However, the
cache size constraint would become a problem for long-running CFDs - to minimise
this issue, selective dispatch for expensive events was used.

ContractSetupCompleted and RolloverCompleted store the whole DLC, which takes a
lot of time to deserialise; these events were chosen to be cached.