### PR TITLE
Define more restrictively what it means that a cfd is closed

### DIFF
--- a/daemon/src/model/cfd.rs
+++ b/daemon/src/model/cfd.rs
@@ -651,8 +651,6 @@ impl Cfd {
 
     fn can_settle_collaboratively(&self) -> bool {
         !self.commit_finality && !self.is_final() && !self.is_attested()
-            // Rollover and collaborative settlement are mutually exclusive, if we are currently rolling over we cannot settle
-            && !self.during_rollover
     }
 
     fn is_attested(&self) -> bool {


### PR DESCRIPTION
Fixes https://github.com/itchysats/itchysats/issues/1355

Previously we mostly used `is_final` as a guard, but it can take significant time until e.g. a collab close transaction gets confirmed which leads to other logic being triggered that is actually not possible anymore.
After a collab close transaction was published, other spend transactions will fail when publishing them, but since we don't handle errors in post-processing additional events will be appended so the `Cfd` was seemingly force-close even though it was already collaboratively closed.

---

Note that there are some other issues attached to this problem:

- We don't deal with in-mempool which is an old problem: #206 - this only changes the problem but not solves it. Instead of asserting that we *have* a transaction available (and assume that is was/will be published) we could assert on finding it in mempool.
- We are not dealing with post-processing failures. Effectively e.g. non-collab settlement *cannot* happen once the collab settlement tx is publsihed, but we store the event nontheless and then the post processing fails. Same for rollover (where the problem becomes visible in the UI more clearly, that's why we added this condition: #1315 )