### PR TITLE
Add timeout on sending TCP packets from taker

### DIFF
--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -355,7 +355,10 @@ impl Actor {
         };
 
         let our_version = Version::current();
-        write.send(TakerToMaker::Hello(our_version.clone())).await?;
+        write
+            .send(TakerToMaker::Hello(our_version.clone()))
+            .timeout(Duration::from_secs(10))
+            .await??;
 
         match read
             .try_next()


### PR DESCRIPTION
An attempt at mitigating production issue where the connection message
handler got stuck for a prolonged period of time.

Unfortunately, it's not easy to cover it with unit tests so the fix could not be
verified.

Partially fixes #1401 