### PR TITLE
Log Rocket requests using tracing macro on debug level

### DIFF
--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -282,6 +282,14 @@ async fn main() -> Result<()> {
                 tracing::info!(endpoint = %http_endpoint, "HTTP interface is ready");
             })
         }))
+        .attach(AdHoc::on_request(
+            "Rocket HTTP request",
+            |request, _data| {
+                Box::pin(async move {
+                    tracing::debug!(%request, "HTTP");
+                })
+            },
+        ))
         .launch()
         .await?;
 

--- a/shared-bin/src/logger.rs
+++ b/shared-bin/src/logger.rs
@@ -22,6 +22,7 @@ pub fn init(level: LevelFilter, json_format: bool) -> Result<()> {
         .add_directive("rocket::launch=off".parse()?) // disable rocket startup logs
         .add_directive("rocket::launch_=off".parse()?) // disable rocket startup logs
         .add_directive("rocket::shield=off".parse()?) // not sure what rocket shield is but it seems unnecessary
+        .add_directive("rocket::server=off".parse()?) // disable rocket request logs (along with potentially other logs)
         .add_directive(format!("taker={level}").parse()?)
         .add_directive(format!("maker={level}").parse()?)
         .add_directive(format!("daemon={level}").parse()?)

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -315,6 +315,12 @@ async fn main() -> Result<()> {
                 tracing::info!(endpoint = %http_endpoint, "HTTP interface is ready");
             })
         }))
+        .attach(AdHoc::on_request("Rocket request", |req, _data| {
+            Box::pin(async move {
+                let request = req;
+                tracing::debug!(%request,  "rocket");
+            })
+        }))
         .launch()
         .await?;
 


### PR DESCRIPTION
Reduce the log spam and allow for easier parsing (Rocket logs used escape codes).