### PR TITLE
Long/short funding rate 

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -243,7 +243,8 @@ impl Maker {
             min_quantity,
             max_quantity,
             tx_fee_rate,
-            funding_rate,
+            funding_rate_long,
+            funding_rate_short,
             opening_fee,
         } = offer_params;
         self.system
@@ -253,7 +254,8 @@ impl Maker {
                 min_quantity,
                 max_quantity,
                 Some(tx_fee_rate),
-                Some(funding_rate),
+                Some(funding_rate_long),
+                Some(funding_rate_short),
                 Some(opening_fee),
             )
             .await
@@ -437,7 +439,8 @@ pub fn dummy_offer_params(position_maker: Position) -> maker_cfd::OfferParams {
         max_quantity: Usd::new(dec!(100)),
         tx_fee_rate: TxFeeRate::new(1),
         // 8.76% annualized = rate of 0.0876 annualized = rate of 0.00024 daily
-        funding_rate: FundingRate::new(dec!(0.00024)).unwrap(),
+        funding_rate_long: FundingRate::new(dec!(0.00024)).unwrap(),
+        funding_rate_short: FundingRate::new(dec!(0.00024)).unwrap(),
         opening_fee: OpeningFee::new(Amount::from_sat(2)),
     }
 }

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -174,7 +174,8 @@ where
         min_quantity: Usd,
         max_quantity: Usd,
         fee_rate: Option<TxFeeRate>,
-        funding_rate: Option<FundingRate>,
+        funding_rate_long: Option<FundingRate>,
+        funding_rate_short: Option<FundingRate>,
         opening_fee: Option<OpeningFee>,
     ) -> Result<()> {
         self.cfd_actor
@@ -184,7 +185,8 @@ where
                 min_quantity,
                 max_quantity,
                 tx_fee_rate: fee_rate.unwrap_or_default(),
-                funding_rate: funding_rate.unwrap_or_default(),
+                funding_rate_long: funding_rate_long.unwrap_or_default(),
+                funding_rate_short: funding_rate_short.unwrap_or_default(),
                 opening_fee: opening_fee.unwrap_or_default(),
             })
             .await??;

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -108,12 +108,11 @@ pub struct CfdNewOfferParamsRequestDeprecated {
     pub min_quantity: Usd,
     pub max_quantity: Usd,
     pub tx_fee_rate: Option<TxFeeRate>,
-    /// The _daily_ funding rate as decided upon by the caller.
-    ///
-    /// The fact that this is the _daily_ funding rate is part of the API contract between this
-    /// application and its caller. Changing this would be a breaking change.
+    /// The current _daily_ funding rate for the maker's long position
+    pub daily_funding_rate_long: Option<FundingRate>,
+    /// The current _daily_ funding rate for the maker's short position
     #[serde(rename = "funding_rate")]
-    pub daily_funding_rate: Option<FundingRate>,
+    pub daily_funding_rate_short: Option<FundingRate>,
     // TODO: This is not inline with other parts of the API! We should not expose internal types
     // here. We have to specify sats for here because of that.
     pub opening_fee: Option<OpeningFee>,
@@ -136,7 +135,8 @@ pub async fn post_sell_order(
             offer_params.min_quantity,
             offer_params.max_quantity,
             offer_params.tx_fee_rate,
-            offer_params.daily_funding_rate,
+            offer_params.daily_funding_rate_long,
+            offer_params.daily_funding_rate_short,
             offer_params.opening_fee,
         )
         .await
@@ -157,11 +157,10 @@ pub struct CfdNewOfferParamsRequest {
     pub min_quantity: Usd,
     pub max_quantity: Usd,
     pub tx_fee_rate: Option<TxFeeRate>,
-    /// The _daily_ funding rate as decided upon by the caller.
-    ///
-    /// The fact that this is the _daily_ funding rate is part of the API contract between this
-    /// application and its caller. Changing this would be a breaking change.
-    pub daily_funding_rate: Option<FundingRate>,
+    /// The current _daily_ funding rate for the maker's long position
+    pub daily_funding_rate_long: Option<FundingRate>,
+    /// The current _daily_ funding rate for the maker's short position
+    pub daily_funding_rate_short: Option<FundingRate>,
     pub funding_rate: Option<FundingRate>,
     // TODO: This is not inline with other parts of the API! We should not expose internal types
     // here. We have to specify sats for here because of that.
@@ -181,7 +180,8 @@ pub async fn put_offer_params(
             offer_params.min_quantity,
             offer_params.max_quantity,
             offer_params.tx_fee_rate,
-            offer_params.daily_funding_rate,
+            offer_params.daily_funding_rate_long,
+            offer_params.daily_funding_rate_short,
             offer_params.opening_fee,
         )
         .await

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -114,7 +114,8 @@ pub struct MakerOffers {
     pub long: Option<Order>,
     pub short: Option<Order>,
     pub tx_fee_rate: TxFeeRate,
-    pub funding_rate: FundingRate,
+    pub funding_rate_long: FundingRate,
+    pub funding_rate_short: FundingRate,
 }
 
 impl fmt::Debug for MakerOffers {
@@ -123,7 +124,8 @@ impl fmt::Debug for MakerOffers {
             .field("long_order_id", &self.long.as_ref().map(|o| o.id))
             .field("short_order_id", &self.long.as_ref().map(|o| o.id))
             .field("tx_fee_rate", &self.tx_fee_rate)
-            .field("funding_rate", &self.funding_rate)
+            .field("funding_rate_long", &self.funding_rate_long)
+            .field("funding_rate_short", &self.funding_rate_short)
             .finish()
     }
 }
@@ -173,7 +175,8 @@ impl MakerOffers {
             long: self.long.map(|order| order.replicate()),
             short: self.short.map(|order| order.replicate()),
             tx_fee_rate: self.tx_fee_rate,
-            funding_rate: self.funding_rate,
+            funding_rate_long: self.funding_rate_long,
+            funding_rate_short: self.funding_rate_short,
         }
     }
 }


### PR DESCRIPTION
This makes the funding rate dependent on the position, so the maker has more control on what rate apply to rollover.

TODO (not part of this PR):

- use both rates in the UI - when we go for https://github.com/itchysats/itchysats/pull/1562 this is trivial
- Adapt the automation accordingly