### PR TITLE
Write proptest to test the limits of `payout_curve` module

### DIFF
--- a/model/src/payout_curve.rs
+++ b/model/src/payout_curve.rs
@@ -107,6 +107,10 @@ fn calculate_payout_parameters(
             let long_amount = to_sats(long_amount_btc)?;
 
             let long_amount_adjusted = match fee {
+                // We use `saturating_sub` because the adjusted payout
+                // cannot go below zero. If the original payout is
+                // close or equal to zero and the fee is sufficiently
+                // large we would overflow otherwise.
                 FeeFlow::LongPaysShort(fee) => long_amount.saturating_sub(fee.as_sat()),
                 FeeFlow::ShortPaysLong(fee) => long_amount.add(fee.as_sat()),
                 FeeFlow::Nein => long_amount,


### PR DESCRIPTION
The intention is to define ranges of values for `price`, `n_contracts`, `taker_leverage`, `n_payouts` and `fee_flow` which
produce sane payouts.

After defining this `proptest` we have noticed that:

- Our payout curve cannot handle an opening price over ~340_000 USD.   Values above that can run into a `Cannot invert singular matrix` error.
- The fee flow cannot be negative (i.e. `ShortPaysLong`), or else we run into an overflow error.

The former can be seen as a limitation of the current implementation. We can probably live with this for the foreseeable future.

The latter is a bug which is solved in https://github.com/itchysats/itchysats/pull/1454/commits/e3a83f8bcd6d8be9250dc2cc1f5af39d315bdf32.