### PR TITLE
Performance improvements for projection

### DIFF
--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -19,7 +19,9 @@ pub async fn insert_cfd_and_update_feed(
     projection_address: &xtra::Address<projection::Actor>,
 ) -> Result<()> {
     db::insert_cfd(cfd, conn).await?;
-    projection_address.send(projection::CfdsChanged).await?;
+    projection_address
+        .send(projection::CfdChanged(cfd.id()))
+        .await?;
     Ok(())
 }
 

--- a/daemon/src/process_manager.rs
+++ b/daemon/src/process_manager.rs
@@ -15,7 +15,7 @@ use xtra_productivity::xtra_productivity;
 pub struct Actor {
     db: sqlx::SqlitePool,
     role: Role,
-    cfds_changed: Box<dyn MessageChannel<projection::CfdsChanged>>,
+    cfds_changed: Box<dyn MessageChannel<projection::CfdChanged>>,
     try_broadcast_transaction: Box<dyn MessageChannel<monitor::TryBroadcastTransaction>>,
     start_monitoring: Box<dyn MessageChannel<monitor::StartMonitoring>>,
     monitor_collaborative_settlement: Box<dyn MessageChannel<monitor::CollaborativeSettlement>>,
@@ -34,7 +34,7 @@ impl Actor {
     pub fn new(
         db: sqlx::SqlitePool,
         role: Role,
-        cfds_changed: &(impl MessageChannel<projection::CfdsChanged> + 'static),
+        cfds_changed: &(impl MessageChannel<projection::CfdChanged> + 'static),
         try_broadcast_transaction: &(impl MessageChannel<monitor::TryBroadcastTransaction> + 'static),
         start_monitoring: &(impl MessageChannel<monitor::StartMonitoring> + 'static),
         monitor_collaborative_settlement: &(impl MessageChannel<monitor::CollaborativeSettlement>
@@ -207,7 +207,7 @@ impl Actor {
 
         // 3. Update UI
         self.cfds_changed
-            .send_async_safe(projection::CfdsChanged)
+            .send_async_safe(projection::CfdChanged(event.id))
             .await?;
 
         Ok(())

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -711,9 +711,11 @@ impl Actor {
 
     fn handle(&mut self, msg: Update<Option<bitmex_price_feed::Quote>>) {
         self.state.update_quote(msg.0);
-        self.tx.update_quote(msg.0);
 
-        self.refresh_cfds().await;
+        let hydrated_cfds = self.state.cfds.clone();
+
+        self.tx.update_quote(msg.0);
+        self.tx.update_cfds(hydrated_cfds, msg.0);
     }
 
     fn handle(&mut self, msg: Update<Vec<model::Identity>>) {

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -631,6 +631,10 @@ impl Tx {
 
         let _ = self.cfds.send(cfds_with_quote);
     }
+
+    fn update_quote(&self, quote: Option<bitmex_price_feed::Quote>) {
+        let _ = self.quote.send(quote.map(|q| q.into()));
+    }
 }
 
 /// Internal struct to keep state in one place
@@ -703,7 +707,8 @@ impl Actor {
 
     fn handle(&mut self, msg: Update<Option<bitmex_price_feed::Quote>>) {
         self.state.update_quote(msg.0);
-        let _ = self.tx.quote.send(msg.0.map(|q| q.into()));
+        self.tx.update_quote(msg.0);
+
         self.refresh_cfds().await;
     }
 


### PR DESCRIPTION
Instead of rehydrating all CFDs whenever any CFD or the quote changes we now:

- Only rehydrate the specific CFD whenever it changes
- Keep the hydrated CFD around (this is basically an in-memory persistent read model)
- Only apply the new quote to the CFDs whenever the quote changes

As a follow-up, we can eventually take apart the `projection::Cfd` struct into two structs:

- The aggregate hydrated from all events
- The struct that is actually serialized over the wire