### PR TITLE
Add libp2p-xtra crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,10 +91,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "asn1_der"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
 name = "async-stream"
@@ -129,6 +141,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atoi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,7 +168,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -165,9 +190,9 @@ checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "barrage"
@@ -342,6 +367,12 @@ checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "btsieve"
@@ -575,6 +606,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +823,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
 name = "devise"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +912,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "ed25519"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d5c4b5e5959dc2c2b89918d8e2cc40fcdd623cef026ed09d2f0ee05199dc8e4"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek 3.2.0",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.8",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +1009,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,7 +1031,7 @@ checksum = "24c3fd473b3a903a62609e413ed7538f99e10b665ecb502b5e481a95283f8ab4"
 dependencies = [
  "futures-core",
  "futures-sink",
- "pin-project",
+ "pin-project 1.0.8",
  "spin 0.9.2",
 ]
 
@@ -1028,6 +1103,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1038,7 +1114,7 @@ checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -1392,7 +1468,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "hashbrown 0.11.2",
  "serde",
 ]
@@ -1405,9 +1481,9 @@ checksum = "3094308123a0e9fd59659ce45e22de9f53fc1d2ac6e1feb9fef988e4f76cad77"
 
 [[package]]
 name = "instant"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1465,9 +1541,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libgit2-sys"
@@ -1486,6 +1562,85 @@ name = "libm"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+
+[[package]]
+name = "libp2p-core"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9164ec41455856e8187addc870bb4fe1ea2ee28e1a9244831d449a2429b32c1a"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "lazy_static",
+ "log",
+ "multiaddr",
+ "multihash",
+ "multistream-select",
+ "parking_lot 0.12.0",
+ "pin-project 1.0.8",
+ "prost",
+ "prost-build",
+ "rand 0.8.4",
+ "ring",
+ "rw-stream-sink",
+ "sha2 0.10.2",
+ "smallvec",
+ "thiserror",
+ "unsigned-varint",
+ "void",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd7e0c94051cda67123be68cf6b65211ba3dde7277be9068412de3e7ffd63ef"
+dependencies = [
+ "bytes",
+ "curve25519-dalek 3.2.0",
+ "futures",
+ "lazy_static",
+ "libp2p-core",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.8.4",
+ "sha2 0.10.2",
+ "snow",
+ "static_assertions",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-xtra"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "asynchronous-codec",
+ "futures",
+ "libp2p-core",
+ "libp2p-noise",
+ "multistream-select",
+ "rand 0.8.4",
+ "thiserror",
+ "tokio",
+ "tokio-tasks",
+ "tracing",
+ "void",
+ "xtra",
+ "xtra_productivity",
+ "xtras",
+ "yamux",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1512,10 +1667,11 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg 1.1.0",
  "scopeguard",
 ]
 
@@ -1749,6 +1905,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c580bfdd8803cce319b047d239559a22f809094aaea4ac13902a1fdcfcd4261"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint",
+ "url",
+]
+
+[[package]]
+name = "multihash"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7392bffd88bc0c4f8297e36a777ab9f80b7127409c4a1acb8fee99c9f27addcd"
+dependencies = [
+ "core2",
+ "digest 0.10.3",
+ "multihash-derive",
+ "sha2 0.10.2",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "multistream-select"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363a84be6453a70e63513660f4894ef815daf88e3356bffcda9ca27d810ce83b"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "pin-project 1.0.8",
+ "smallvec",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,6 +2040,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,7 +2091,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -1884,7 +2111,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -1894,7 +2121,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -1905,7 +2132,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1917,7 +2144,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "libm",
 ]
 
@@ -1984,7 +2211,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -1999,6 +2236,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2063,12 +2313,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9615c18d31137579e9ff063499264ddc1278e7b1982757ebc111028c4d1dc909"
+dependencies = [
+ "pin-project-internal 0.4.29",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.0.8",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "044964427019eed9d49d9d5bbce6047ef18f37100ea400912a9fa4a3523ab12a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2178,6 +2458,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,7 +2529,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot",
+ "parking_lot 0.11.2",
  "protobuf",
  "thiserror",
 ]
