### PR TITLE
Unlock wallet UTXOs after sufficient time has passed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "maia"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/maia#cf0df283e494a3452398dc62ca6c6df47963a329"
+source = "git+https://github.com/comit-network/maia#896d49ee340fc57f0ae441b979abf8aa45249085"
 dependencies = [
  "anyhow",
  "bdk",

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use daemon::bdk;
 use daemon::bdk::bitcoin::Network;
+use daemon::bdk::blockchain::ElectrumBlockchain;
 use daemon::oracle;
 use daemon::projection::Cfd;
 use daemon::projection::CfdAction;
@@ -35,7 +36,7 @@ use tokio::select;
 use tokio::sync::watch;
 use uuid::Uuid;
 
-pub type Maker = MakerActorSystem<oracle::Actor, wallet::Actor>;
+pub type Maker = MakerActorSystem<oracle::Actor, wallet::Actor<ElectrumBlockchain>>;
 
 #[allow(clippy::too_many_arguments)]
 #[rocket::get("/feed")]

--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -1,6 +1,7 @@
 use daemon::bdk;
 use daemon::bdk::bitcoin::Amount;
 use daemon::bdk::bitcoin::Network;
+use daemon::bdk::blockchain::ElectrumBlockchain;
 use daemon::connection::ConnectionStatus;
 use daemon::oracle;
 use daemon::projection;
@@ -35,7 +36,11 @@ use tokio::select;
 use tokio::sync::watch;
 use uuid::Uuid;
 
-type Taker = TakerActorSystem<oracle::Actor, wallet::Actor, xtra_bitmex_price_feed::Actor>;
+type Taker = TakerActorSystem<
+    oracle::Actor,
+    wallet::Actor<ElectrumBlockchain>,
+    xtra_bitmex_price_feed::Actor,
+>;
 
 const HEARTBEAT_INTERVAL_SECS: u64 = 5;
 


### PR DESCRIPTION
Fixes #1135.

Most of what was changed with the first 3 patches ended up being unnecessary, so we can drop it if it's unwanted. The main benefit of those changes was to be able to write the test in ff69a50196254056f6690755933fe53c1222943d.