### PR TITLE
Allow to easily enable bitmex logs

### DIFF
--- a/daemon/src/bitmex_price_feed.rs
+++ b/daemon/src/bitmex_price_feed.rs
@@ -67,6 +67,7 @@ impl xtra::Actor for Actor {
 
                                     match quote {
                                         Some(quote) => {
+                                            tracing::debug!("Received new quote: {:?}", quote);
                                             let is_our_address_disconnected = this.send(NewQuoteReceived(quote)).await.is_err();
 
                                             // Our task should already be dead and the actor restarted if this happens.


### PR DESCRIPTION
To see more logs for bitmex: 

```
 RUST_LOG="daemon::bitmex_price_feed=trace"
```

