### PR TITLE
Re-write supervisor pattern to work with `xtra::Actor::Stop`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "xtra"
 version = "0.6.0"
-source = "git+https://github.com/comit-network/xtra#b90ffec9c1b27fea1210379cb4a0df3f7f0c77e1"
+source = "git+https://github.com/comit-network/xtra#95508e6a39a96721f7ca292a075ac7200b755a2e"
 dependencies = [
  "async-trait",
  "barrage",

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -175,7 +175,9 @@ impl Maker {
         tasks.add(wallet_fut);
 
         let (price_feed_addr, price_feed_fut) = price_feed.create(None).run();
-        tasks.add(price_feed_fut);
+        tasks.add(async move {
+            let _ = price_feed_fut.await;
+        });
 
         let settlement_interval = SETTLEMENT_INTERVAL;
 
@@ -289,7 +291,7 @@ impl Taker {
 
                 Ok(monitor)
             },
-            move |_| price_feed.clone(),
+            move || price_feed.clone(),
             config.n_payouts,
             config.heartbeat_interval,
             Duration::from_secs(10),

--- a/daemon-tests/src/mocks/monitor.rs
+++ b/daemon-tests/src/mocks/monitor.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use daemon::command;
 use daemon::model::cfd::OrderId;
 use daemon::monitor;
@@ -24,7 +25,12 @@ impl MonitorActor {
     }
 }
 
-impl xtra::Actor for MonitorActor {}
+#[async_trait]
+impl xtra::Actor for MonitorActor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
 
 #[xtra_productivity(message_impl = false)]
 impl MonitorActor {

--- a/daemon-tests/src/mocks/oracle.rs
+++ b/daemon-tests/src/mocks/oracle.rs
@@ -1,4 +1,5 @@
 use crate::maia::OliviaData;
+use async_trait::async_trait;
 use daemon::model::BitMexPriceEventId;
 use daemon::oracle;
 use mockall::*;
@@ -22,7 +23,12 @@ impl OracleActor {
     }
 }
 
-impl xtra::Actor for OracleActor {}
+#[async_trait]
+impl xtra::Actor for OracleActor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
 impl Oracle for OracleActor {}
 
 #[xtra_productivity(message_impl = false)]

--- a/daemon-tests/src/mocks/price_feed.rs
+++ b/daemon-tests/src/mocks/price_feed.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use daemon::bitmex_price_feed;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -17,7 +18,14 @@ impl PriceFeedActor {
     }
 }
 
-impl xtra::Actor for PriceFeedActor {}
+#[async_trait]
+impl xtra::Actor for PriceFeedActor {
+    type Stop = bitmex_price_feed::Error;
+
+    async fn stopped(self) -> Self::Stop {
+        bitmex_price_feed::Error::Unspecified
+    }
+}
 
 #[xtra_productivity(message_impl = false)]
 impl PriceFeedActor {

--- a/daemon-tests/src/mocks/wallet.rs
+++ b/daemon-tests/src/mocks/wallet.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use daemon::bdk;
 use daemon::bdk::bitcoin::ecdsa;
 use daemon::bdk::bitcoin::util::psbt::PartiallySignedTransaction;
@@ -35,7 +36,12 @@ impl WalletActor {
     }
 }
 
