### PR TITLE
Explicit `position_maker` field in `NewOrder` and when initializing `Order`

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -245,7 +245,7 @@ impl Maker {
             tx_fee_rate,
             funding_rate,
             opening_fee,
-            position,
+            position_maker,
         } = offer_params;
         self.system
             .set_offer_params(
@@ -255,7 +255,7 @@ impl Maker {
                 Some(tx_fee_rate),
                 Some(funding_rate),
                 Some(opening_fee),
-                Some(position),
+                Some(position_maker),
             )
             .await
             .unwrap();
@@ -425,7 +425,7 @@ pub fn dummy_quote() -> Quote {
     }
 }
 
-pub fn dummy_offer_params(position: Position) -> maker_cfd::OfferParams {
+pub fn dummy_offer_params(position_maker: Position) -> maker_cfd::OfferParams {
     maker_cfd::OfferParams {
         price: Price::new(dummy_price()).unwrap(),
         min_quantity: Usd::new(dec!(5)),
@@ -434,7 +434,7 @@ pub fn dummy_offer_params(position: Position) -> maker_cfd::OfferParams {
         // 8.76% annualized = rate of 0.0876 annualized = rate of 0.00024 daily
         funding_rate: FundingRate::new(dec!(0.00024)).unwrap(),
         opening_fee: OpeningFee::new(Amount::from_sat(2)),
-        position,
+        position_maker,
     }
 }
 

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -178,7 +178,7 @@ where
         fee_rate: Option<TxFeeRate>,
         funding_rate: Option<FundingRate>,
         opening_fee: Option<OpeningFee>,
-        position: Option<Position>,
+        position_maker: Option<Position>,
     ) -> Result<()> {
         self.cfd_actor
             .send(maker_cfd::OfferParams {
@@ -189,7 +189,7 @@ where
                 funding_rate: funding_rate.unwrap_or_default(),
                 opening_fee: opening_fee.unwrap_or_default(),
                 // For backwards compatibility, default to maker going short
-                position: position.unwrap_or(Position::Short),
+                position_maker: position_maker.unwrap_or(Position::Short),
             })
             .await??;
 

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -79,7 +79,7 @@ pub struct OfferParams {
     pub tx_fee_rate: TxFeeRate,
     pub funding_rate: FundingRate,
     pub opening_fee: OpeningFee,
-    pub position: Position,
+    pub position_maker: Position,
 }
 
 #[derive(Clone, Copy)]
@@ -553,7 +553,7 @@ where
             tx_fee_rate,
             funding_rate,
             opening_fee,
-            position,
+            position_maker,
         } = msg;
 
         let oracle_event_id = oracle::next_announcement_after(
@@ -561,7 +561,7 @@ where
         )?;
 
         let order = Order::new(
-            position,
+            position_maker,
             price,
             min_quantity,
             max_quantity,


### PR DESCRIPTION
Makes it clearer what the position represents throughout creating an `Order`.

This is a tiny cleanup.