### PR TITLE
Release version 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.7] - 2022-02-28
+
 ## [0.4.6] - 2022-02-23
 
 ## [0.4.3] - 2022-02-14
@@ -72,7 +74,8 @@ Backport <https://github.com/itchysats/itchysats/pull/924> in an attempt to fix 
 
 Initial release for mainnet.
 
-[Unreleased]: https://github.com/itchysats/itchysats/compare/0.4.6...HEAD
+[Unreleased]: https://github.com/itchysats/itchysats/compare/0.4.7...HEAD
+[0.4.7]: https://github.com/itchysats/itchysats/compare/0.4.6...0.4.7
 [0.4.6]: https://github.com/itchysats/itchysats/compare/0.4.3...0.4.6
 [0.4.2]: https://github.com/itchysats/itchysats/compare/0.4.1...0.4.2
 [0.4.1]: https://github.com/itchysats/itchysats/compare/0.4.0...0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "maker"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "taker"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "daemon"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daemon"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 
 [dependencies]

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maker"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/taker/Cargo.toml
+++ b/taker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taker"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Hi @da-kami!
This PR was created in response to a manual trigger of the release workflow here: https://github.com/itchysats/itchysats/actions/runs/1908730461.
I've bumped the versions in the manifest files in this commit: 4c49615b774e4fe4ad6188d5af1f89a6f0cc3850.
Merging this PR will create a GitHub release!