### PR TITLE
Improve ergonomics for spawning actors into `Tasks`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,6 +3810,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "tokio",
+ "xtra",
 ]
 
 [[package]]

--- a/daemon-tests/Cargo.toml
+++ b/daemon-tests/Cargo.toml
@@ -18,7 +18,7 @@ rust_decimal = "1.22"
 rust_decimal_macros = "1.22"
 time = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
-tokio-tasks = { path = "../tokio-tasks" }
+tokio-tasks = { path = "../tokio-tasks", features = ["xtra"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter", "local-time", "tracing-log", "json"] }
 xtra = { version = "0.6" }

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -174,8 +174,7 @@ impl Maker {
 
         let mut tasks = Tasks::default();
 
-        let (wallet_addr, wallet_fut) = wallet.create(None).run();
-        tasks.add(wallet_fut);
+        let wallet_addr = wallet.create(None).spawn(&mut tasks);
 
         let (price_feed_addr, price_feed_fut) = price_feed.create(None).run();
         tasks.add(async move {
@@ -302,8 +301,7 @@ impl Taker {
         let (wallet, wallet_mock) = WalletActor::new();
         let (price_feed, price_feed_mock) = PriceFeedActor::new();
 
-        let (wallet_addr, wallet_fut) = wallet.create(None).run();
-        tasks.add(wallet_fut);
+        let wallet_addr = wallet.create(None).spawn(&mut tasks);
 
         let (projection_actor, projection_context) = xtra::Context::new(None);
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -33,7 +33,7 @@ statrs = "0.15"
 thiserror = "1"
 time = { version = "0.3", features = ["serde", "macros", "parsing", "formatting", "serde-well-known"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
-tokio-tasks = { path = "../tokio-tasks" }
+tokio-tasks = { path = "../tokio-tasks", features = ["xtra"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tracing = { version = "0.1" }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/daemon/src/auto_rollover.rs
+++ b/daemon/src/auto_rollover.rs
@@ -81,7 +81,7 @@ where
         let this = ctx
             .address()
             .expect("actor to be able to give address to itself");
-        let (addr, fut) = rollover_taker::Actor::new(
+        let addr = rollover_taker::Actor::new(
             order_id,
             self.n_payouts,
             self.oracle_pk,
@@ -92,10 +92,9 @@ where
             self.db.clone(),
         )
         .create(None)
-        .run();
+        .spawn(&mut self.tasks);
 
         disconnected.insert(addr);
-        self.tasks.add(fut);
     }
 }
 

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -20,7 +20,7 @@ rust-embed-rocket = { path = "../rust-embed-rocket" }
 serde = { version = "1", features = ["derive"] }
 shared-bin = { path = "../shared-bin" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
-tokio-tasks = { path = "../tokio-tasks" }
+tokio-tasks = { path = "../tokio-tasks", features = ["xtra"] }
 tracing = { version = "0.1" }
 uuid = "0.8"
 xtra = { version = "0.6" }

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -170,8 +170,7 @@ async fn main() -> Result<()> {
 
     let (wallet, wallet_feed_receiver) = wallet::Actor::new(opts.network.electrum(), ext_priv_key)?;
 
-    let (wallet, wallet_fut) = wallet.create(None).run();
-    tasks.add(wallet_fut);
+    let wallet = wallet.create(None).spawn(&mut tasks);
 
     if let Some(Withdraw::Withdraw {
         amount,
@@ -242,8 +241,7 @@ async fn main() -> Result<()> {
             | xtra_bitmex_price_feed::Error::StreamEnded => true, // always restart price feed actor
         });
 
-    let (_supervisor_address, task) = supervisor.create(None).run();
-    tasks.add(task);
+    let _supervisor_address = supervisor.create(None).spawn(&mut tasks);
 
     let (proj_actor, projection_feeds) =
         projection::Actor::new(db.clone(), Role::Maker, bitcoin_network, &price_feed);

--- a/taker/Cargo.toml
+++ b/taker/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["derive"] }
 shared-bin = { path = "../shared-bin" }
 time = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
-tokio-tasks = { path = "../tokio-tasks" }
+tokio-tasks = { path = "../tokio-tasks", features = ["xtra"] }
 tracing = { version = "0.1" }
 uuid = "0.8"
 x25519-dalek = "1.1"

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -213,8 +213,7 @@ async fn main() -> Result<()> {
 
     let (wallet, wallet_feed_receiver) = wallet::Actor::new(opts.network.electrum(), ext_priv_key)?;
 
-    let (wallet, wallet_fut) = wallet.create(None).run();
-    tasks.add(wallet_fut);
+    let wallet = wallet.create(None).spawn(&mut tasks);
 
     if let Some(Withdraw::Withdraw {
         amount,

--- a/tokio-tasks/Cargo.toml
+++ b/tokio-tasks/Cargo.toml
@@ -7,6 +7,7 @@ description = "Control the lifetime of async tasks by leveraging Drop"
 [dependencies]
 futures = { version = "0.3", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread"] }
+xtra = { version = "0.6", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time", "macros"] }

--- a/tokio-tasks/src/lib.rs
+++ b/tokio-tasks/src/lib.rs
@@ -44,3 +44,10 @@ impl Tasks {
         self.0.push(handle);
     }
 }
+
+#[cfg(feature = "xtra")]
+impl xtra::spawn::Spawner for Tasks {
+    fn spawn<F: Future<Output = ()> + Send + 'static>(&mut self, fut: F) {
+        self.add(fut);
+    }
+}


### PR DESCRIPTION
`xtra` offers a `Spawner` abstraction that we can plug into. This allows
us to use the `.spawn` function on `ActorManager` which cuts out a bit of
boilerplate in some cases.