### PR TITLE
Taker leveraged short

### DIFF
--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -20,7 +20,7 @@ use daemon_tests::Maker;
 use daemon_tests::MakerConfig;
 use daemon_tests::Taker;
 use daemon_tests::TakerConfig;
-use model::calculate_long_margin;
+use model::calculate_margin;
 use model::olivia;
 use model::Identity;
 use model::OrderId;
@@ -132,8 +132,11 @@ async fn taker_receives_order_from_maker_on_publication() {
 
 fn assert_eq_order(mut published: CfdOrder, received: CfdOrder) {
     // align margin_per_parcel to be the long margin_per_parcel
-    let long_margin_per_parcel =
-        calculate_long_margin(published.price, published.parcel_size, published.leverage);
+    let long_margin_per_parcel = calculate_margin(
+        published.price,
+        published.parcel_size,
+        published.leverage_taker,
+    );
     published.margin_per_parcel = long_margin_per_parcel;
 
     assert_eq!(published, received);

--- a/daemon/src/cfd_actors.rs
+++ b/daemon/src/cfd_actors.rs
@@ -25,7 +25,7 @@ pub async fn load_cfd(order_id: OrderId, conn: &mut PoolConnection<Sqlite>) -> R
             id,
             position,
             initial_price,
-            leverage,
+            taker_leverage: leverage,
             settlement_interval,
             counterparty_network_identity,
             role,

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -117,7 +117,7 @@ pub async fn insert_cfd(cfd: &model::Cfd, conn: &mut PoolConnection<Sqlite>) -> 
     .bind(&cfd.id())
     .bind(&cfd.position())
     .bind(&cfd.initial_price())
-    .bind(&cfd.leverage())
+    .bind(&cfd.taker_leverage())
     .bind(&cfd.settlement_time_interval_hours().whole_hours())
     .bind(&cfd.quantity())
     .bind(&cfd.counterparty_network_identity())
@@ -184,7 +184,7 @@ pub struct Cfd {
     pub id: OrderId,
     pub position: Position,
     pub initial_price: Price,
-    pub leverage: Leverage,
+    pub taker_leverage: Leverage,
     pub settlement_interval: Duration,
     pub quantity_usd: Usd,
     pub counterparty_network_identity: Identity,
@@ -227,7 +227,7 @@ pub async fn load_cfd(
         id: cfd_row.uuid,
         position: cfd_row.position,
         initial_price: cfd_row.initial_price,
-        leverage: cfd_row.leverage,
+        taker_leverage: cfd_row.leverage,
         settlement_interval: Duration::hours(cfd_row.settlement_time_interval_hours),
         quantity_usd: cfd_row.quantity_usd,
         counterparty_network_identity: cfd_row.counterparty_network_identity,
@@ -359,7 +359,7 @@ mod tests {
                 id,
                 position,
                 initial_price,
-                leverage,
+                taker_leverage: leverage,
                 settlement_interval,
                 quantity_usd,
                 counterparty_network_identity,
@@ -374,7 +374,7 @@ mod tests {
         assert_eq!(cfd.id(), id);
         assert_eq!(cfd.position(), position);
         assert_eq!(cfd.initial_price(), initial_price);
-        assert_eq!(cfd.leverage(), leverage);
+        assert_eq!(cfd.taker_leverage(), leverage);
         assert_eq!(cfd.settlement_time_interval_hours(), settlement_interval);
         assert_eq!(cfd.quantity(), quantity_usd);
         assert_eq!(
@@ -546,7 +546,7 @@ mod tests {
             OrderId::default(),
             Position::Long,
             Price::new(dec!(60_000)).unwrap(),
-            Leverage::new(2).unwrap(),
+            Leverage::TWO,
             Duration::hours(24),
             Role::Taker,
             Usd::new(dec!(1_000)),

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -273,7 +273,7 @@ where
 
         let cfd = Cfd::from_order(
             current_order.clone(),
-            current_order.position,
+            current_order.position_maker,
             quantity,
             taker_id,
             Role::Maker,

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -121,7 +121,7 @@ pub async fn new(
         payout_curve::calculate(
             setup_params.price,
             setup_params.quantity,
-            setup_params.leverage,
+            setup_params.long_leverage,
             n_payouts,
             setup_params.fee_account.settle(),
         )?,
@@ -381,7 +381,7 @@ pub async fn roll_over(
         payout_curve::calculate(
             rollover_params.price,
             rollover_params.quantity,
-            rollover_params.leverage,
+            rollover_params.long_leverage,
             n_payouts,
             rollover_params.fee_account.settle(),
         )?,

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -170,7 +170,7 @@ where
         // recorded
         let cfd = Cfd::from_order(
             current_order.clone(),
-            current_order.position.counter_position(),
+            current_order.position_maker.counter_position(),
             quantity,
             self.maker_identity,
             Role::Taker,

--- a/model/src/contract_setup.rs
+++ b/model/src/contract_setup.rs
@@ -13,7 +13,11 @@ pub struct SetupParams {
     pub counterparty_identity: Identity,
     pub price: Price,
     pub quantity: Usd,
-    pub leverage: Leverage,
+    /// The long leverage
+    ///
+    /// This is used for calculating the payout curve only, which always requires the long leverage
+    /// at the moment
+    pub long_leverage: Leverage,
     pub refund_timelock: u32,
     pub tx_fee_rate: TxFeeRate,
     pub fee_account: FeeAccount,
@@ -27,7 +31,7 @@ impl SetupParams {
         counterparty_identity: Identity,
         price: Price,
         quantity: Usd,
-        leverage: Leverage,
+        long_leverage: Leverage,
         refund_timelock: u32,
         tx_fee_rate: TxFeeRate,
         fee_account: FeeAccount,
@@ -38,7 +42,7 @@ impl SetupParams {
             counterparty_identity,
             price,
             quantity,
-            leverage,
+            long_leverage,
             refund_timelock,
             tx_fee_rate,
             fee_account,

--- a/model/src/rollover.rs
+++ b/model/src/rollover.rs
@@ -9,7 +9,11 @@ use crate::Usd;
 pub struct RolloverParams {
     pub price: Price,
     pub quantity: Usd,
-    pub leverage: Leverage,
+    /// The long leverage
+    ///
+    /// This is used for calculating the payout curve only, which always requires the long leverage
+    /// at the moment
+    pub long_leverage: Leverage,
     pub refund_timelock: u32,
     pub fee_rate: TxFeeRate,
     pub fee_account: FeeAccount,
@@ -20,7 +24,7 @@ impl RolloverParams {
     pub fn new(
         price: Price,
         quantity: Usd,
-        leverage: Leverage,
+        long_leverage: Leverage,
         refund_timelock: u32,
         fee_rate: TxFeeRate,
         fee_account: FeeAccount,
@@ -29,7 +33,7 @@ impl RolloverParams {
         Self {
             price,
             quantity,
-            leverage,
+            long_leverage,
             refund_timelock,
             fee_rate,
             fee_account,


### PR DESCRIPTION
The leverage is now handled correctly, internally we store long and short leverage and calcuate the margin accordingly. In the database we only store the taker leverage (that's what is in the `Order` and is currently always 2). The maker leverage is always assumed to be `1` no matter if the maker is short or long.

Note that the `Order` should be changed to be an `Offer`, and the position of said offer should *not* be the maker's (as it currently is) but the taker's. It is super confusing that the Order's position is the maker's whereas the order's leverage is the one of the taker.

