### PR TITLE
Tighten maker /offer API

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -251,10 +251,10 @@ impl Maker {
                 price_short,
                 min_quantity,
                 max_quantity,
-                Some(tx_fee_rate),
-                Some(funding_rate_long),
-                Some(funding_rate_short),
-                Some(opening_fee),
+                tx_fee_rate,
+                funding_rate_long,
+                funding_rate_short,
+                opening_fee,
             )
             .await
             .unwrap();

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -173,10 +173,10 @@ where
         price_short: Option<Price>,
         min_quantity: Usd,
         max_quantity: Usd,
-        fee_rate: Option<TxFeeRate>,
-        funding_rate_long: Option<FundingRate>,
-        funding_rate_short: Option<FundingRate>,
-        opening_fee: Option<OpeningFee>,
+        tx_fee_rate: TxFeeRate,
+        funding_rate_long: FundingRate,
+        funding_rate_short: FundingRate,
+        opening_fee: OpeningFee,
     ) -> Result<()> {
         self.cfd_actor
             .send(maker_cfd::OfferParams {
@@ -184,10 +184,10 @@ where
                 price_short,
                 min_quantity,
                 max_quantity,
-                tx_fee_rate: fee_rate.unwrap_or_default(),
-                funding_rate_long: funding_rate_long.unwrap_or_default(),
-                funding_rate_short: funding_rate_short.unwrap_or_default(),
-                opening_fee: opening_fee.unwrap_or_default(),
+                tx_fee_rate,
+                funding_rate_long,
+                funding_rate_short,
+                opening_fee,
             })
             .await??;
 

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -134,10 +134,10 @@ pub async fn post_sell_order(
             Some(offer_params.price_short),
             offer_params.min_quantity,
             offer_params.max_quantity,
-            offer_params.tx_fee_rate,
-            offer_params.daily_funding_rate_long,
-            offer_params.daily_funding_rate_short,
-            offer_params.opening_fee,
+            offer_params.tx_fee_rate.unwrap_or_default(),
+            offer_params.daily_funding_rate_long.unwrap_or_default(),
+            offer_params.daily_funding_rate_short.unwrap_or_default(),
+            offer_params.opening_fee.unwrap_or_default(),
         )
         .await
         .map_err(|e| {
@@ -156,14 +156,14 @@ pub struct CfdNewOfferParamsRequest {
     pub price_short: Option<Price>,
     pub min_quantity: Usd,
     pub max_quantity: Usd,
-    pub tx_fee_rate: Option<TxFeeRate>,
     /// The current _daily_ funding rate for the maker's long position
-    pub daily_funding_rate_long: Option<FundingRate>,
+    pub daily_funding_rate_long: FundingRate,
     /// The current _daily_ funding rate for the maker's short position
-    pub daily_funding_rate_short: Option<FundingRate>,
+    pub daily_funding_rate_short: FundingRate,
+    pub tx_fee_rate: TxFeeRate,
     // TODO: This is not inline with other parts of the API! We should not expose internal types
     // here. We have to specify sats for here because of that.
-    pub opening_fee: Option<OpeningFee>,
+    pub opening_fee: OpeningFee,
 }
 
 #[rocket::put("/offer", data = "<offer_params>")]


### PR DESCRIPTION
These fields were optional for backwards compatibility. With new endpoint, they
could be set explicitly from the beginning.

This prevents us from accidentally not charging funding rate when taker goes
short (an optional field on the old /order/sell endpoint).