-impl xtra::Actor for WalletActor {}
+#[async_trait]
+impl xtra::Actor for WalletActor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
 
 #[xtra_productivity(message_impl = false)]
 impl WalletActor {

--- a/daemon/src/auto_rollover.rs
+++ b/daemon/src/auto_rollover.rs
@@ -143,14 +143,17 @@ where
 #[async_trait]
 impl<O> xtra::Actor for Actor<O>
 where
-    O: 'static,
-    Self: xtra::Handler<AutoRollover>,
+    O: xtra::Handler<oracle::GetAnnouncement> + 'static,
 {
+    type Stop = ();
+
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("we are alive");
         self.tasks
             .add(this.send_interval(Duration::from_secs(5 * 60), || AutoRollover));
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }
 
 /// Message sent to ourselves at an interval to check if rollover can

--- a/daemon/src/collab_settlement_maker.rs
+++ b/daemon/src/collab_settlement_maker.rs
@@ -80,6 +80,7 @@ impl Actor {
 
 #[async_trait]
 impl xtra::Actor for Actor {
+    type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let order_id = self.proposal.order_id;
 
@@ -107,6 +108,8 @@ impl xtra::Actor for Actor {
 
         xtra::KeepRunning::StopAll
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }
 
 impl Actor {

--- a/daemon/src/collab_settlement_taker.rs
+++ b/daemon/src/collab_settlement_taker.rs
@@ -155,6 +155,7 @@ impl Actor {
 
 #[async_trait]
 impl xtra::Actor for Actor {
+    type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("get address to ourselves");
 
@@ -192,6 +193,8 @@ impl xtra::Actor for Actor {
 
         xtra::KeepRunning::StopAll
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }
 
 #[xtra_productivity]

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -17,6 +17,7 @@ use crate::Tasks;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use async_trait::async_trait;
 use bdk::bitcoin::Amount;
 use futures::SinkExt;
 use futures::StreamExt;
@@ -569,7 +570,12 @@ impl Actor {
     }
 }
 
-impl xtra::Actor for Actor {}
+#[async_trait]
+impl xtra::Actor for Actor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
 
 // TODO: Move the reconnection logic inside the connection::Actor instead of
 // depending on a watch channel

--- a/daemon/src/fan_out.rs
+++ b/daemon/src/fan_out.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use xtra::prelude::MessageChannel;
 
 /// A fan-out actor takes every incoming message and forwards it to a set of other actors.
@@ -13,7 +14,15 @@ impl<M: xtra::Message<Result = ()>> Actor<M> {
     }
 }
 
-impl<M> xtra::Actor for Actor<M> where M: xtra::Message<Result = ()> {}
+#[async_trait]
+impl<M> xtra::Actor for Actor<M>
+where
+    M: xtra::Message<Result = ()>,
+{
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
 
 #[async_trait::async_trait]
 impl<M> xtra::Handler<M> for Actor<M>

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -721,4 +721,9 @@ impl Message for FromTaker {
     type Result = ();
 }
 
-impl<O: 'static, T: 'static, W: 'static> xtra::Actor for Actor<O, T, W> {}
+#[async_trait]
+impl<O: 'static, T: 'static, W: 'static> xtra::Actor for Actor<O, T, W> {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}

--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -535,7 +535,10 @@ struct ListenerFailed {
 
 #[async_trait]
 impl xtra::Actor for Actor {
+    type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         self.start_listener(ctx).await;
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -793,6 +793,7 @@ impl xtra::Message for Sync {
 
 #[async_trait]
 impl xtra::Actor for Actor {
+    type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("we are alive");
         self.tasks
@@ -910,6 +911,8 @@ impl xtra::Actor for Actor {
             },
         );
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }
 
 #[xtra_productivity]

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -305,6 +305,7 @@ impl From<Announcement> for maia::Announcement {
 
 #[async_trait]
 impl xtra::Actor for Actor {
+    type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("we are alive");
         self.tasks.add(
@@ -342,6 +343,8 @@ impl xtra::Actor for Actor {
             },
         );
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }
 
 impl xtra::Message for Attestation {

--- a/daemon/src/process_manager.rs
+++ b/daemon/src/process_manager.rs
@@ -8,6 +8,7 @@ use crate::monitor::TransactionKind;
 use crate::oracle;
 use crate::projection;
 use anyhow::Result;
+use async_trait::async_trait;
 use xtra::prelude::MessageChannel;
 use xtra_productivity::xtra_productivity;
 use xtras::SendAsyncSafe;
@@ -201,4 +202,9 @@ impl Actor {
     }
 }
 
-impl xtra::Actor for Actor {}
+#[async_trait]
+impl xtra::Actor for Actor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -731,6 +731,7 @@ impl Actor {
 
 #[async_trait]
 impl xtra::Actor for Actor {
+    type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("we just started");
         let pool = self.db.clone();
@@ -774,6 +775,8 @@ impl xtra::Actor for Actor {
             }
         })
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/daemon/src/rollover_maker.rs
+++ b/daemon/src/rollover_maker.rs
@@ -230,6 +230,7 @@ impl Actor {
 
 #[async_trait::async_trait]
 impl xtra::Actor for Actor {
+    type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let order_id = self.order_id;
 
@@ -278,6 +279,8 @@ impl xtra::Actor for Actor {
 
         KeepRunning::StopAll
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }
 
 #[xtra_productivity]

--- a/daemon/src/rollover_taker.rs
+++ b/daemon/src/rollover_taker.rs
@@ -186,6 +186,7 @@ impl Actor {
 
 #[async_trait]
 impl xtra::Actor for Actor {
+    type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("self to be alive");
 
@@ -229,6 +230,8 @@ impl xtra::Actor for Actor {
 
         xtra::KeepRunning::StopAll
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }
 
 #[xtra_productivity]

--- a/daemon/src/setup_maker.rs
+++ b/daemon/src/setup_maker.rs
@@ -230,6 +230,7 @@ impl Actor {
 
 #[async_trait]
 impl xtra::Actor for Actor {
+    type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let quantity = self.quantity;
         if quantity < self.order.min_quantity || quantity > self.order.max_quantity {
@@ -267,6 +268,8 @@ impl xtra::Actor for Actor {
 
         xtra::KeepRunning::StopAll
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }
 
 /// Message sent from the `maker_cfd::Actor` to the

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -212,6 +212,7 @@ impl Actor {
 
 #[async_trait]
 impl xtra::Actor for Actor {
+    type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let address = ctx
             .address()
@@ -246,6 +247,8 @@ impl xtra::Actor for Actor {
 
         self.tasks.add(maker_response_timeout);
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }
 
 /// Message sent from the `connection::Actor` to the

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -19,6 +19,7 @@ use crate::wallet;
 use crate::Tasks;
 use anyhow::Context as _;
 use anyhow::Result;
+use async_trait::async_trait;
 use bdk::bitcoin::secp256k1::schnorrsig;
 use xtra::prelude::*;
 use xtra::Actor as _;
@@ -224,4 +225,9 @@ where
     }
 }
 
-impl<O: 'static, W: 'static> xtra::Actor for Actor<O, W> {}
+#[async_trait]
+impl<O: 'static, W: 'static> xtra::Actor for Actor<O, W> {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -190,12 +190,15 @@ impl Actor {
 
 #[async_trait]
 impl xtra::Actor for Actor {
+    type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("self to be alive");
 
         self.tasks
             .add(this.send_interval(Duration::from_secs(10), || Sync));
     }
+
+    async fn stopped(self) -> Self::Stop {}
 }
 
 pub struct BuildPartyParams {

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -266,7 +266,7 @@ async fn main() -> Result<()> {
                 monitor::Actor::new(db.clone(), electrum, executor)
             }
         },
-        bitmex_price_feed::Actor::new,
+        bitmex_price_feed::Actor::default,
         N_PAYOUTS,
         HEARTBEAT_INTERVAL,
         Duration::from_secs(10),

--- a/xtras/src/actor_name.rs
+++ b/xtras/src/actor_name.rs
@@ -35,5 +35,10 @@ mod tests {
 
     struct Dummy;
 
-    impl xtra::Actor for Dummy {}
+    #[async_trait::async_trait]
+    impl xtra::Actor for Dummy {
+        type Stop = ();
+
+        async fn stopped(self) -> Self::Stop {}
+    }
 }

--- a/xtras/src/address_map.rs
+++ b/xtras/src/address_map.rs
@@ -153,5 +153,10 @@ mod tests {
 
     struct Dummy;
 
-    impl xtra::Actor for Dummy {}
+    #[async_trait::async_trait]
+    impl xtra::Actor for Dummy {
+        type Stop = ();
+
+        async fn stopped(self) -> Self::Stop {}
+    }
 }


### PR DESCRIPTION
With this patch, we are adopting a proposed patch of xtra that
allows actors to return a value from `stopped`. We utilize this
communicate the reason why an actor stopped back to the supervisor.

This has multiple benefits:

a) We no longer need the supervisor's address within the supervised actor.
b) It is impossible to "forget" to report the stop reason to the supervisor.
c) It allows us to easily supervise ANY actor because they no longer
need to have "knowledge" of the `supervisor` module.

The fork of xtra that we are bumping in this patch also contains another
patch that is of interest to the supervisor pattern: We change the default
of `Actor::stopping` to `KeepRunning::StopSelf` which makes our supervisor
pattern work in the first place.