### PR TITLE
Create new /offer endpoint in the maker

### DIFF
--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -259,6 +259,7 @@ async fn main() -> Result<()> {
             rocket::routes![
                 routes::maker_feed,
                 routes::post_sell_order,
+                routes::put_offer_params,
                 routes::post_cfd_action,
                 routes::get_health_check,
                 routes::post_withdraw_request,

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -95,9 +95,10 @@ pub async fn maker_feed(
     }
 }
 
+// TODO: Delete after upgrading automation to prefer /offer endpoint
 /// The maker POSTs this to set the offer params
 #[derive(Debug, Clone, Deserialize)]
-pub struct CfdNewOfferParamsRequest {
+pub struct CfdNewOfferParamsRequestDeprecated {
     #[serde(rename = "price")]
     // TODO: Make this Option<Price> when we don't want to create other side
     pub price_short: Price,
@@ -113,10 +114,10 @@ pub struct CfdNewOfferParamsRequest {
     pub price_long: Option<Price>,
 }
 
-// TODO: Change to `/offer` after turning off legacy maker
+// TODO: Delete after upgrading automation to prefer /offer endpoint
 #[rocket::post("/order/sell", data = "<offer_params>")]
 pub async fn post_sell_order(
-    offer_params: Json<CfdNewOfferParamsRequest>,
+    offer_params: Json<CfdNewOfferParamsRequestDeprecated>,
     maker: &State<Maker>,
     _auth: Authenticated,
 ) -> Result<(), HttpApiProblem> {
@@ -128,6 +129,51 @@ pub async fn post_sell_order(
             offer_params.max_quantity,
             offer_params.tx_fee_rate,
             offer_params.funding_rate,
+            offer_params.opening_fee,
+        )
+        .await
+        .map_err(|e| {
+            HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .title("Posting offer failed")
+                .detail(format!("{e:#}"))
+        })?;
+
+    Ok(())
+}
+
+/// The maker PUTs this to set the offer params
+#[derive(Debug, Clone, Deserialize)]
+pub struct CfdNewOfferParamsRequest {
+    pub price_long: Option<Price>,
+    pub price_short: Option<Price>,
+    pub min_quantity: Usd,
+    pub max_quantity: Usd,
+    pub tx_fee_rate: Option<TxFeeRate>,
+    /// The _daily_ funding rate as decided upon by the caller.
+    ///
+    /// The fact that this is the _daily_ funding rate is part of the API contract between this
+    /// application and its caller. Changing this would be a breaking change.
+    pub daily_funding_rate: Option<FundingRate>,
+    pub funding_rate: Option<FundingRate>,
+    // TODO: This is not inline with other parts of the API! We should not expose internal types
+    // here. We have to specify sats for here because of that.
+    pub opening_fee: Option<OpeningFee>,
+}
+
+#[rocket::put("/offer", data = "<offer_params>")]
+pub async fn put_offer_params(
+    offer_params: Json<CfdNewOfferParamsRequest>,
+    maker: &State<Maker>,
+    _auth: Authenticated,
+) -> Result<(), HttpApiProblem> {
+    maker
+        .set_offer_params(
+            offer_params.price_long,
+            offer_params.price_short,
+            offer_params.min_quantity,
+            offer_params.max_quantity,
+            offer_params.tx_fee_rate,
+            offer_params.daily_funding_rate,
             offer_params.opening_fee,
         )
         .await


### PR DESCRIPTION
Evolve the API to allow setting `Option<Price>` for both short and long price.

The deprecated endpoint ( /order/sell) will be removed after automation upgrade.