### PR TITLE
Exclude final CFDs from processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,7 +1557,7 @@ dependencies = [
 [[package]]
 name = "maia"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/maia#3d133700f576925cc6086797d36f6322e5901cf8"
+source = "git+https://github.com/comit-network/maia#cf0df283e494a3452398dc62ca6c6df47963a329"
 dependencies = [
  "anyhow",
  "bdk",

--- a/daemon/sqlx-data.json
+++ b/daemon/sqlx-data.json
@@ -108,6 +108,30 @@
       ]
     }
   },
+  "93c7f10cbb553b0191d00f20320bb561936281bcfb1a6c63d655c1bb76aacea0": {
+    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: model::cfd::OrderId\"\n            from\n                cfds\n            where not exists (\n                select id from EVENTS as events\n                where cfd_id = cfds.id and\n                (\n                    events.name = $1 or\n                    events.name = $2 or\n                    events.name= $3 or\n                    events.name= $4 or\n                    events.name= $5\n                )\n            )\n            order by cfd_id desc\n            ",
+    "describe": {
+      "columns": [
+        {
+          "name": "cfd_id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "uuid: model::cfd::OrderId",
+          "ordinal": 1,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 5
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
   "b15ee697209deb50569172bbf4a67bde5d9936525e4937119ba88447cec52a4e": {
     "query": "\n\n        select\n            name,\n            data,\n            created_at as \"created_at: model::Timestamp\"\n        from\n            events\n        where\n            cfd_id = $1\n            ",
     "describe": {

--- a/daemon/src/auto_rollover.rs
+++ b/daemon/src/auto_rollover.rs
@@ -108,7 +108,7 @@ where
         ctx: &mut xtra::Context<Actor<O>>,
     ) -> Result<(), anyhow::Error> {
         let mut conn = self.db.acquire().await?;
-        let cfd_ids = db::load_all_cfd_ids(&mut conn).await?;
+        let cfd_ids = db::load_open_cfd_ids(&mut conn).await?;
         let this = ctx
             .address()
             .expect("actor to be able to give address to itself");

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -730,7 +730,7 @@ impl xtra::Actor for Actor {
                 async move {
                     let mut conn = db.acquire().await?;
 
-                    for id in db::load_all_cfd_ids(&mut conn).await? {
+                    for id in db::load_open_cfd_ids(&mut conn).await? {
                         let (_, events) = db::load_cfd(id, &mut conn).await?;
 
                         let Cfd {
@@ -792,7 +792,7 @@ impl xtra::Actor for Actor {
                 async move {
                     let mut conn = db.acquire().await?;
 
-                    for id in db::load_all_cfd_ids(&mut conn).await? {
+                    for id in db::load_open_cfd_ids(&mut conn).await? {
                         let (_, events) = db::load_cfd(id, &mut conn).await?;
 
                         let Cfd {

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -251,7 +251,7 @@ impl Actor {
 
         let mut conn = self.db.acquire().await?;
 
-        for id in db::load_all_cfd_ids(&mut conn).await? {
+        for id in db::load_open_cfd_ids(&mut conn).await? {
             if let Err(err) = self
                 .executor
                 .execute(id, |cfd| cfd.decrypt_cet(&attestation.0))
@@ -303,7 +303,7 @@ impl xtra::Actor for Actor {
                 async move {
                     let mut conn = db.acquire().await?;
 
-                    for id in db::load_all_cfd_ids(&mut conn).await? {
+                    for id in db::load_open_cfd_ids(&mut conn).await? {
                         let (_, events) = db::load_cfd(id, &mut conn).await?;
                         let cfd = events
                             .into_iter()


### PR DESCRIPTION
For auto-rollover and monitoring final CFDs are irrelevant and should not be processed.
We see a lot of warnings because we currently process all CFDs all the time.
This simple SQL statements reduces this problem by just not loading final CFDs for processing.
We only load all CFDs in the projection.

This change is very non-intrusive. We don't need to change anything on the model or anything else. 
I think this is a change that will help with multiple issues (warnings upon startup, long startup times, ...), processing monitoring and rollovers.

We *can* obviously decide to optimize loading CFDs as well, but I see that as a completely orthogonal thing to tackle.