### PR TITLE
Reduce the watch channel timeout in actor tests in debug mode

### DIFF
--- a/daemon-tests/src/flow.rs
+++ b/daemon-tests/src/flow.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use tokio::sync::watch;
 
 /// Waiting time for the time on the watch channel before returning error
-const NEXT_WAIT_TIME: Duration = Duration::from_secs(if cfg!(debug_assertions) { 180 } else { 30 });
+const NEXT_WAIT_TIME: Duration = Duration::from_secs(if cfg!(debug_assertions) { 60 } else { 30 });
 
 pub async fn next_order(
     rx_a: &mut watch::Receiver<Option<CfdOrder>>,

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -55,7 +55,7 @@ use std::time::Duration;
 use xtra::prelude::MessageChannel;
 
 /// How long protocol waits for the next message before giving up
-const MSG_TIMEOUT: Duration = Duration::from_secs(70);
+const MSG_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Given an initial set of parameters, sets up the CFD contract with
 /// the other party.


### PR DESCRIPTION
With the recent performance improvements, 180s wait seems unnecessary,
especially when one wants to make a test fail on a dev machine.