### PR TITLE
A rollover being accepted is not `ContractSetup`

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -431,7 +431,7 @@ impl Cfd {
                 }
             },
             RolloverAccepted => {
-                self.state = CfdState::ContractSetup;
+                self.state = CfdState::Open;
             }
         };
 


### PR DESCRIPTION
While on an abstract level this is not incorrect, displaying `ContractSetup` after a rollover was accepted is super confusing in the UI.
Recently we said we should just treat all of rollover as `Open`, so that's what we do now.