### PR TITLE
Display Cfd tiles in reverse chronoligical order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "cached",
  "futures",
  "hkdf",
+ "itertools",
  "maia",
  "model",
  "parse-display",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -12,6 +12,7 @@ bytes = "1"
 cached = { version = "0.30.0", default-features = false, features = ["proc_macro"] }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hkdf = "0.12"
+itertools = "0.10"
 maia = "0.1.0"
 model = { path = "../model" }
 parse-display = "0.5.3"

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -488,7 +488,9 @@ pub struct WalletInfo {
     pub last_updated_at: Timestamp,
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, sqlx::Type)]
+#[derive(
+    Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, sqlx::Type,
+)]
 #[sqlx(transparent)]
 pub struct Timestamp(i64);
 


### PR DESCRIPTION
Confirmed that the Cfd tiles are displayed in a random order on master.

Tested PR by creating bunch of orders on a local taker/maker and checking they were in reverse chronological order after multiple restarts

Close #1328 