### PR TITLE
Trigger CET finality monitoring using process manager

### DIFF
--- a/daemon-tests/src/mocks/monitor.rs
+++ b/daemon-tests/src/mocks/monitor.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use daemon::command;
 use daemon::monitor;
-use daemon::oracle;
 use model::cfd::OrderId;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -40,9 +39,11 @@ impl MonitorActor {
 
     async fn handle(&mut self, _: monitor::CollaborativeSettlement) {}
 
-    async fn handle(&mut self, _: oracle::Attestation) {}
-
     async fn handle(&mut self, _: monitor::TryBroadcastTransaction) -> Result<()> {
+        Ok(())
+    }
+
+    async fn handle(&mut self, _: monitor::MonitorCetFinality) -> Result<()> {
         Ok(())
     }
 }

--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -2,7 +2,6 @@ use daemon::bdk::bitcoin::Amount;
 use daemon::connection::ConnectionStatus;
 use daemon::projection::CfdOrder;
 use daemon::projection::CfdState;
-use daemon_tests::deliver_event;
 use daemon_tests::dummy_new_order;
 use daemon_tests::dummy_quote;
 use daemon_tests::flow::is_next_none;
@@ -13,6 +12,7 @@ use daemon_tests::flow::one_cfd_with_state;
 use daemon_tests::init_tracing;
 use daemon_tests::maia::OliviaData;
 use daemon_tests::mocks::oracle::dummy_wrong_attestation;
+use daemon_tests::simulate_attestation;
 use daemon_tests::start_both;
 use daemon_tests::wait_next_state;
 use daemon_tests::Maker;
@@ -196,9 +196,6 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
     maker.mocks.mock_party_params().await;
     taker.mocks.mock_party_params().await;
 
-    maker.mocks.mock_oracle_monitor_attestation().await;
-    taker.mocks.mock_oracle_monitor_attestation().await;
-
     maker.mocks.mock_wallet_sign_and_broadcast().await;
     taker.mocks.mock_wallet_sign_and_broadcast().await;
 
