### PR TITLE
Allow closing position without lock confirmation

### DIFF
--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -644,7 +644,7 @@ impl Cfd {
     }
 
     fn can_settle_collaboratively(&self) -> bool {
-        self.lock_finality && !self.commit_finality && !self.is_final() && !self.is_attested()
+        !self.commit_finality && !self.is_final() && !self.is_attested()
     }
 
     fn is_attested(&self) -> bool {
@@ -943,7 +943,7 @@ impl Cfd {
         settlement: CollaborativeSettlementCompleted,
     ) -> Result<Event> {
         if !self.can_settle_collaboratively() {
-            bail!("Cannot collaboratively settle anymore")
+            bail!("Cannot collaboratively settle")
         }
 
         let event = match settlement {

--- a/taker-frontend/src/components/CloseButton.tsx
+++ b/taker-frontend/src/components/CloseButton.tsx
@@ -27,7 +27,7 @@ interface Props {
 /// maker is online.
 export default function CloseButton({ cfd, request, status, buttonTitle, isForceCloseButton }: Props) {
     const disableCloseButton = cfd.state.getGroup() === StateGroupKey.CLOSED
-        || !(cfd.state.key === StateKey.OPEN);
+        || ![StateKey.OPEN, StateKey.PENDING_OPEN].includes(cfd.state.key);
 
     let popoverBody = <>
         <Text>


### PR DESCRIPTION
fixes https://github.com/itchysats/itchysats/issues/1305

At some point we only allowed close if lock is confirmed.
That is an unnecessary restriction, as we can chain transactions together and close with lock being unconfirmed.
With the recent change of only displaying `Open` (no `Pending Open`) the behaviour of not being able to click the close button became confusing.
Thus, we allow closing right after the setup finished.

Note: We don't *have* to merge this one but we can.
I tested it locally by closing a position where lock was not confirmed yet and it worked.