### PR TITLE
Demote failure log message to debug

### DIFF
--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -319,7 +319,7 @@ impl Actor {
 
     async fn handle_read_fail(&mut self, msg: ReadFail) {
         let taker_id = msg.0;
-        tracing::error!(%taker_id, "Failed to read incoming messages from taker");
+        tracing::debug!(%taker_id, "Failed to read incoming messages from taker");
 
         self.drop_taker_connection(&taker_id).await;
     }


### PR DESCRIPTION
A taker disconnecting is not something we can do much about. The
network connection failing when it shouldn't is a problem but we
cannot tell that from this code path.

Thus, logging this on error just clutters the logs and makes looking
for actual errors much harder.

@klochowicz Might be worth considering to include this in the point release.