### PR TITLE
Treat RevokeConfirmed as CommitConfirmed

### DIFF
--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -1237,7 +1237,12 @@ impl Cfd {
                 // commands
             }
             ManualCommit { tx } => self.commit_tx = Some(tx),
-            RevokeConfirmed => todo!("Deal with revoke"),
+            RevokeConfirmed => {
+                tracing::error!(order_id = %self.id, "Revoked logic not implemented");
+                // TODO: we should punish the other party instead. For now, we pretend we are in
+                // commit finalized and will receive our money based on an old CET.
+                self.commit_finality = true;
+            }
         }
 
         self

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -275,7 +275,10 @@ impl Cfd {
             | OracleAttestedPriorCetTimelock { .. }
             | CollaborativeSettlementStarted { .. }
             | CollaborativeSettlementProposalAccepted => self,
-            RevokeConfirmed => todo!("Deal with revoked"),
+            RevokeConfirmed => {
+                tracing::error!("Revoked logic not implemented");
+                self
+            }
         }
     }
 }

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -487,7 +487,10 @@ impl Cfd {
 
                 self.state = CfdState::PendingCommit;
             }
-            RevokeConfirmed => todo!("Deal with revoked"),
+            RevokeConfirmed => {
+                tracing::error!(order_id = %self.order_id, "Revoked logic not implemented");
+                self.state = CfdState::OpenCommitted;
+            }
             RolloverStarted { .. } => match role {
                 Role::Maker => {
                     self.state = CfdState::IncomingRolloverProposal;


### PR DESCRIPTION
Fixes #1300

The problem was that we monitor for the publishment of revoked commit transaction but don't act on it yet. If there is a `todo!` in the code, we will panic and cannot recover from this.

While if the other party publishes a revoked commit transaction we should punish them this logic is not yet implemented.

For now, we just pretend that everything is fine and treat it as if it was the expected commit transaction.
The downside is that we will receive our money according to an old price.