### PR TITLE
Add project automation

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,16 @@
+name: Project automation
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add_issue_to_project:
+    name: Add new issues to project board
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh api graphql -f query='mutation($project:ID!, $issue:ID!) { addProjectNextItem(input: {projectId: $project, contentId: $issue}) { projectNextItem { id }  } }' -f project=${{ secrets.PROJECT_BOARD_ID }} -f issue=${{ github.event.issue.node_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.ITCHY_PROJECT_AUTOMATION_TOKEN }}


### PR DESCRIPTION
GitHub's new project boards are cool but they require new issues to be
added manually. This is being fixed [0]. Until then, use this automation
to make things less tedious.

[0]: https://github.com/github/roadmap/issues/286