### PR TITLE
Allow maker going long

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -24,6 +24,7 @@ use model::cfd::Role;
 use model::FundingRate;
 use model::Identity;
 use model::OpeningFee;
+use model::Position;
 use model::Price;
 use model::TxFeeRate;
 use model::Usd;
@@ -408,7 +409,7 @@ pub fn dummy_quote() -> Quote {
     }
 }
 
-pub fn dummy_new_order() -> maker_cfd::NewOrder {
+pub fn dummy_new_order(position: Position) -> maker_cfd::NewOrder {
     maker_cfd::NewOrder {
         price: Price::new(dummy_price()).unwrap(),
         min_quantity: Usd::new(dec!(5)),
@@ -417,6 +418,7 @@ pub fn dummy_new_order() -> maker_cfd::NewOrder {
         // 8.76% annualized = rate of 0.0876 annualized = rate of 0.00024 daily
         funding_rate: FundingRate::new(dec!(0.00024)).unwrap(),
         opening_fee: OpeningFee::new(Amount::from_sat(2)),
+        position,
     }
 }
 

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -15,6 +15,7 @@ use model::olivia;
 use model::FundingRate;
 use model::Identity;
 use model::OpeningFee;
+use model::Position;
 use model::Price;
 use model::TxFeeRate;
 use model::Usd;
@@ -168,6 +169,7 @@ where
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn new_order(
         &self,
         price: Price,
@@ -176,6 +178,7 @@ where
         fee_rate: Option<TxFeeRate>,
         funding_rate: Option<FundingRate>,
         opening_fee: Option<OpeningFee>,
+        position: Option<Position>,
     ) -> Result<()> {
         self.cfd_actor
             .send(maker_cfd::NewOrder {
@@ -185,6 +188,8 @@ where
                 tx_fee_rate: fee_rate.unwrap_or_default(),
                 funding_rate: funding_rate.unwrap_or_default(),
                 opening_fee: opening_fee.unwrap_or_default(),
+                // For backwards compatibility, default to maker going short
+                position: position.unwrap_or(Position::Short),
             })
             .await??;
 

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -69,6 +69,7 @@ pub struct NewOrder {
     pub tx_fee_rate: TxFeeRate,
     pub funding_rate: FundingRate,
     pub opening_fee: OpeningFee,
+    pub position: Position,
 }
 
 pub struct TakerConnected {
@@ -268,7 +269,7 @@ where
 
         let cfd = Cfd::from_order(
             current_order.clone(),
-            Position::Short,
+            current_order.position,
             quantity,
             taker_id,
             Role::Maker,
@@ -549,13 +550,15 @@ where
             tx_fee_rate,
             funding_rate,
             opening_fee,
+            position,
         } = msg;
 
         let oracle_event_id = oracle::next_announcement_after(
             time::OffsetDateTime::now_utc() + self.settlement_interval,
         )?;
 
-        let order = Order::new_short(
+        let order = Order::new(
+            position,
             price,
             min_quantity,
             max_quantity,

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -16,7 +16,6 @@ use model::cfd::OrderId;
 use model::cfd::Origin;
 use model::cfd::Role;
 use model::Identity;
-use model::Position;
 use model::Price;
 use model::Usd;
 use tokio_tasks::Tasks;
@@ -171,7 +170,7 @@ where
         // recorded
         let cfd = Cfd::from_order(
             current_order.clone(),
-            Position::Long,
+            current_order.position.counter_position(),
             quantity,
             self.maker_identity,
             Role::Taker,

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -13,6 +13,7 @@ use model::cfd::OrderId;
 use model::FundingRate;
 use model::Identity;
 use model::OpeningFee;
+use model::Position;
 use model::Price;
 use model::TxFeeRate;
 use model::Usd;
@@ -104,6 +105,7 @@ pub struct CfdNewOrderRequest {
     // TODO: This is not inline with other parts of the API! We should not expose internal types
     // here. We have to specify sats for here because of that.
     pub opening_fee: Option<OpeningFee>,
+    pub position: Option<Position>,
 }
 
 #[rocket::post("/order/sell", data = "<order>")]
@@ -120,6 +122,7 @@ pub async fn post_sell_order(
             order.tx_fee_rate,
             order.funding_rate,
             order.opening_fee,
+            order.position,
         )
         .await
         .map_err(|e| {


### PR DESCRIPTION
Automation / GUI should be able to create the offers going the other way from
now on.

Add tests covering most common scenarios: close, force-close,
rollover (contract setup is covered as part of each of them).

TODO: Allow simultaneous offers both ways