### PR TITLE
Instrument log with taker_id

### DIFF
--- a/daemon/src/collab_settlement_maker.rs
+++ b/daemon/src/collab_settlement_maker.rs
@@ -84,6 +84,7 @@ impl xtra::Actor for Actor {
         let order_id = self.proposal.order_id;
 
         tracing::info!(
+            taker_id = %self.taker_id,
             %order_id,
             price = %self.proposal.price,
             "Received settlement proposal"

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -194,7 +194,7 @@ where
         taker_id: Identity,
         ctx: &mut xtra::Context<Self>,
     ) -> Result<()> {
-        tracing::info!(%order_id, %taker_id,  "Received proposal from taker");
+        tracing::info!(%order_id, %taker_id,  "Received rollover proposal from taker");
         let this = ctx.address().expect("acquired own address");
 
         let (rollover_actor_addr, rollover_actor_future) = rollover_maker::Actor::new(

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -194,7 +194,7 @@ where
         taker_id: Identity,
         ctx: &mut xtra::Context<Self>,
     ) -> Result<()> {
-        tracing::info!(%order_id, "Received proposal from taker {taker_id}");
+        tracing::info!(%order_id, %taker_id,  "Received proposal from taker");
         let this = ctx.address().expect("acquired own address");
 
         let (rollover_actor_addr, rollover_actor_future) = rollover_maker::Actor::new(

--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -345,7 +345,8 @@ impl Actor {
 
         if self.connections.contains_key(&identity) {
             tracing::warn!(
-                "Refusing to accept 2nd connection from already connected taker {identity}!"
+                taker_id = %identity,
+                "Refusing to accept 2nd connection from already connected taker!"
             );
             return;
         }


### PR DESCRIPTION
This allows for easier log analysis

Would be nice to backport this to 0.4.x so that we get better logs for the maker