### PR TITLE
Demote new block notification log to `trace`

### DIFF
--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -485,7 +485,7 @@ impl State {
         }
 
         if latest_block_height > self.latest_block_height {
-            tracing::debug!(
+            tracing::trace!(
                 block_height = u32::from(latest_block_height),
                 "Got notification for new block"
             );


### PR DESCRIPTION
Not the most important information and the logs are dominated by this on debug level on testnet.