@@ -262,12 +259,14 @@ async fn force_close_an_open_cfd() {
     expire!(cet timelock, order_id, maker, taker);
 
     // Delivering the wrong attestation does not move state to `PendingCet`
-    deliver_event!(maker, taker, dummy_wrong_attestation());
+    simulate_attestation!(taker, maker, order_id, dummy_wrong_attestation());
+
     sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
 
     // Delivering correct attestation moves the state `PendingCet`
-    deliver_event!(maker, taker, oracle_data.attestation());
+    simulate_attestation!(taker, maker, order_id, oracle_data.attestation());
+
     sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     wait_next_state!(order_id, maker, taker, CfdState::PendingCet);
 
@@ -435,9 +434,6 @@ async fn start_from_open_cfd_state(announcement: olivia::Announcement) -> (Maker
 
     maker.mocks.mock_party_params().await;
     taker.mocks.mock_party_params().await;
-
-    maker.mocks.mock_oracle_monitor_attestation().await;
-    taker.mocks.mock_oracle_monitor_attestation().await;
 
     maker.mocks.mock_wallet_sign_and_broadcast().await;
     taker.mocks.mock_wallet_sign_and_broadcast().await;

--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -1,15 +1,10 @@
 use crate::db;
-use crate::olivia;
-use crate::process_manager;
 use crate::projection;
-use crate::try_continue;
-use anyhow::Context;
 use anyhow::Result;
 use model::cfd::Cfd;
 use model::cfd::OrderId;
 use sqlx::pool::PoolConnection;
 use sqlx::Sqlite;
-use sqlx::SqlitePool;
 
 pub async fn insert_cfd_and_update_feed(
     cfd: &Cfd,
@@ -56,34 +51,4 @@ pub async fn load_cfd(order_id: OrderId, conn: &mut PoolConnection<Sqlite>) -> R
         events,
     );
     Ok(cfd)
-}
-
-pub async fn handle_oracle_attestation(
-    attestation: &olivia::Attestation,
-    db: &SqlitePool,
-    process_manager: &xtra::Address<process_manager::Actor>,
-) -> Result<()> {
-    let mut conn = db.acquire().await?;
-    let price_event_id = attestation.id;
-
-    tracing::debug!("Learnt latest oracle attestation for event: {price_event_id}");
-
-    for id in db::load_all_cfd_ids(&mut conn).await? {
-        let cfd = try_continue!(load_cfd(id, &mut conn).await);
-        let event = try_continue!(cfd
-            .decrypt_cet(attestation)
-            .context("Failed to decrypt CET using attestation"));
-
-        if let Some(event) = event {
-            // Note: ? OK, because if the actor is disconnected we can fail the loop
-            if let Err(e) = process_manager
-                .send(process_manager::Event::new(event.clone()))
-                .await?
-            {
-                tracing::error!("Sending event to process manager failed: {:#}", e);
-            }
-        }
-    }
-
-    Ok(())
 }

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -1,4 +1,3 @@
-use crate::cfd_actors;
 use crate::cfd_actors::insert_cfd_and_update_feed;
 use crate::collab_settlement_maker;
 use crate::command;
@@ -490,15 +489,6 @@ impl<O, T, W> Actor<O, T, W> {
         message: Stopping<collab_settlement_maker::Actor>,
     ) {
         self.settlement_actors.gc(message);
-    }
-
-    async fn handle_attestation(&mut self, msg: oracle::Attestation) {
-        if let Err(e) =
-            cfd_actors::handle_oracle_attestation(msg.as_inner(), &self.db, &self.process_manager)
-                .await
-        {
-            tracing::warn!("Failed to handle oracle attestation: {:#}", e)
-        }
     }
 
     async fn handle_rollover_actor_stopping(&mut self, msg: Stopping<rollover_maker::Actor>) {

--- a/daemon/src/process_manager.rs
+++ b/daemon/src/process_manager.rs
@@ -103,11 +103,11 @@ impl Actor {
                 match self.role {
                     Role::Maker => {
                         self.try_broadcast_transaction
-                            .send(monitor::TryBroadcastTransaction {
+                            .send_async_safe(monitor::TryBroadcastTransaction {
                                 tx: spend_tx,
                                 kind: TransactionKind::CollaborativeClose,
                             })
-                            .await??;
+                            .await?;
                     }
                     Role::Taker => {
                         // TODO: Publish the tx once the collaborative settlement is symmetric,

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -1,4 +1,3 @@
-use crate::cfd_actors;
 use crate::cfd_actors::insert_cfd_and_update_feed;
 use crate::collab_settlement_taker;
 use crate::connection;
@@ -139,21 +138,6 @@ impl<O, W> Actor<O, W> {
         disconnected.insert(addr);
 
         Ok(())
-    }
-}
-
-#[xtra_productivity(message_impl = false)]
-impl<O, W> Actor<O, W> {
-    async fn handle_attestation(&mut self, msg: oracle::Attestation) {
-        if let Err(e) = cfd_actors::handle_oracle_attestation(
-            msg.as_inner(),
-            &self.db,
-            &self.process_manager_actor,
-        )
-        .await
-        {
-            tracing::warn!("Failed to handle oracle attestation: {:#}", e)
-        }
     }
 }
 

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -218,7 +218,7 @@ async fn main() -> Result<()> {
         db.clone(),
         wallet.clone(),
         *olivia::PUBLIC_KEY,
-        |channel| oracle::Actor::new(db.clone(), channel, SETTLEMENT_INTERVAL),
+        |executor| oracle::Actor::new(db.clone(), executor, SETTLEMENT_INTERVAL),
         {
             |executor| {
                 let electrum = opts.network.electrum().to_string();

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -252,7 +252,7 @@ async fn main() -> Result<()> {
         wallet.clone(),
         *olivia::PUBLIC_KEY,
         identity_sk,
-        |channel| oracle::Actor::new(db.clone(), channel, SETTLEMENT_INTERVAL),
+        |executor| oracle::Actor::new(db.clone(), executor, SETTLEMENT_INTERVAL),
         {
             |executor| {
                 let electrum = opts.network.electrum().to_string();


### PR DESCRIPTION
We can trigger CET finality monitoring in the process manager when the oracle attestation events occur. This removes the need for a channel between oracle and monitor actor.

NOTE: Will probably squash all commits! Probably not worth reviewing it commit by commit as rebase may of messed things up.