@@ -2259,6 +2549,59 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_xorshift 0.3.0",
  "regex-syntax",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -2640,7 +2983,7 @@ dependencies = [
  "memchr",
  "multer",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project-lite",
  "rand 0.8.4",
  "ref-cast",
@@ -2700,7 +3043,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pear",
  "percent-encoding",
  "pin-project-lite",
@@ -2860,6 +3203,17 @@ name = "rustversion"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
+name = "rw-stream-sink"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
+dependencies = [
+ "futures",
+ "pin-project 0.4.29",
+ "static_assertions",
+]
 
 [[package]]
 name = "ryu"
@@ -3178,6 +3532,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+
+[[package]]
 name = "simba"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,6 +3585,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek 4.0.0-pre.1",
  "rand_core 0.6.3",
+ "ring",
  "rustc_version 0.4.0",
  "sha2 0.10.2",
  "subtle",
@@ -3410,6 +3771,12 @@ checksum = "87cf4f5369e6d3044b5e365c9690f451516ac8f0954084622b49ea3fde2f6de5"
 dependencies = [
  "loom 0.5.1",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
@@ -3738,14 +4105,14 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d0183f6f6001549ab68f8c7585093bb732beefbcf6d23a10b9b95c73a1dd49"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
@@ -3813,7 +4180,7 @@ checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
 dependencies = [
  "futures-util",
  "log",
- "pin-project",
+ "pin-project 1.0.8",
  "rustls 0.19.1",
  "tokio",
  "tokio-rustls 0.22.0",
@@ -4054,6 +4421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsigned-varint"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,6 +4659,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4339,6 +4723,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,6 +4813,7 @@ dependencies = [
  "log",
  "pollster",
  "prometheus",
+ "tokio",
 ]
 
 [[package]]
@@ -4434,6 +4862,20 @@ dependencies = [
  "tracing-subscriber",
  "xtra",
  "xtra_productivity",
+]
+
+[[package]]
+name = "yamux"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0608f53c1dc0bad505d03a34bbd49fbf2ad7b51eb036123e896365532745a1"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.0",
+ "rand 0.8.4",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "model",
   "btsieve",
   "bitmex-stream",
+  "libp2p-xtra",
 ]
 resolver = "2"
 

--- a/bors.toml
+++ b/bors.toml
@@ -14,6 +14,7 @@ status = [
   "clippy (xtra-bitmex-price-feed)",
   "clippy (btsieve)",
   "clippy (bitmex-stream)",
+  "clippy (libp2p-xtra)",
   "lint-commits",
   "frontend (maker)",
   "frontend (taker)",

--- a/libp2p-xtra/Cargo.toml
+++ b/libp2p-xtra/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "libp2p-xtra"
+version = "0.1.0"
+edition = "2021"
+description = "Networking with xtra made easy. Backed by libp2p-core."
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+async-trait = "0.1"
+futures = "0.3"
+libp2p-core = { version = "0.32", default-features = false }
+libp2p-noise = "0.35"
+multistream-select = "0.11"
+thiserror = "1"
+tokio = { version = "1", features = ["time"] }
+tokio-tasks = { path = "../tokio-tasks" }
+tracing = "0.1"
+void = "1"
+xtra = { version = "0.6", features = ["with-tokio-1"] }
+xtra_productivity = "0.1"
+xtras = { path = "../xtras" }
+yamux = "0.10"
+
+[dev-dependencies]
+asynchronous-codec = "0.6"
+rand = "0.8"
+tokio = { version = "1", features = ["full"] }

--- a/libp2p-xtra/src/endpoint.rs
+++ b/libp2p-xtra/src/endpoint.rs
@@ -1,0 +1,509 @@
+use crate::multiaddress_ext::MultiaddrExt as _;
+use crate::upgrade;
+use crate::Connection;
+use crate::Substream;
+use anyhow::bail;
+use anyhow::Context as _;
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::future::BoxFuture;
+use futures::stream::BoxStream;
+use futures::AsyncRead;
+use futures::AsyncWrite;
+use futures::TryStreamExt;
+use libp2p_core::identity::Keypair;
+use libp2p_core::transport::Boxed;
+use libp2p_core::transport::ListenerEvent;
+use libp2p_core::Multiaddr;
+use libp2p_core::PeerId;
+use libp2p_core::Transport;
+use multistream_select::NegotiationError;
+use multistream_select::Version;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::marker::PhantomData;
+use std::time::Duration;
+use thiserror::Error;
+use tokio_tasks::Tasks;
+use xtra::message_channel::StrongMessageChannel;
+use xtra_productivity::xtra_productivity;
+use xtras::SendAsyncSafe;
+
+/// An actor for managing multiplexed connections over a given transport thus representing an
+/// _endpoint_.
+///
+/// The actor does not impose any policy on connection and/or protocol management.
+/// New connections can be established by sending a [`Connect`] messages. Existing connections can
+/// be disconnected by sending [`Disconnect`]. Listening for incoming connections is done by sending
+/// a [`ListenOn`] message. To list the current state, send the [`GetConnectionStats`] message.
+///
+/// The combination of the above should make it possible to implement a fairly large number of
+/// policies. For example, to maintain a connection to an another endpoint, you can regularly check
+/// if the connection is still established by sending [`GetConnectionStats`] and react accordingly
+/// (f.e. sending [`Connect`] in case the connection has disappeared).
+///
+/// Once a connection with a peer is established, both sides can open substreams on top of the
+/// connection. Any incoming substream will - assuming the protocol is supported by the endpoint -
+/// trigger a [`NewInboundSubstream`] message to the actor provided in the constructor.
+/// Opening a new substream can be achieved by sending the [`OpenSubstream`] message.
+pub struct Endpoint {
+    transport: Boxed<Connection>,
+    tasks: Tasks,
+    controls: HashMap<PeerId, (yamux::Control, Tasks)>,
+    inbound_substream_channels:
+        HashMap<&'static str, Box<dyn StrongMessageChannel<NewInboundSubstream>>>,
+    listen_addresses: HashSet<Multiaddr>,
+    inflight_connections: HashSet<PeerId>,
+    connection_timeout: Duration,
+}
+
+/// Open a substream to the provided peer.
+///
+/// Fails if we are not connected to the peer or the peer does not support any of the requested
+/// protocols.
+#[derive(Debug)]
+pub struct OpenSubstream<P> {
+    peer: PeerId,
+    protocols: Vec<&'static str>,
+    marker_num_protocols: PhantomData<P>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Single {}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Multiple {}
+
+impl OpenSubstream<Single> {
+    /// Constructs [`OpenSubstream`] with a single protocol.
+    ///
+    /// We will only attempt to negotiate the given protocol. If the endpoint does not speak this
+    /// protocol, negotiation will fail.
+    pub fn single_protocol(peer: PeerId, protocol: &'static str) -> Self {
+        Self {
+            peer,
+            protocols: vec![protocol],
+            marker_num_protocols: PhantomData,
+        }
+    }
+}
+
+impl OpenSubstream<Multiple> {
+    /// Constructs [`OpenSubstream`] with multiple protocols.
+    ///
+    /// The given protocols will be tried **in order**, with the first successful one being used.
+    /// Specifying multiple protocols can useful to maintain backwards-compatibility. An endpoint
+    /// can attempt to first establish a substream with a new protocol and falling back to older
+    /// versions in case the new version is not supported.
+    pub fn multiple_protocols(peer: PeerId, protocols: Vec<&'static str>) -> Self {
+        Self {
+            peer,
+            protocols,
+            marker_num_protocols: PhantomData,
+        }
+    }
+}
+
+/// Connect to the given [`Multiaddr`].
+///
+/// The address must contain a `/p2p` suffix.
+/// Will fail if we are already connected to the peer.
+#[derive(Debug)]
+pub struct Connect(pub Multiaddr);
+
+/// Disconnect from the given peer.
+#[derive(Clone, Copy, Debug)]
+pub struct Disconnect(pub PeerId);
+
+/// Listen on the provided [`Multiaddr`].
+///
+/// For this to work, the [`Endpoint`] needs to be constructed with a compatible transport.
+/// In other words, you cannot listen on a `/memory` address if you haven't configured a `/memory`
+/// transport.
+pub struct ListenOn(pub Multiaddr);
+
+/// Retrieve [`ConnectionStats`] from the [`Endpoint`].
+#[derive(Clone, Copy, Debug)]
+pub struct GetConnectionStats;
+
+#[derive(Debug)]
+pub struct ConnectionStats {
+    pub connected_peers: HashSet<PeerId>,
+    pub listen_addresses: HashSet<Multiaddr>,
+}
+
+/// Notifies an actor of a new, inbound substream from the given peer.
+#[derive(Debug)]
+pub struct NewInboundSubstream {
+    pub peer: PeerId,
+    pub stream: Substream,
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("No connection to {0}")]
+    NoConnection(PeerId),
+    #[error("Timeout in protocol negotiation")]
+    NegotiationTimeoutReached,
+    #[error("Failed to negotiate protocol")]
+    NegotiationFailed(#[from] NegotiationError), // TODO(public-api): Consider breaking this up.
+    #[error("Bad connection")]
+    BadConnection(#[from] yamux::ConnectionError), // TODO(public-api): Consider removing this.
+    #[error("Address {0} does not end with a peer ID")]
+    NoPeerIdInAddress(Multiaddr),
+    #[error("Either currently connecting or already connected to peer {0}")]
+    AlreadyConnected(PeerId),
+}
+
+impl Endpoint {
+    /// Construct a new [`Endpoint`] from the provided transport.
+    ///
+    /// An [`Endpoint`]s identity ([`PeerId`]) will be computed from the given [`Keypair`].
+    ///
+    /// The `connection_timeout` is applied to:
+    /// 1. Connection upgrades (i.e. noise handshake, yamux upgrade, etc)
+    /// 2. Protocol negotiations
+    ///
+    /// The provided substream handlers are actors that will be given the fully-negotiated
+    /// substreams whenever a peer opens a new substream for the provided protocol.
+    pub fn new<T, const N: usize>(
+        transport: T,
+        identity: Keypair,
+        connection_timeout: Duration,
+        inbound_substream_handlers: [(
+            &'static str,
+            Box<dyn StrongMessageChannel<NewInboundSubstream>>,
+        ); N],
+    ) -> Self
+    where
+        T: Transport + Clone + Send + Sync + 'static,
+        T::Output: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        T::Error: Send + Sync,
+        T::Listener: Send + 'static,
+        T::Dial: Send + 'static,
+        T::ListenerUpgrade: Send + 'static,
+    {
+        let transport = upgrade::transport(
+            transport,
+            &identity,
+            inbound_substream_handlers
+                .iter()
+                .map(|(proto, _)| *proto)
+                .collect(),
+            connection_timeout,
+        );
+
+        Self {
+            transport,
+            tasks: Tasks::default(),
+            inbound_substream_channels: verify_unique_handlers(inbound_substream_handlers),
+            controls: HashMap::default(),
+            listen_addresses: HashSet::default(),
+            inflight_connections: HashSet::default(),
+            connection_timeout,
+        }
+    }
+
+    fn drop_connection(&mut self, peer: &PeerId) {
+        let (mut control, tasks) = match self.controls.remove(peer) {
+            None => return,
+            Some(control) => control,
+        };
+
+        // TODO: Evaluate whether dropping and closing has to be in a particular order.
+        self.tasks.add(async move {
+            let _ = control.close().await;
+            drop(tasks);
+        });
+    }
+
+    async fn open_substream(
+        &mut self,
+        peer: PeerId,
+        protocols: Vec<&'static str>,
+    ) -> Result<(&'static str, Substream), Error> {
+        let (control, _) = self
+            .controls
+            .get_mut(&peer)
+            .ok_or(Error::NoConnection(peer))?;
+
+        let stream = control.open_stream().await?;
+
+        let (protocol, stream) = tokio::time::timeout(
+            self.connection_timeout,
+            multistream_select::dialer_select_proto(stream, protocols, Version::V1),
+        )
+        .await
+        .map_err(|_timeout| Error::NegotiationTimeoutReached)?
+        .map_err(Error::NegotiationFailed)?;
+
+        Ok((protocol, stream))
+    }
+}
+
+#[xtra_productivity]
+impl Endpoint {
+    async fn handle(&mut self, msg: NewConnection, ctx: &mut xtra::Context<Self>) {
+        self.inflight_connections.remove(&msg.peer);
+        let this = ctx.address().expect("we are alive");
+
+        let NewConnection {
+            peer,
+            control,
+            mut incoming_substreams,
+            worker,
+        } = msg;
+
+        let mut tasks = Tasks::default();
+        tasks.add(worker);
+        tasks.add_fallible(
+            {
+                let inbound_substream_channels = self
+                    .inbound_substream_channels
+                    .iter()
+                    .map(|(proto, channel)| {
+                        (
+                            proto.to_owned(),
+                            StrongMessageChannel::clone_channel(channel.as_ref()),
+                        )
+                    })
+                    .collect::<HashMap<_, _>>();
+
+                async move {
+                    loop {
+                        let (stream, protocol) = match incoming_substreams.try_next().await {
+                            Ok(Some(Ok((stream, protocol)))) => (stream, protocol),
+                            Ok(Some(Err(upgrade::Error::NegotiationTimeoutReached))) => {
+                                tracing::debug!("Hit timeout while negotiating substream");
+                                continue;
+                            }
+                            Ok(Some(Err(upgrade::Error::NegotiationFailed(e)))) => {
+                                tracing::debug!("Failed to negotiate substream: {}", e);
+                                continue;
+                            }
+                            Ok(None) => bail!("Substream listener closed"),
+                            Err(e) => bail!(e),
+                        };
+
+                        let channel = inbound_substream_channels
+                            .get(&protocol)
+                            .expect("Cannot negotiate a protocol that we don't support");
+
+                        let _ = channel
+                            .send_async_safe(NewInboundSubstream { peer, stream })
+                            .await;
+                    }
+                }
+            },
+            move |error| async move {
+                let _ = this.send(ConnectionFailed { peer, error }).await;
+            },
+        );
+        self.controls.insert(peer, (control, tasks));
+    }
+
+    async fn handle(&mut self, msg: ListenerFailed) {
+        tracing::debug!("Listener failed: {:#}", msg.error);
+
+        self.listen_addresses.remove(&msg.address);
+    }
+
+    async fn handle(&mut self, msg: FailedToConnect) {
+        tracing::debug!("Failed to connect: {:#}", msg.error);
+        let peer = msg.peer;
+
+        self.inflight_connections.remove(&peer);
+        self.drop_connection(&peer);
+    }
+
+    async fn handle(&mut self, msg: ConnectionFailed) {
+        tracing::debug!("Connection failed: {:#}", msg.error);
+        let peer = msg.peer;
+
+        self.drop_connection(&peer);
+    }
+
+    async fn handle(&mut self, _: GetConnectionStats) -> ConnectionStats {
+        ConnectionStats {
+            connected_peers: self.controls.keys().copied().collect(),
+            listen_addresses: self.listen_addresses.clone(),
+        }
+    }
+
+    async fn handle(&mut self, msg: Connect, ctx: &mut xtra::Context<Self>) -> Result<(), Error> {
+        let this = ctx.address().expect("we are alive");
+
+        let peer = msg
+            .0
+            .clone()
+            .extract_peer_id()
+            .ok_or_else(|| Error::NoPeerIdInAddress(msg.0.clone()))?;
+
+        if self.inflight_connections.contains(&peer) || self.controls.contains_key(&peer) {
+            return Err(Error::AlreadyConnected(peer));
+        }
+
+        self.inflight_connections.insert(peer);
+        self.tasks.add_fallible(
+            {
+                let transport = self.transport.clone();
+                let this = this.clone();
+
+                async move {
+                    let (peer, control, incoming_substreams, worker) =
+                        transport.clone().dial(msg.0)?.await?;
+
+                    let _ = this
+                        .send_async_safe(NewConnection {
+                            peer,
+                            control,
+                            incoming_substreams,
+                            worker,
+                        })
+                        .await;
+
+                    anyhow::Ok(())
+                }
+            },
+            move |error| async move {
+                let _ = this.send(FailedToConnect { peer, error }).await;
+            },
+        );
+
+        Ok(())
+    }
+
+    async fn handle(&mut self, msg: Disconnect) {
+        self.drop_connection(&msg.0);
+    }
+
+    async fn handle(&mut self, msg: ListenOn, ctx: &mut xtra::Context<Self>) {
+        let this = ctx.address().expect("we are alive");
+        let listen_address = msg.0.clone();
+
+        self.listen_addresses.insert(listen_address.clone()); // FIXME: This address could be a "catch-all" like "0.0.0.0" which actually results in
+                                                              // listening on multiple interfaces.
+        self.tasks.add_fallible(
+            {
+                let transport = self.transport.clone();
+                let this = this.clone();
+
+                async move {
+                    let mut stream = transport.listen_on(msg.0)?;
+
+                    loop {
+                        let event = stream.try_next().await?.context("Listener closed")?;
+                        let (peer, control, incoming_substreams, worker) = match event {
+                            ListenerEvent::Upgrade { upgrade, .. } => upgrade.await?,
+                            _ => continue,
+                        };
+
+                        this.send_async_safe(NewConnection {
+                            peer,
+                            control,
+                            incoming_substreams,
+                            worker,
+                        })
+                        .await?;
+                    }
+                }
+            },
+            |error| async move {
+                let _ = this
+                    .send(ListenerFailed {
+                        address: listen_address,
+                        error,
+                    })
+                    .await;
+            },
+        );
+    }
+
+    async fn handle(&mut self, msg: OpenSubstream<Single>) -> Result<Substream, Error> {
+        let peer = msg.peer;
+        let protocols = msg.protocols;
+
+        debug_assert!(
+            protocols.len() == 1,
+            "Type-system enforces that we only try to negotiate one protocol"
+        );
+
+        let (protocol, stream) = self.open_substream(peer, protocols.clone()).await?;
+
+        debug_assert!(
+            protocol == protocols[0],
+            "If negotiation is successful, must have selected the only protocol we sent."
+        );
+
+        Ok(stream)
+    }
+
+    async fn handle(
+        &mut self,
+        msg: OpenSubstream<Multiple>,
+    ) -> Result<(&'static str, Substream), Error> {
+        let peer = msg.peer;
+        let protocols = msg.protocols;
+
+        let (protocol, stream) = self.open_substream(peer, protocols).await?;
+
+        Ok((protocol, stream))
+    }
+}
+
+fn verify_unique_handlers<const N: usize>(
+    inbound_substream_handlers: [(&str, Box<dyn StrongMessageChannel<NewInboundSubstream>>); N],
+) -> HashMap<&str, Box<dyn StrongMessageChannel<NewInboundSubstream>>> {
+    let mut map = HashMap::with_capacity(inbound_substream_handlers.len());
+
+    for (protocol, handler) in inbound_substream_handlers {
+        let previous_handler = map.insert(protocol, handler);
+
+        debug_assert!(
+            previous_handler.is_none(),
+            "Duplicate handler declared for protocol {protocol}"
+        );
+    }
+
+    map
+}
+
+#[async_trait]
+impl xtra::Actor for Endpoint {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+#[derive(Debug)]
+struct ListenerFailed {
+    address: Multiaddr,
+    error: anyhow::Error,
+}
+
+#[derive(Debug)]
+struct FailedToConnect {
+    peer: PeerId,
+    error: anyhow::Error,
+}
+
+#[derive(Debug)]
+struct ConnectionFailed {
+    peer: PeerId,
+    error: anyhow::Error,
+}
+
+struct NewConnection {
+    peer: PeerId,
+    control: yamux::Control,
+    #[allow(clippy::type_complexity)]
+    incoming_substreams: BoxStream<
+        'static,
+        Result<Result<(Substream, &'static str), upgrade::Error>, yamux::ConnectionError>,
+    >,
+    worker: BoxFuture<'static, ()>,
+}
+
+impl xtra::Message for NewInboundSubstream {
+    type Result = ();
+}

--- a/libp2p-xtra/src/lib.rs
+++ b/libp2p-xtra/src/lib.rs
@@ -1,0 +1,35 @@
+pub use crate::endpoint::Connect;
+pub use crate::endpoint::ConnectionStats;
+pub use crate::endpoint::Disconnect;
+pub use crate::endpoint::Endpoint;
+pub use crate::endpoint::Error;
+pub use crate::endpoint::GetConnectionStats;
+pub use crate::endpoint::ListenOn;
+pub use crate::endpoint::Multiple;
+pub use crate::endpoint::NewInboundSubstream;
+pub use crate::endpoint::OpenSubstream;
+pub use crate::endpoint::Single;
+pub use libp2p_core as libp2p;
+pub use multistream_select::NegotiationError;
+
+pub type Substream = Negotiated<yamux::Stream>;
+
+use futures::future::BoxFuture;
+use futures::stream::BoxStream;
+use libp2p_core::Negotiated;
+use libp2p_core::PeerId;
+
+mod endpoint;
+mod multiaddress_ext;
+mod upgrade;
+mod verify_peer_id;
+
+type Connection = (
+    PeerId,
+    yamux::Control,
+    BoxStream<
+        'static,
+        Result<Result<(Substream, &'static str), upgrade::Error>, yamux::ConnectionError>,
+    >,
+    BoxFuture<'static, ()>,
+);

--- a/libp2p-xtra/src/multiaddress_ext.rs
+++ b/libp2p-xtra/src/multiaddress_ext.rs
@@ -1,0 +1,18 @@
+use libp2p_core::multiaddr::Protocol;
+use libp2p_core::Multiaddr;
+use libp2p_core::PeerId;
+
+pub trait MultiaddrExt {
+    fn extract_peer_id(self) -> Option<PeerId>;
+}
+
+impl MultiaddrExt for Multiaddr {
+    fn extract_peer_id(mut self) -> Option<PeerId> {
+        let peer_id = match self.pop()? {
+            Protocol::P2p(hash) => PeerId::from_multihash(hash).ok()?,
+            _ => return None,
+        };
+
+        Some(peer_id)
+    }
+}

--- a/libp2p-xtra/src/upgrade.rs
+++ b/libp2p-xtra/src/upgrade.rs
@@ -1,0 +1,152 @@
+use crate::verify_peer_id::VerifyPeerId;
+use crate::Connection;
+use futures::channel::mpsc;
+use futures::future;
+use futures::AsyncRead;
+use futures::AsyncWrite;
+use futures::FutureExt;
+use futures::SinkExt;
+use futures::StreamExt;
+use libp2p_core::identity::Keypair;
+use libp2p_core::transport::timeout::TransportTimeout;
+use libp2p_core::transport::Boxed;
+use libp2p_core::upgrade;
+use libp2p_core::upgrade::Version;
+use libp2p_core::Endpoint;
+use libp2p_core::Transport;
+use libp2p_noise as noise;
+use multistream_select::NegotiationError;
+use std::time::Duration;
+use void::Void;
+use yamux::Mode;
+
+/// Upgrades the given [`Transport`].
+///
+/// We apply:
+/// - Noise encryption and authentication
+/// - PeerID verification for each connection
+/// - Yamux multiplexing
+/// - Connection upgrade timeout
+pub fn transport<T>(
+    transport: T,
+    identity: &Keypair,
+    supported_inbound_protocols: Vec<&'static str>,
+    connection_timeout: Duration,
+) -> Boxed<Connection>
+where
+    T: Transport + Clone + Send + Sync + 'static,
+    T::Output: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    T::Error: Send + Sync,
+    T::Listener: Send + 'static,
+    T::Dial: Send + 'static,
+    T::ListenerUpgrade: Send + 'static,
+{
+    let identity = noise::Keypair::<noise::X25519Spec>::new()
+        .into_authentic(identity)
+        .expect("ed25519 signing does not fail");
+
+    let authenticated = transport.and_then(|conn, endpoint| {
+        upgrade::apply(
+            conn,
+            noise::NoiseConfig::xx(identity).into_authenticated(),
+            endpoint,
+            Version::V1,
+        )
+    });
+
+    let peer_id_verified = VerifyPeerId::new(authenticated);
+
+    let multiplexed = peer_id_verified.and_then(|(peer_id, conn), endpoint| {
+        upgrade::apply(
+            conn,
+            upgrade::from_fn::<_, _, _, _, _, Void>(
+                b"/yamux/1.0.0",
+                move |conn, endpoint| async move {
+                    Ok(match endpoint {
+                        Endpoint::Dialer => (
+                            peer_id,
+                            yamux::Connection::new(conn, yamux::Config::default(), Mode::Client),
+                        ),
+                        Endpoint::Listener => (
+                            peer_id,
+                            yamux::Connection::new(conn, yamux::Config::default(), Mode::Server),
+                        ),
+                    })
+                },
+            ),
+            endpoint,
+            Version::V1,
+        )
+    });
+
+    let protocols_negotiated = multiplexed.map(move |(peer, mut connection), _| {
+        let control = connection.control();
+
+        let (mut sender, receiver) = mpsc::channel(5); // Use a bounded channel to allow caller to exercise back-pressure.
+
+        let worker = async move {
+            while let Ok(Some(stream)) = connection.next_stream().await {
+                match future::poll_fn(|cx| sender.poll_ready(cx)).await {
+                    Ok(()) => {}
+                    Err(e) => {
+                        if e.is_disconnected() {
+                            break; // Consumer is no longer interested
+                        }
+
+                        debug_assert!(
+                            !e.is_full(),
+                            "We checked that there is space in the queue with `poll_ready`"
+                        )
+                    }
+                }
+
+                match sender.send(stream).await {
+                    Ok(()) => {}
+                    Err(e) => {
+                        if e.is_disconnected() {
+                            break; // Consumer is no longer interested
+                        }
+
+                        debug_assert!(
+                            !e.is_full(),
+                            "We checked that there is space in the queue with `poll_ready`"
+                        )
+                    }
+                }
+            }
+        }
+        .boxed();
+
+        let incoming = receiver
+            .then(move |stream| {
+                let supported_protocols = supported_inbound_protocols.clone();
+
+                async move {
+                    let result = tokio::time::timeout(
+                        connection_timeout,
+                        multistream_select::listener_select_proto(stream, &supported_protocols),
+                    )
+                    .await;
+
+                    match result {
+                        Ok(Ok((protocol, stream))) => Ok(Ok((stream, *protocol))),
+                        Ok(Err(e)) => Ok(Err(Error::NegotiationFailed(e))),
+                        Err(_timeout) => Ok(Err(Error::NegotiationTimeoutReached)),
+                    }
+                }
+            })
+            .boxed();
+
+        (peer, control, incoming, worker)
+    });
+
+    TransportTimeout::new(protocols_negotiated, connection_timeout).boxed()
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Timeout in protocol negotiation")]
+    NegotiationTimeoutReached,
+    #[error("Failed to negotiate protocol")]
+    NegotiationFailed(#[from] NegotiationError),
+}

--- a/libp2p-xtra/src/verify_peer_id.rs
+++ b/libp2p-xtra/src/verify_peer_id.rs
@@ -1,0 +1,208 @@
+use crate::multiaddress_ext::MultiaddrExt;
+use futures::future::BoxFuture;
+use futures::stream::BoxStream;
+use futures::FutureExt;
+use futures::StreamExt;
+use futures::TryFutureExt;
+use futures::TryStreamExt;
+use libp2p_core::transport::ListenerEvent;
+use libp2p_core::transport::TransportError;
+use libp2p_core::Multiaddr;
+use libp2p_core::PeerId;
+use libp2p_core::Transport;
+use std::fmt;
+use std::fmt::Debug;
+
+/// A [`Transport`] wrapper that ensures we only connect to the expected peer.
+///
+/// Multi-addresses can contain a `/p2p` segment that specifies, which peer we want to connect to,
+/// for example: `/memory/10000/p2p/12D3KooWSLdEVWR1rjrnimdX3KwTvRT8uxNs8q7keREr6MsuizJ7`
+/// However, the `/p2p` part is not actually necessary to establish the physical connection. As
+/// such, it can happen that a different peer sits at the end of an address like `/memory/10000`.
+/// `libp2p-core` does not prevent this situation from happening. It is the responsibility of the
+/// caller of [`Transport::dial`] to verify that we connected to the expected peer.
+///
+/// [`VerifyPeerId`] is a wrapper around [`Transport`] that performs this check for you. As a
+/// trade-off, it does not allow "blind" connections to peers, i.e.: connecting to a multi-address
+/// without a `/p2p` segment.
+#[derive(Clone)]
+pub struct VerifyPeerId<TInner> {
+    inner: TInner,
+}
+
+impl<TInner> VerifyPeerId<TInner> {
+    pub fn new(inner: TInner) -> Self {
+        Self { inner }
+    }
+}
+
+impl<TInner, C> Transport for VerifyPeerId<TInner>
+where
+    TInner: Transport<Output = (PeerId, C)> + 'static,
+    TInner::Dial: Send + 'static,
+    TInner::Listener: Send + 'static,
+    TInner::ListenerUpgrade: Send + 'static,
+    TInner::Error: 'static,
+    C: 'static,
+{
+    type Output = TInner::Output;
+    type Error = Error<TInner::Error>;
+    #[allow(clippy::type_complexity)]
+    type Listener =
+        BoxStream<'static, Result<ListenerEvent<Self::ListenerUpgrade, Self::Error>, Self::Error>>;
+    type ListenerUpgrade = BoxFuture<'static, Result<Self::Output, Self::Error>>;
+    type Dial = BoxFuture<'static, Result<Self::Output, Self::Error>>;
+
+    fn listen_on(self, addr: Multiaddr) -> Result<Self::Listener, TransportError<Self::Error>>
+    where
+        Self: Sized,
+    {
+        let listener = self
+            .inner
+            .listen_on(addr)
+            .map_err(|e| e.map(Error::Inner))?
+            .map_err(Error::Inner)
+            .map_ok(|e| {
+                e.map(|u| u.map_err(Error::Inner).boxed())
+                    .map_err(Error::Inner)
+            })
+            .boxed();
+
+        Ok(listener)
+    }
+
+    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>>
+    where
+        Self: Sized,
+    {
+        let expected_peer_id = addr
+            .clone()
+            .extract_peer_id()
+            .ok_or(TransportError::Other(Error::NoPeerId))?;
+
+        let dial = self.inner.dial(addr).map_err(|e| e.map(Error::Inner))?;
+
+        Ok(dial_and_verify_peer_id::<TInner, C>(dial, expected_peer_id).boxed())
+    }
+
+    fn dial_as_listener(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>>
+    where
+        Self: Sized,
+    {
+        let expected_peer_id = addr
+            .clone()
+            .extract_peer_id()
+            .ok_or(TransportError::Other(Error::NoPeerId))?;
+        let dial = self
+            .inner
+            .dial_as_listener(addr)
+            .map_err(|e| e.map(Error::Inner))?;
+
+        Ok(dial_and_verify_peer_id::<TInner, C>(dial, expected_peer_id).boxed())
+    }
+
+    fn address_translation(&self, listen: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
+        self.inner.address_translation(listen, observed)
+    }
+}
+
+async fn dial_and_verify_peer_id<T, C>(
+    dial: T::Dial,
+    expected_peer_id: PeerId,
+) -> Result<(PeerId, C), Error<T::Error>>
+where
+    T: Transport<Output = (PeerId, C)>,
+{
+    let (actual_peer_id, conn) = dial.await.map_err(Error::Inner)?;
+
+    if expected_peer_id != actual_peer_id {
+        return Err(Error::PeerIdMismatch {
+            actual: actual_peer_id,
+            expected: expected_peer_id,
+        });
+    }
+
+    Ok((actual_peer_id, conn))
+}
+
+#[derive(Debug)]
+pub enum Error<T> {
+    PeerIdMismatch { expected: PeerId, actual: PeerId },
+    NoPeerId,
+    Inner(T),
+}
+
+impl<T: fmt::Display> fmt::Display for Error<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::PeerIdMismatch { actual, expected } => {
+                write!(f, "Peer ID mismatch, expected {expected} but got {actual}")
+            }
+            Error::Inner(_) => Ok(()),
+            Error::NoPeerId => write!(f, "The given address does not contain a peer ID"),
+        }
+    }
+}
+
+impl<T> std::error::Error for Error<T>
+where
+    T: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::PeerIdMismatch { .. } => None,
+            Error::NoPeerId => None,
+            Error::Inner(inner) => Some(inner),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p_core::transport::memory::Channel;
+    use libp2p_core::transport::MemoryTransport;
+    use libp2p_core::ConnectedPoint;
+
+    #[test]
+    fn rejects_address_without_peer_id() {
+        let transport = VerifyPeerId::new(MemoryTransport::default().map(simulate_auth_upgrade));
+
+        let result = transport.dial("/memory/10000".parse().unwrap());
+
+        assert!(matches!(
+            result,
+            Err(TransportError::Other(Error::NoPeerId))
+        ))
+    }
+
+    #[tokio::test]
+    async fn fails_dial_with_unexpected_peer_id() {
+        let _alice = MemoryTransport::default()
+            .map(simulate_auth_upgrade)
+            .listen_on("/memory/10000".parse().unwrap())
+            .unwrap();
+        let bob = VerifyPeerId::new(MemoryTransport::default().map(simulate_auth_upgrade));
+
+        let result = bob
+            .dial(
+                // Hardcoded PeerId will unlikely be equal to random one that is simulated in auth
+                // upgrade.
+                "/memory/10000/p2p/12D3KooWSLdEVWR1rjrnimdX3KwTvRT8uxNs8q7keREr6MsuizJ7"
+                    .parse()
+                    .unwrap(),
+            )
+            .unwrap()
+            .await;
+
+        assert!(matches!(result, Err(Error::PeerIdMismatch { .. })))
+    }
+
+    // Mapping function for simulating an authentication upgrade in a transport.
+    fn simulate_auth_upgrade(
+        conn: Channel<Vec<u8>>,
+        _: ConnectedPoint,
+    ) -> (PeerId, Channel<Vec<u8>>) {
+        (PeerId::random(), conn)
+    }
+}

--- a/libp2p-xtra/tests/basic.rs
+++ b/libp2p-xtra/tests/basic.rs
@@ -1,0 +1,282 @@
+use anyhow::Context as _;
+use anyhow::Result;
+use async_trait::async_trait;
+use asynchronous_codec::Bytes;
+use futures::SinkExt;
+use futures::StreamExt;
+use libp2p_core::multiaddr::Protocol;
+use libp2p_core::Multiaddr;
+use libp2p_xtra::libp2p::identity::Keypair;
+use libp2p_xtra::libp2p::transport::MemoryTransport;
+use libp2p_xtra::libp2p::PeerId;
+use libp2p_xtra::Connect;
+use libp2p_xtra::Disconnect;
+use libp2p_xtra::Endpoint;
+use libp2p_xtra::GetConnectionStats;
+use libp2p_xtra::ListenOn;
+use libp2p_xtra::NewInboundSubstream;
+use libp2p_xtra::OpenSubstream;
+use std::collections::HashSet;
+use std::time::Duration;
+use tokio_tasks::Tasks;
+use xtra::message_channel::StrongMessageChannel;
+use xtra::spawn::TokioGlobalSpawnExt;
+use xtra::Actor;
+use xtra::Address;
+use xtra_productivity::xtra_productivity;
+
+#[tokio::test]
+async fn hello_world() {
+    let alice_hello_world_handler = HelloWorld::default().create(None).spawn_global();
+    let (alice_peer_id, _, _alice, bob, _) = alice_and_bob(
+        [(
+            "/hello-world/1.0.0",
+            alice_hello_world_handler.clone_channel(),
+        )],
+        [],
+    )
+    .await;
+
+    let bob_to_alice = bob
+        .send(OpenSubstream::single_protocol(
+            alice_peer_id,
+            "/hello-world/1.0.0",
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+
+    let string = hello_world_dialer(bob_to_alice, "Bob").await.unwrap();
+
+    assert_eq!(string, "Hello Bob!");
+}
+
+#[tokio::test]
+async fn after_connect_see_each_other_as_connected() {
+    let (alice_peer_id, bob_peer_id, alice, bob, _) = alice_and_bob([], []).await;
+
+    let alice_stats = alice.send(GetConnectionStats).await.unwrap();
+    let bob_stats = bob.send(GetConnectionStats).await.unwrap();
+
+    assert_eq!(alice_stats.connected_peers, HashSet::from([bob_peer_id]));
+    assert_eq!(bob_stats.connected_peers, HashSet::from([alice_peer_id]));
+}
+
+#[tokio::test]
+async fn disconnect_is_reflected_in_stats() {
+    let (_, bob_peer_id, alice, bob, _) = alice_and_bob([], []).await;
+
+    alice.send(Disconnect(bob_peer_id)).await.unwrap();
+
+    let alice_stats = alice.send(GetConnectionStats).await.unwrap();
+    let bob_stats = bob.send(GetConnectionStats).await.unwrap();
+
+    assert_eq!(alice_stats.connected_peers, HashSet::from([]));
+    assert_eq!(bob_stats.connected_peers, HashSet::from([]));
+}
+
+#[tokio::test]
+async fn cannot_open_substream_for_unhandled_protocol() {
+    let (_, bob_peer_id, alice, _bob, _) = alice_and_bob([], []).await;
+
+    let error = alice
+        .send(OpenSubstream::single_protocol(
+            bob_peer_id,
+            "/foo/bar/1.0.0",
+        ))
+        .await
+        .unwrap()
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        libp2p_xtra::Error::NegotiationFailed(libp2p_xtra::NegotiationError::Failed)
+    ))
+}
+
+#[tokio::test]
+async fn cannot_connect_twice() {
+    let (alice_peer_id, _bob_peer_id, _alice, bob, alice_listen) = alice_and_bob([], []).await;
+
+    let error = bob
+        .send(Connect(
+            alice_listen.with(Protocol::P2p(alice_peer_id.into())),
+        ))
+        .await
+        .unwrap()
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        libp2p_xtra::Error::AlreadyConnected(twin) if twin == alice_peer_id
+    ))
+}
+
+#[tokio::test]
+async fn chooses_first_protocol_in_list_of_multiple() {
+    let alice_hello_world_handler = HelloWorld::default().create(None).spawn_global();
+    let (alice_peer_id, _, _alice, bob, _) = alice_and_bob(
+        [(
+            "/hello-world/1.0.0",
+            alice_hello_world_handler.clone_channel(),
+        )],
+        [],
+    )
+    .await;
+
+    let (actual_protocol, _) = bob
+        .send(OpenSubstream::multiple_protocols(
+            alice_peer_id,
+            vec![
+                "/hello-world/1.0.0",
+                "/foo-bar/1.0.0", // This is unsupported by Alice.
+            ],
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(actual_protocol, "/hello-world/1.0.0");
+}
+
+#[cfg_attr(debug_assertions, tokio::test)] // The assertion for duplicate handlers only runs in debug mode.
+#[should_panic(expected = "Duplicate handler declared for protocol /hello-world/1.0.0")]
+async fn disallow_duplicate_handlers() {
+    let hello_world_handler = HelloWorld::default().create(None).spawn_global();
+
+    make_endpoint([
+        ("/hello-world/1.0.0", hello_world_handler.clone_channel()),
+        ("/hello-world/1.0.0", hello_world_handler.clone_channel()),
+    ]);
+}
+
+#[tokio::test]
+async fn falls_back_to_next_protocol_if_unsupported() {
+    let alice_hello_world_handler = HelloWorld::default().create(None).spawn_global();
+    let (alice_peer_id, _, _alice, bob, _) = alice_and_bob(
+        [(
+            "/hello-world/1.0.0",
+            alice_hello_world_handler.clone_channel(),
+        )],
+        [],
+    )
+    .await;
+
+    let (actual_protocol, _) = bob
+        .send(OpenSubstream::multiple_protocols(
+            alice_peer_id,
+            vec![
+                "/foo-bar/1.0.0", // This is unsupported by Alice.
+                "/hello-world/1.0.0",
+            ],
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(actual_protocol, "/hello-world/1.0.0");
+}
+
+async fn alice_and_bob<const AN: usize, const BN: usize>(
+    alice_inbound_substream_handlers: [(
+        &'static str,
+        Box<dyn StrongMessageChannel<NewInboundSubstream>>,
+    ); AN],
+    bob_inbound_substream_handlers: [(
+        &'static str,
+        Box<dyn StrongMessageChannel<NewInboundSubstream>>,
+    ); BN],
+) -> (
+    PeerId,
+    PeerId,
+    Address<Endpoint>,
+    Address<Endpoint>,
+    Multiaddr,
+) {
+    let port = rand::random::<u16>();
+
+    let (alice_peer_id, alice) = make_endpoint(alice_inbound_substream_handlers);
+    let (bob_peer_id, bob) = make_endpoint(bob_inbound_substream_handlers);
+
+    let alice_listen = format!("/memory/{port}").parse::<Multiaddr>().unwrap();
+
+    alice.send(ListenOn(alice_listen.clone())).await.unwrap();
+
+    bob.send(Connect(
+        format!("/memory/{port}/p2p/{alice_peer_id}")
+            .parse()
+            .unwrap(),
+    ))
+    .await
+    .unwrap()
+    .unwrap();
+
+    (alice_peer_id, bob_peer_id, alice, bob, alice_listen)
+}
+
+fn make_endpoint<const N: usize>(
+    substream_handlers: [(
+        &'static str,
+        Box<dyn StrongMessageChannel<NewInboundSubstream>>,
+    ); N],
+) -> (PeerId, Address<Endpoint>) {
+    let id = Keypair::generate_ed25519();
+    let peer_id = id.public().to_peer_id();
+
+    let endpoint = Endpoint::new(
+        MemoryTransport::default(),
+        id,
+        Duration::from_secs(20),
+        substream_handlers,
+    )
+    .create(None)
+    .spawn_global();
+
+    (peer_id, endpoint)
+}
+
+#[derive(Default)]
+struct HelloWorld {
+    tasks: Tasks,
+}
+
+#[xtra_productivity(message_impl = false)]
+impl HelloWorld {
+    async fn handle(&mut self, msg: NewInboundSubstream) {
+        tracing::info!("New hello world stream from {}", msg.peer);
+
+        self.tasks
+            .add_fallible(hello_world_listener(msg.stream), move |e| async move {
+                tracing::warn!("Hello world protocol with peer {} failed: {}", msg.peer, e);
+            });
+    }
+}
+
+#[async_trait]
+impl Actor for HelloWorld {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+async fn hello_world_dialer(stream: libp2p_xtra::Substream, name: &'static str) -> Result<String> {
+    let mut stream = asynchronous_codec::Framed::new(stream, asynchronous_codec::LengthCodec);
+
+    stream.send(Bytes::from(name)).await?;
+    let bytes = stream.next().await.context("Expected message")??;
+    let message = String::from_utf8(bytes.to_vec())?;
+
+    Ok(message)
+}
+
+async fn hello_world_listener(stream: libp2p_xtra::Substream) -> Result<()> {
+    let mut stream =
+        asynchronous_codec::Framed::new(stream, asynchronous_codec::LengthCodec).fuse();
+
+    let bytes = stream.select_next_some().await?;
+    let name = String::from_utf8(bytes.to_vec())?;
+
+    stream.send(Bytes::from(format!("Hello {name}!"))).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This crate provides a single actor called `Endpoint` which implements a
simple, yet powerful abstraction for managing network connections. Built
on top of libp2p-core, every connection is fully encrypted and
authenticated with noise and multiplexed with yamux.

Closes #45. (Still needs to be adopted but the base work is done.)

The code has been written and tested in isolation and I think it is ready for (temporary) inclusion here. Once we've adopted it for the network layer and found it sufficiently mature enough, we should extract it into its own repository again!