### PR TITLE
Always allow failing of contract setup

### DIFF
--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -339,7 +339,7 @@ impl<O, T, W> Actor<O, T, W> {
             .await
         {
             self.executor
-                .execute(order_id, |cfd| cfd.fail_contract_setup(anyhow!(error)))
+                .execute(order_id, |cfd| Ok(cfd.fail_contract_setup(anyhow!(error))))
                 .await?;
 
             bail!("Accept failed: No active contract setup for order {order_id}")
@@ -360,7 +360,7 @@ impl<O, T, W> Actor<O, T, W> {
             .await
         {
             self.executor
-                .execute(order_id, |cfd| cfd.fail_contract_setup(anyhow!(error)))
+                .execute(order_id, |cfd| Ok(cfd.fail_contract_setup(anyhow!(error))))
                 .await?;
 
             bail!("Reject failed: No active contract setup for order {order_id}")

--- a/daemon/src/setup_maker.rs
+++ b/daemon/src/setup_maker.rs
@@ -141,7 +141,7 @@ impl Actor {
     async fn emit_fail(&mut self, error: anyhow::Error, ctx: &mut xtra::Context<Self>) {
         if let Err(e) = self
             .executor
-            .execute(self.order.id, |cfd| cfd.fail_contract_setup(error))
+            .execute(self.order.id, |cfd| Ok(cfd.fail_contract_setup(error)))
             .await
         {
             tracing::error!("Failed to execute `fail_contract_setup` command: {e:#}");

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -161,7 +161,7 @@ impl Actor {
     fn handle(&mut self, msg: SetupFailed, ctx: &mut xtra::Context<Self>) {
         if let Err(e) = self
             .executor
-            .execute(self.order_id, |cfd| cfd.fail_contract_setup(msg.error))
+            .execute(self.order_id, |cfd| Ok(cfd.fail_contract_setup(msg.error)))
             .await
         {
             tracing::warn!("Failed to execute `fail_contract_setup` command: {e:#}");
@@ -187,7 +187,8 @@ impl Actor {
         if let Err(e) = self
             .executor
             .execute(self.order_id, |cfd| {
-                cfd.fail_contract_setup(anyhow!("Maker did not respond within {timeout} seconds"))
+                Ok(cfd
+                    .fail_contract_setup(anyhow!("Maker did not respond within {timeout} seconds")))
             })
             .await
         {

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -984,16 +984,10 @@ impl Cfd {
         Ok(self.event(EventKind::OfferRejected))
     }
 
-    pub fn fail_contract_setup(self, error: anyhow::Error) -> Result<CfdEvent> {
-        anyhow::ensure!(
-            self.version <= 1,
-            "Failing contract setup not allowed because cfd in version {}",
-            self.version
-        );
-
+    pub fn fail_contract_setup(self, error: anyhow::Error) -> CfdEvent {
         tracing::error!(order_id = %self.id, "Contract setup failed: {error:#}");
 
-        Ok(self.event(EventKind::ContractSetupFailed))
+        self.event(EventKind::ContractSetupFailed)
     }
 
     pub fn complete_rollover(self, dlc: Dlc, funding_fee: FundingFee) -> CfdEvent {


### PR DESCRIPTION
We actually have encountered this error whilst testing late last week.

I don't believe that we should prohibit *failing* a protocol.

@luckysori adding you too, as this one touches the "versioning" invariants. I'd be open to potentially changing this PR to instead use `debug_assert!` (to validate and specify our assumption, but not to crash in production)