### PR TITLE
Add missing timeout to noise initiator handshake

### DIFF
--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -1,5 +1,6 @@
 use daemon::bdk::bitcoin::Amount;
 use daemon::connection::ConnectionStatus;
+use daemon::connection::MAX_RECONNECT_INTERVAL_SECONDS;
 use daemon::projection::CfdOrder;
 use daemon::projection::CfdState;
 use daemon_tests::deliver_event;
@@ -375,7 +376,8 @@ async fn taker_notices_lack_of_maker() {
 
     let _maker = Maker::start(&maker_config).await;
 
-    sleep(taker_config.heartbeat_interval).await;
+    sleep(Duration::from_secs(MAX_RECONNECT_INTERVAL_SECONDS) + taker_config.heartbeat_interval)
+        .await;
 
     assert_eq!(
         ConnectionStatus::Online,

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -42,6 +42,8 @@ use xtras::SendInterval;
 /// Time between reconnection attempts
 pub const MAX_RECONNECT_INTERVAL_SECONDS: u64 = 60;
 
+const TCP_TIMEOUT: std::time::Duration = Duration::from_secs(10);
+
 /// The "Connected" state of our connection with the maker.
 #[allow(clippy::large_enum_variant)]
 enum State {
@@ -351,7 +353,7 @@ impl Actor {
                 &self.identity_sk,
                 &maker_identity.pk(),
             )
-            .timeout(Duration::from_secs(10))
+            .timeout(TCP_TIMEOUT)
             .await??;
 
             Framed::new(connection, EncryptedJsonCodec::new(noise)).split()
@@ -360,12 +362,12 @@ impl Actor {
         let our_version = Version::current();
         write
             .send(TakerToMaker::Hello(our_version.clone()))
-            .timeout(Duration::from_secs(10))
+            .timeout(TCP_TIMEOUT)
             .await??;
 
         match read
             .try_next()
-            .timeout(Duration::from_secs(10))
+            .timeout(TCP_TIMEOUT)
             .await
             .with_context(|| {
                 format!(

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -351,7 +351,8 @@ impl Actor {
                 &self.identity_sk,
                 &maker_identity.pk(),
             )
-            .await?;
+            .timeout(Duration::from_secs(10))
+            .await??;
 
             Framed::new(connection, EncryptedJsonCodec::new(noise)).split()
         };

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -21,6 +21,8 @@ use model::Identity;
 use model::Price;
 use model::Timestamp;
 use model::Usd;
+use rand::thread_rng;
+use rand::Rng;
 use std::net::SocketAddr;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -38,7 +40,7 @@ use xtras::LogFailure;
 use xtras::SendInterval;
 
 /// Time between reconnection attempts
-const CONNECT_TO_MAKER_INTERVAL: Duration = Duration::from_secs(5);
+pub const MAX_RECONNECT_INTERVAL_SECONDS: u64 = 60;
 
 /// The "Connected" state of our connection with the maker.
 #[allow(clippy::large_enum_variant)]
@@ -611,13 +613,16 @@ pub async fn connect(
                 }
 
                 let num_addresses = maker_addresses.len();
-                let seconds = CONNECT_TO_MAKER_INTERVAL.as_secs();
+
+                // Apply a random number of seconds between the reconnection
+                // attempts so that all takers don't try to reconnect at the same time
+                let seconds = thread_rng().gen_range(5, MAX_RECONNECT_INTERVAL_SECONDS);
 
                 tracing::warn!(
                     "Tried connecting to {num_addresses} addresses without success, retrying in {seconds} seconds",
                 );
 
-                tokio::time::sleep(CONNECT_TO_MAKER_INTERVAL).await;
+                tokio::time::sleep(Duration::from_secs(seconds)).await;
             }
         }
         maker_online_status_feed_receiver


### PR DESCRIPTION
Fixes #1401. Will need to be backported to `0.4.3`.