### PR TITLE
Allow skipping one heartbeat in taker UI

### DIFF
--- a/taker-frontend/src/useEventSource.ts
+++ b/taker-frontend/src/useEventSource.ts
@@ -26,7 +26,7 @@ export function useEventSource(url: string): [EventSource | null, boolean] {
 
             const hearbeat: Heartbeat = JSON.parse((event as EventSourceEvent).data);
             const interval_msecs = hearbeat.interval * 1000;
-            const buffered_interval_msecs = interval_msecs * 2;
+            const buffered_interval_msecs = interval_msecs * 2.2;
             timer = setTimeout(() => {
                 setIsConnected(false);
             }, buffered_interval_msecs);


### PR DESCRIPTION
By setting `interval_msecs * 2` we basically say that if we skip one, the next one would have to be exactly at `interval_msecs * 2` which might cause trouble if the daemon is not running on the same machine.
By increasing the to `interval_msecs * 2` we have more resilience in skipping one heartbeat.
Note that this does not explain why we would miss a heartbeat in the first place.

Fixes #1128 