### PR TITLE
Do not store whole redundant CET in CfdEvents

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -70,6 +70,7 @@ pub mod supervisor;
 pub mod taker_cfd;
 pub mod to_sse_event;
 pub mod tokio_ext;
+mod transaction_ext;
 pub mod try_continue;
 pub mod wallet;
 pub mod wire;

--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -30,6 +30,8 @@ use bdk::bitcoin::PublicKey;
 use bdk::bitcoin::Script;
 use bdk::bitcoin::SignedAmount;
 use bdk::bitcoin::Transaction;
+use bdk::bitcoin::TxIn;
+use bdk::bitcoin::TxOut;
 use bdk::bitcoin::Txid;
 use bdk::descriptor::Descriptor;
 use bdk::miniscript::DescriptorTrait;
@@ -1352,13 +1354,61 @@ pub fn calculate_profit_at_price(
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Cet {
-    pub tx: Transaction,
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    pub maker_amount: Amount,
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    pub taker_amount: Amount,
     pub adaptor_sig: EcdsaAdaptorSignature,
 
     // TODO: Range + number of digits (usize) could be represented as Digits similar to what we do
     // in the protocol lib
     pub range: RangeInclusive<u64>,
     pub n_bits: usize,
+
+    pub txid: Txid,
+}
+
+impl Cet {
+    /// Build an actual `Transaction` out of the payout information
+    /// stored in `Self`, together with the input and the output
+    /// addresses.
+    ///
+    /// The order of the outputs matters.
+    ///
+    /// We verify that the TXID of the resulting transaction matches
+    /// the TXID with which `Self` was constructed.
+    pub fn to_tx(
+        &self,
+        (commit_tx, commit_descriptor): (&Transaction, &Descriptor<PublicKey>),
+        maker_address: &Address,
+        taker_address: &Address,
+    ) -> Result<Transaction> {
+        let tx = Transaction {
+            version: 2,
+            input: vec![TxIn {
+                previous_output: commit_tx.outpoint(&commit_descriptor.script_pubkey())?,
+                sequence: CET_TIMELOCK,
+                ..Default::default()
+            }],
+            lock_time: 0,
+            output: vec![
+                TxOut {
+                    value: self.maker_amount.as_sat(),
+                    script_pubkey: maker_address.script_pubkey(),
+                },
+                TxOut {
+                    value: self.taker_amount.as_sat(),
+                    script_pubkey: taker_address.script_pubkey(),
+                },
+            ],
+        };
+
+        if tx.txid() != self.txid {
+            bail!("Reconstructed wrong CET");
+        }
+
+        Ok(tx)
+    }
 }
 
 /// Contains all data we've assembled about the CFD through the setup protocol.
@@ -1532,23 +1582,27 @@ impl Dlc {
             }
         };
 
-        let Cet {
-            tx: cet,
-            adaptor_sig: encsig,
-            n_bits,
-            ..
-        } = cets
+        let cet = cets
             .iter()
             .find(|Cet { range, .. }| range.contains(&attestation.price))
             .context("Price out of range of cets")?;
+        let encsig = cet.adaptor_sig;
 
         let mut decryption_sk = attestation.scalars[0];
