### PR TITLE
Don't force close if collaborative settlement fails

### DIFF
--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -309,10 +309,7 @@ pub enum CfdEvent {
         script: Script,
         price: Price,
     },
-    CollaborativeSettlementRejected {
-        #[serde(with = "hex_transaction")]
-        commit_tx: Transaction,
-    },
+    CollaborativeSettlementRejected,
     // TODO: We can distinguish different "failed" scenarios and potentially decide to publish the
     // commit transaction for some
     CollaborativeSettlementFailed,
@@ -947,7 +944,7 @@ impl Cfd {
     }
 
     pub fn settle_collaboratively(
-        mut self,
+        self,
         settlement: CollaborativeSettlementCompleted,
     ) -> Result<Event> {
         if !self.can_settle_collaboratively() {
@@ -964,15 +961,8 @@ impl Cfd {
                 price: settlement.price,
             },
             Completed::Rejected { reason, .. } => {
-                tracing::info!(order_id=%self.id(), "Collaborative close rejected: {:#}, force-closing the position", reason);
-
-                let dlc = self
-                    .dlc
-                    .take()
-                    .context("No dlc after collaborative settlement rejected")?;
-                let commit_tx = dlc.signed_commit_tx()?;
-
-                CfdEvent::CollaborativeSettlementRejected { commit_tx }
+                tracing::info!(order_id=%self.id(), "Collaborative close rejected: {:#}", reason);
+                CfdEvent::CollaborativeSettlementRejected
             }
             Completed::Failed { error, .. } => {
                 tracing::warn!(order_id=%self.id(), "Collaborative close failed: {:#}", error);
@@ -1218,11 +1208,7 @@ impl Cfd {
                 self.settlement_proposal = None;
                 self.collaborative_settlement_spend_tx = Some(spend_tx);
             }
-            CollaborativeSettlementRejected { commit_tx } => {
-                self.settlement_proposal = None;
-                self.commit_tx = Some(commit_tx);
-            }
-            CollaborativeSettlementFailed => {
+            CollaborativeSettlementRejected | CollaborativeSettlementFailed => {
                 self.settlement_proposal = None;
             }
             CetConfirmed => self.cet_finality = true,

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -263,8 +263,7 @@ impl Cfd {
                 cet: Some(cet),
                 ..self
             },
-            CollaborativeSettlementRejected { commit_tx }
-            | CollaborativeSettlementFailed { commit_tx } => Self {
+            CollaborativeSettlementRejected { commit_tx } => Self {
                 commit_tx: Some(commit_tx),
                 ..self
             },
@@ -274,6 +273,7 @@ impl Cfd {
             | ManualCommit { .. }
             | OracleAttestedPriorCetTimelock { .. }
             | CollaborativeSettlementStarted { .. }
+            | CollaborativeSettlementFailed
             | CollaborativeSettlementProposalAccepted => self,
             RevokeConfirmed => {
                 tracing::error!("Revoked logic not implemented");

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -263,16 +263,13 @@ impl Cfd {
                 cet: Some(cet),
                 ..self
             },
-            CollaborativeSettlementRejected { commit_tx } => Self {
-                commit_tx: Some(commit_tx),
-                ..self
-            },
             RolloverStarted { .. }
             | RolloverAccepted
             | RolloverFailed
             | ManualCommit { .. }
             | OracleAttestedPriorCetTimelock { .. }
             | CollaborativeSettlementStarted { .. }
+            | CollaborativeSettlementRejected
             | CollaborativeSettlementFailed
             | CollaborativeSettlementProposalAccepted => self,
             RevokeConfirmed => {

--- a/daemon/src/process_manager.rs
+++ b/daemon/src/process_manager.rs
@@ -130,17 +130,6 @@ impl Actor {
                         .await?;
                 }
             }
-            CollaborativeSettlementFailed { commit_tx } => {
-                // The maker does not have an incentive to publish commit if collab settlement fails
-                if self.role == Role::Taker {
-                    self.try_broadcast_transaction
-                        .send_async_safe(monitor::TryBroadcastTransaction {
-                            tx: commit_tx,
-                            kind: TransactionKind::Commit,
-                        })
-                        .await?;
-                }
-            }
             OracleAttestedPostCetTimelock { cet, .. }
             | CetTimelockExpiredPostOracleAttestation { cet } => {
                 self.try_broadcast_transaction
@@ -209,6 +198,7 @@ impl Actor {
             | CetConfirmed
             | RevokeConfirmed
             | CollaborativeSettlementConfirmed
+            | CollaborativeSettlementFailed
             | CetTimelockExpiredPriorOracleAttestation => {}
         }
 

--- a/daemon/src/process_manager.rs
+++ b/daemon/src/process_manager.rs
@@ -118,18 +118,6 @@ impl Actor {
                     })
                     .await?;
             }
-            CollaborativeSettlementRejected { commit_tx } => {
-                // The maker does not have an incentive to publish commit if collab settlement is
-                // rejected
-                if self.role == Role::Taker {
-                    self.try_broadcast_transaction
-                        .send_async_safe(monitor::TryBroadcastTransaction {
-                            tx: commit_tx,
-                            kind: TransactionKind::Commit,
-                        })
-                        .await?;
-                }
-            }
             OracleAttestedPostCetTimelock { cet, .. }
             | CetTimelockExpiredPostOracleAttestation { cet } => {
                 self.try_broadcast_transaction
@@ -198,6 +186,7 @@ impl Actor {
             | CetConfirmed
             | RevokeConfirmed
             | CollaborativeSettlementConfirmed
+            | CollaborativeSettlementRejected
             | CollaborativeSettlementFailed
             | CetTimelockExpiredPriorOracleAttestation => {}
         }


### PR DESCRIPTION
There are multiple different ways how collaborative settlement can fail at the moment, and we don't distinguish between "cannot do it atm" and "it failed in a bad way we should force close".
Since the different error scenarios require some more design work, we remove force closing on a failed collaborative settlement for now.
The only side effect that this can have is, that the taker runs into a failure, but the maker still publishes the collab close transaction, which will only eventually be picked up by the taker.
This behavior is totally acceptable and way better than randomly running into a force close because of e.g. and ongoing rollover or a collab settlement already in progress for the cfd.