### PR TITLE
Fix errors around collab settlement and rollover

### DIFF
--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -428,6 +428,41 @@ async fn maker_rejects_rollover_after_commit_finality() {
 }
 
 #[tokio::test]
+async fn maker_accepts_rollover_after_commit_finality() {
+    let _guard = init_tracing();
+    let oracle_data = OliviaData::example_0();
+    let (mut maker, mut taker, order_id) =
+        start_from_open_cfd_state(oracle_data.announcement(), Position::Short).await;
+
+    taker.mocks.mock_latest_quote(Some(dummy_quote())).await;
+    maker.mocks.mock_latest_quote(Some(dummy_quote())).await;
+    next_with(taker.quote_feed(), |q| q).await.unwrap(); // if quote is available on feed, it propagated through the system
+
+    taker.trigger_rollover(order_id).await;
+
+    wait_next_state!(
+        order_id,
+        maker,
+        taker,
+        CfdState::IncomingRolloverProposal,
+        CfdState::OutgoingRolloverProposal
+    );
+
+    confirm!(commit transaction, order_id, maker, taker);
+
+    maker.system.accept_rollover(order_id).await.unwrap(); // This should fail
+
+    wait_next_state!(
+        order_id,
+        maker,
+        taker,
+        // FIXME: Maker wrongly changes state even when rollover does not happen
+        CfdState::ContractSetup,
+        CfdState::OpenCommitted
+    );
+}
+
+#[tokio::test]
 async fn maker_rejects_collab_settlement_after_commit_finality() {
     let _guard = init_tracing();
     let (mut maker, mut taker, order_id) =

--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -428,6 +428,64 @@ async fn maker_rejects_rollover_after_commit_finality() {
 }
 
 #[tokio::test]
+async fn maker_rejects_collab_settlement_after_commit_finality() {
+    let _guard = init_tracing();
+    let (mut maker, mut taker, order_id) =
+        start_from_open_cfd_state(OliviaData::example_0().announcement(), Position::Short).await;
+    taker.mocks.mock_latest_quote(Some(dummy_quote())).await;
+    maker.mocks.mock_latest_quote(Some(dummy_quote())).await;
+    next_with(taker.quote_feed(), |q| q).await.unwrap(); // if quote is available on feed, it propagated through the system
+
+    taker.system.propose_settlement(order_id).await.unwrap();
+
+    wait_next_state!(
+        order_id,
+        maker,
+        taker,
+        CfdState::IncomingSettlementProposal,
+        CfdState::OutgoingSettlementProposal
+    );
+
+    confirm!(commit transaction, order_id, maker, taker);
+
+    maker.system.reject_settlement(order_id).await.unwrap();
+    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
+
+    // After rejecting rollover, we should display where we were before the
+    // rollover attempt
+    wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
+}
+
+#[tokio::test]
+async fn maker_accepts_collab_settlement_after_commit_finality() {
+    let _guard = init_tracing();
+    let (mut maker, mut taker, order_id) =
+        start_from_open_cfd_state(OliviaData::example_0().announcement(), Position::Short).await;
+    taker.mocks.mock_latest_quote(Some(dummy_quote())).await;
+    maker.mocks.mock_latest_quote(Some(dummy_quote())).await;
+    next_with(taker.quote_feed(), |q| q).await.unwrap(); // if quote is available on feed, it propagated through the system
+
+    taker.system.propose_settlement(order_id).await.unwrap();
+
+    wait_next_state!(
+        order_id,
+        maker,
+        taker,
+        CfdState::IncomingSettlementProposal,
+        CfdState::OutgoingSettlementProposal
+    );
+
+    confirm!(commit transaction, order_id, maker, taker);
+
+    maker.system.accept_settlement(order_id).await.unwrap();
+    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
+
+    // After rejecting rollover, we should display where we were before the
+    // rollover attempt
+    wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
+}
+
+#[tokio::test]
 async fn open_cfd_is_refunded() {
     let _guard = init_tracing();
     let oracle_data = OliviaData::example_0();

--- a/daemon/src/collab_settlement_maker.rs
+++ b/daemon/src/collab_settlement_maker.rs
@@ -162,7 +162,9 @@ impl Actor {
         let order_id = self.proposal.order_id;
         if let Err(e) = self
             .executor
-            .execute(order_id, |cfd| cfd.reject_collaborative_settlement(reason))
+            .execute(order_id, |cfd| {
+                Ok(cfd.reject_collaborative_settlement(reason))
+            })
             .await
         {
             tracing::warn!(%order_id, "Failed to execute `reject_collaborative_settlement` command: {e:#}");
@@ -175,7 +177,7 @@ impl Actor {
         let order_id = self.proposal.order_id;
         if let Err(e) = self
             .executor
-            .execute(order_id, |cfd| cfd.fail_collaborative_settlement(error))
+            .execute(order_id, |cfd| Ok(cfd.fail_collaborative_settlement(error)))
             .await
         {
             tracing::warn!(%order_id, "Failed to execute `fail_collaborative_settlement` command: {e:#}");

--- a/daemon/src/collab_settlement_maker.rs
+++ b/daemon/src/collab_settlement_maker.rs
@@ -148,7 +148,7 @@ impl Actor {
         if let Err(e) = self
             .executor
             .execute(order_id, |cfd| {
-                cfd.complete_collaborative_settlement(settlement)
+                Ok(cfd.complete_collaborative_settlement(settlement))
             })
             .await
         {

--- a/daemon/src/collab_settlement_taker.rs
+++ b/daemon/src/collab_settlement_taker.rs
@@ -113,7 +113,7 @@ impl Actor {
         if let Err(e) = self
             .executor
             .execute(order_id, |cfd| {
-                cfd.complete_collaborative_settlement(settlement)
+                Ok(cfd.complete_collaborative_settlement(settlement))
             })
             .await
         {

--- a/daemon/src/collab_settlement_taker.rs
+++ b/daemon/src/collab_settlement_taker.rs
@@ -127,7 +127,9 @@ impl Actor {
         let order_id = self.order_id;
         if let Err(e) = self
             .executor
-            .execute(order_id, |cfd| cfd.reject_collaborative_settlement(reason))
+            .execute(order_id, |cfd| {
+                Ok(cfd.reject_collaborative_settlement(reason))
+            })
             .await
         {
             tracing::warn!(%order_id, "Failed to execute `reject_collaborative_settlement` command: {e:#}");
@@ -140,7 +142,7 @@ impl Actor {
         let order_id = self.order_id;
         if let Err(e) = self
             .executor
-            .execute(order_id, |cfd| cfd.fail_collaborative_settlement(error))
+            .execute(order_id, |cfd| Ok(cfd.fail_collaborative_settlement(error)))
             .await
         {
             tracing::warn!(%order_id, "Failed to execute `fail_collaborative_settlement` command: {e:#}");
@@ -232,9 +234,9 @@ impl Actor {
         if let Err(e) = self
             .executor
             .execute(self.order_id, |cfd| {
-                cfd.fail_collaborative_settlement(anyhow!(
+                Ok(cfd.fail_collaborative_settlement(anyhow!(
                     "Maker did not respond within {timeout} seconds"
-                ))
+                )))
             })
             .await
         {

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -393,7 +393,7 @@ impl<O, T, W> Actor<O, T, W> {
         {
             self.executor
                 .execute(order_id, |cfd| {
-                    cfd.fail_collaborative_settlement(anyhow!(error))
+                    Ok(cfd.fail_collaborative_settlement(anyhow!(error)))
                 })
                 .await?;
 
@@ -414,7 +414,7 @@ impl<O, T, W> Actor<O, T, W> {
         {
             self.executor
                 .execute(order_id, |cfd| {
-                    cfd.fail_collaborative_settlement(anyhow!(error))
+                    Ok(cfd.fail_collaborative_settlement(anyhow!(error)))
                 })
                 .await?;
 

--- a/daemon/src/rollover_maker.rs
+++ b/daemon/src/rollover_maker.rs
@@ -105,7 +105,7 @@ impl Actor {
         if let Err(e) = self
             .executor
             .execute(self.order_id, |cfd| {
-                Ok(cfd.complete_rollover(dlc, funding_fee)?)
+                Ok(cfd.complete_rollover(dlc, funding_fee))
             })
             .await
         {

--- a/daemon/src/rollover_taker.rs
+++ b/daemon/src/rollover_taker.rs
@@ -170,7 +170,7 @@ impl Actor {
     ) {
         let result = self
             .executor
-            .execute(self.id, |cfd| Ok(cfd.complete_rollover(dlc, funding_fee)?))
+            .execute(self.id, |cfd| Ok(cfd.complete_rollover(dlc, funding_fee)))
             .await;
 
         if let Err(e) = result {

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1036,26 +1036,16 @@ impl Cfd {
         }))
     }
 
-    pub fn reject_collaborative_settlement(self, reason: anyhow::Error) -> Result<CfdEvent> {
-        anyhow::ensure!(
-            self.can_settle_collaboratively(),
-            "Cannot reject collaborative settlement"
-        );
-
+    pub fn reject_collaborative_settlement(self, reason: anyhow::Error) -> CfdEvent {
         tracing::info!(order_id=%self.id(), "Collaborative settlement rejected: {reason:#}");
 
-        Ok(self.event(EventKind::CollaborativeSettlementRejected))
+        self.event(EventKind::CollaborativeSettlementRejected)
     }
 
-    pub fn fail_collaborative_settlement(self, error: anyhow::Error) -> Result<CfdEvent> {
-        anyhow::ensure!(
-            self.can_settle_collaboratively(),
-            "Cannot fail collaborative settlement"
-        );
-
+    pub fn fail_collaborative_settlement(self, error: anyhow::Error) -> CfdEvent {
         tracing::warn!(order_id=%self.id(), "Collaborative settlement failed: {:#}", error);
 
-        Ok(self.event(EventKind::CollaborativeSettlementFailed))
+        self.event(EventKind::CollaborativeSettlementFailed)
     }
 
     /// Given an attestation, find and decrypt the relevant CET.


### PR DESCRIPTION
There were multiple cases where we would stop trying to finish a protocol instead of appending a "failed" event.
See commits for details (and new tests).