### PR TITLE
Don't set gauges to zero on startup

### DIFF
--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -128,14 +128,6 @@ impl Actor<ElectrumBlockchain> {
             used_utxos: LockedUtxos::new(time_to_lock),
         };
 
-        BALANCE_GAUGE.set(0.0);
-        NUM_UTXO_GAUGE.set(0.0);
-        MEDIAN_UTXO_VALUE_GAUGE.set(0.0);
-        MIN_UTXO_VALUE_GAUGE.set(0.0);
-        MAX_UTXO_VALUE_GAUGE.set(0.0);
-        MEAN_UTXO_VALUE_GAUGE.set(0.0);
-        STD_DEV_UTXO_VALUE_GAUGE.set(0.0);
-
         Ok((actor, receiver))
     }
 }


### PR DESCRIPTION
This produces spikes in the actual graph until we do the first sync.
Grafana can be taught to interpolate between two missing datapoints
which is the right thing to do in this context.