-        for oracle_attestation in attestation.scalars[1..*n_bits].iter() {
+        for oracle_attestation in attestation.scalars[1..cet.n_bits].iter() {
             decryption_sk.add_assign(oracle_attestation.as_ref())?;
         }
 
+        let cet = cet
+            .to_tx(
+                (&self.commit.0, &self.commit.2),
+                &self.maker_address,
+                &self.taker_address,
+            )
+            .context("Failed to reconstruct CET")?;
+
         let sig_hash = spending_tx_sighash(
-            cet,
+            &cet,
             &self.commit.2,
             Amount::from_sat(self.commit.0.output[0].value),
         );
@@ -1562,7 +1616,7 @@ impl Dlc {
         let counterparty_pubkey = self.identity_counterparty;
 
         let signed_cet = finalize_spend_transaction(
-            cet.clone(),
+            cet,
             &self.commit.2,
             (our_pubkey, our_sig),
             (counterparty_pubkey, counterparty_sig),
@@ -2445,10 +2499,12 @@ mod tests {
             dummy_cet_with_zero_price_range.insert(
                 BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc()),
                 vec![Cet {
-                    tx: dummy_tx.clone(),
+                    maker_amount: Amount::from_sat(0),
+                    taker_amount: Amount::from_sat(0),
                     adaptor_sig: dummy_adapter_sig,
                     range: RangeInclusive::new(0, 1),
                     n_bits: 0,
+                    txid: dummy_tx.txid(),
                 }],
             );
 

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -13,6 +13,7 @@ use crate::model::Usd;
 use crate::oracle;
 use crate::payout_curve;
 use crate::tokio_ext::FutureExt;
+use crate::transaction_ext::TransactionExt;
 use crate::wallet;
 use crate::wire::Msg0;
 use crate::wire::Msg1;
@@ -303,6 +304,8 @@ pub async fn new(
     // need some fallback handling (after x time) to spend the outputs in a different way so the
     // other party cannot hold us hostage
 
+    let maker_script_pubkey = params.maker().address.script_pubkey();
+    let taker_script_pubkey = params.taker().address.script_pubkey();
     let cets = tokio::task::spawn_blocking(move || {
         own_cets
             .into_iter()
@@ -328,11 +331,17 @@ pub async fn new(
                                     "Missing counterparty adaptor signature for CET corresponding to price range {range:?}",
                                 )
                             })?;
+
+                        let maker_amount = tx.find_output_amount(&maker_script_pubkey).unwrap_or_default();
+                        let taker_amount = tx.find_output_amount(&taker_script_pubkey).unwrap_or_default();
+
                         Ok(Cet {
-                            tx,
+                            maker_amount,
+                            taker_amount,
                             adaptor_sig: *other_encsig,
                             range: digits.range(),
                             n_bits: digits.len(),
+                            txid: tx.txid(),
                         })
                     })
                     .collect::<Result<Vec<_>>>()?;
@@ -599,6 +608,8 @@ pub async fn roll_over(
     )
     .context("Refund signature does not verify")?;
 
+    let maker_script_pubkey = dlc.maker_address.script_pubkey();
+    let taker_script_pubkey = dlc.taker_address.script_pubkey();
     let cets = own_cets
         .into_iter()
         .map(|grouped_cets| {
@@ -624,11 +635,21 @@ pub async fn roll_over(
                                  price range {range:?}"
                             )
                         })?;
+
+                    let maker_amount = tx
+                        .find_output_amount(&maker_script_pubkey)
+                        .unwrap_or_default();
+                    let taker_amount = tx
+                        .find_output_amount(&taker_script_pubkey)
+                        .unwrap_or_default();
+
                     Ok(Cet {
-                        tx,
+                        maker_amount,
+                        taker_amount,
                         adaptor_sig: *other_encsig,
                         range: digits.range(),
                         n_bits: digits.len(),
+                        txid: tx.txid(),
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;

--- a/daemon/src/transaction_ext.rs
+++ b/daemon/src/transaction_ext.rs
@@ -1,0 +1,22 @@
+use bdk::bitcoin::Amount;
+use bdk::bitcoin::OutPoint;
+use bdk::bitcoin::Script;
+use bdk::bitcoin::Transaction;
+use maia::TransactionExt as _;
+
+pub trait TransactionExt {
+    fn find_output_amount(&self, script_pubkey: &Script) -> Option<Amount>;
+}
+
+impl TransactionExt for Transaction {
+    fn find_output_amount(&self, script_pubkey: &Script) -> Option<Amount> {
+        let OutPoint {
+            vout: maker_vout, ..
+        } = match self.outpoint(script_pubkey) {
+            Ok(out_point) => out_point,
+            Err(_) => return None,
+        };
+
+        Some(Amount::from_sat(self.output[maker_vout as usize].value))
+    }
+}


### PR DESCRIPTION
Instead we recompute it when we need it.

We still have to keep the TXID around for monitoring purposes. We would like to be able to recompute it, but that would make applying `CfdEvent`s fallible, which is forbidden.

This should help with https://github.com/itchysats/itchysats/issues/1288.

It's only a draft PR because it's just an attempt at doing this quickly. I considered adding some of this functionality to `maia` so that the protocol knowledge remains in that crate (e.g. the order of the outputs in the CET), but this was simpler.