### PR TITLE
Remove job running tests in release mode on the CI and bors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,18 +111,6 @@ jobs:
           curl --fail http://localhost:8000/api/alive
           curl --fail http://localhost:8001/api/alive
 
-  test_daemons_release_mode:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2.4.0
-      - name: Setup rust toolchain
-        run: rustup show
-      - uses: Swatinem/rust-cache@v1.3.0
-      - run: cargo test --release --workspace
-
   daemons_arm_build:
     runs-on: ubuntu-latest
     steps:

--- a/bors.toml
+++ b/bors.toml
@@ -17,7 +17,5 @@ status = [
   "frontend (taker)",
   "test_daemons (ubuntu-latest)",
   "test_daemons (macos-latest)",
-  "test_daemons_release_mode (ubuntu-latest)",
-  "test_daemons_release_mode (macos-latest)",
   "daemons_arm_build",
 ]


### PR DESCRIPTION
Importance of this job decreased since we fixed the major performance downsides
in debug mode which used to cause flaky test behaviour in debug mode. Right
now they seem to be more of a hindrance than adding any value as we are
being hit by compile times on the CI and bors.