### PR TITLE
Update wire protocol to support sending both long and short offers

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -238,23 +238,23 @@ impl Maker {
 
     pub async fn set_offer_params(&mut self, offer_params: maker_cfd::OfferParams) {
         let maker_cfd::OfferParams {
-            price,
+            price_long,
+            price_short,
             min_quantity,
             max_quantity,
             tx_fee_rate,
             funding_rate,
             opening_fee,
-            position_maker,
         } = offer_params;
         self.system
             .set_offer_params(
-                price,
+                price_long,
+                price_short,
                 min_quantity,
                 max_quantity,
                 Some(tx_fee_rate),
                 Some(funding_rate),
                 Some(opening_fee),
-                Some(position_maker),
             )
             .await
             .unwrap();
@@ -423,16 +423,22 @@ pub fn dummy_quote() -> Quote {
     }
 }
 
+// Offer params allowing a single position, either short or long
 pub fn dummy_offer_params(position_maker: Position) -> maker_cfd::OfferParams {
+    let (price_long, price_short) = match position_maker {
+        Position::Long => (Some(Price::new(dummy_price()).unwrap()), None),
+        Position::Short => (None, Some(Price::new(dummy_price()).unwrap())),
+    };
+
     maker_cfd::OfferParams {
-        price: Price::new(dummy_price()).unwrap(),
+        price_long,
+        price_short,
         min_quantity: Usd::new(dec!(5)),
         max_quantity: Usd::new(dec!(100)),
         tx_fee_rate: TxFeeRate::new(1),
         // 8.76% annualized = rate of 0.0876 annualized = rate of 0.00024 daily
         funding_rate: FundingRate::new(dec!(0.00024)).unwrap(),
         opening_fee: OpeningFee::new(Amount::from_sat(2)),
-        position_maker,
     }
 }
 

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -15,6 +15,7 @@ use bdk::bitcoin::Amount;
 use futures::SinkExt;
 use futures::StreamExt;
 use futures::TryStreamExt;
+use model::pick_single_offer;
 use model::Identity;
 use model::OrderId;
 use model::Price;
@@ -562,10 +563,12 @@ impl Actor {
                     Err(NotConnected(_)) => tracing::warn!(%order_id, "No active rollover"),
                 }
             }
-            wire::MakerToTaker::CurrentOrder(msg) => {
+            wire::MakerToTaker::CurrentOffers(maker_offers) => {
+                let order = pick_single_offer(maker_offers);
+
                 let _ = self
                     .current_order
-                    .send(CurrentOrder(msg))
+                    .send(CurrentOrder(order))
                     .log_failure("Failed to forward current order from maker")
                     .await;
             }

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -14,7 +14,6 @@ use model::Identity;
 use model::OpeningFee;
 use model::Order;
 use model::OrderId;
-use model::Position;
 use model::Price;
 use model::Role;
 use model::TxFeeRate;
@@ -170,24 +169,23 @@ where
     #[allow(clippy::too_many_arguments)]
     pub async fn set_offer_params(
         &self,
-        price: Price,
+        price_long: Option<Price>,
+        price_short: Option<Price>,
         min_quantity: Usd,
         max_quantity: Usd,
         fee_rate: Option<TxFeeRate>,
         funding_rate: Option<FundingRate>,
         opening_fee: Option<OpeningFee>,
-        position_maker: Option<Position>,
     ) -> Result<()> {
         self.cfd_actor
             .send(maker_cfd::OfferParams {
-                price,
+                price_long,
+                price_short,
                 min_quantity,
                 max_quantity,
                 tx_fee_rate: fee_rate.unwrap_or_default(),
                 funding_rate: funding_rate.unwrap_or_default(),
                 opening_fee: opening_fee.unwrap_or_default(),
-                // For backwards compatibility, default to maker going short
-                position_maker: position_maker.unwrap_or(Position::Short),
             })
             .await??;
 

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -17,7 +17,7 @@ use maia::CfdTransactions;
 use maia::PartyParams;
 use maia::PunishParams;
 use model::FundingRate;
-use model::Order;
+use model::MakerOffers;
 use model::OrderId;
 use model::Price;
 use model::Timestamp;
@@ -45,7 +45,7 @@ pub struct Version(semver::Version);
 
 impl Version {
     pub fn current() -> Self {
-        Self(semver::Version::new(2, 0, 0))
+        Self(semver::Version::new(3, 0, 0))
     }
 }
 
@@ -130,9 +130,9 @@ impl fmt::Display for TakerToMaker {
 #[allow(clippy::large_enum_variant)]
 pub enum MakerToTaker {
     Hello(Version),
-    /// Periodically broadcasted message, indicating maker's presence
+    /// Periodically broadcast message, indicating maker's presence
     Heartbeat,
-    CurrentOrder(Option<Order>),
+    CurrentOffers(Option<MakerOffers>),
     ConfirmOrder(OrderId),
     RejectOrder(OrderId),
     InvalidOrderId(OrderId),
@@ -182,7 +182,7 @@ impl fmt::Display for MakerToTaker {
         match self {
             MakerToTaker::Hello(_) => write!(f, "Hello"),
             MakerToTaker::Heartbeat { .. } => write!(f, "Heartbeat"),
-            MakerToTaker::CurrentOrder(_) => write!(f, "CurrentOrder"),
+            MakerToTaker::CurrentOffers { .. } => write!(f, "CurrentOffers"),
             MakerToTaker::ConfirmOrder(_) => write!(f, "ConfirmOrder"),
             MakerToTaker::RejectOrder(_) => write!(f, "RejectOrder"),
             MakerToTaker::InvalidOrderId(_) => write!(f, "InvalidOrderId"),


### PR DESCRIPTION
This is a refactor, which aimed to preserve the current functionality - the only
difference from API perspective is the nature of choosing whether the maker
wants to go short or long (now it's done by setting `price_long` if maker
wants to go long, before it was choosing `position_maker`).