### PR TITLE
Update maia after introduction of long-short terminology

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "maia"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/maia#896d49ee340fc57f0ae441b979abf8aa45249085"
+source = "git+https://github.com/comit-network/maia?branch=the-long-and-short-of-it#1b095c9d0f2f5b97a414597a7628598898d451e5"
 dependencies = [
  "anyhow",
  "bdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ resolver = "2"
 
 [patch.crates-io]
 xtra = { git = "https://github.com/comit-network/xtra" } # We need to use unreleased patches.
-maia = { git = "https://github.com/comit-network/maia" } # Unreleased
+maia = { git = "https://github.com/comit-network/maia", branch = "the-long-and-short-of-it" } # Unreleased
 xtra_productivity = { git = "https://github.com/comit-network/xtra-productivity" } # Unreleased

--- a/daemon/src/collab_settlement_taker.rs
+++ b/daemon/src/collab_settlement_taker.rs
@@ -67,8 +67,8 @@ impl Actor {
         self.connection
             .send(connection::ProposeSettlement {
                 timestamp: proposal.timestamp,
-                taker: proposal.taker,
-                maker: proposal.maker,
+                long: proposal.long,
+                short: proposal.short,
                 price: proposal.price,
                 address: this,
                 order_id: self.order_id,

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -209,8 +209,8 @@ pub struct TakeOrder {
 pub struct ProposeSettlement {
     pub order_id: OrderId,
     pub timestamp: Timestamp,
-    pub taker: Amount,
-    pub maker: Amount,
+    pub long: Amount,
+    pub short: Amount,
     pub price: Price,
     pub address: xtra::Address<collab_settlement_taker::Actor>,
 }
@@ -272,8 +272,8 @@ impl Actor {
         let ProposeSettlement {
             order_id,
             timestamp,
-            taker,
-            maker,
+            long,
+            short,
             price,
             address,
         } = msg;
@@ -283,8 +283,8 @@ impl Actor {
                 order_id,
                 msg: wire::taker_to_maker::Settlement::Propose {
                     timestamp,
-                    taker,
-                    maker,
+                    long,
+                    short,
                     price,
                 },
             })

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -633,8 +633,8 @@ where
                 msg:
                     wire::taker_to_maker::Settlement::Propose {
                         timestamp,
-                        taker,
-                        maker,
+                        long,
+                        short,
                         price,
                     },
             } => {
@@ -644,8 +644,8 @@ where
                         SettlementProposal {
                             order_id,
                             timestamp,
-                            taker,
-                            maker,
+                            long,
+                            short,
                             price,
                         },
                     )

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -442,6 +442,9 @@ enum Event {
 
 impl MonitorParams {
     pub fn new(dlc: Dlc) -> Self {
+        // this is used for the refund transaction, and we can assume
+        // that both addresses will be present since both parties
+        // should have put up coins
         let script_pubkey = dlc.maker_address.script_pubkey();
         MonitorParams {
             lock: (dlc.lock.0.txid(), dlc.lock.1),

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -445,7 +445,7 @@ impl MonitorParams {
         // this is used for the refund transaction, and we can assume
         // that both addresses will be present since both parties
         // should have put up coins
-        let script_pubkey = dlc.maker_address.script_pubkey();
+        let script_pubkey = dlc.address.script_pubkey();
         MonitorParams {
             lock: (dlc.lock.0.txid(), dlc.lock.1),
             commit: (dlc.commit.0.txid(), dlc.commit.2),

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -231,7 +231,7 @@ impl Aggregated {
         }
     }
 
-    fn payout(self, role: Role) -> Option<Amount> {
+    fn payout(self) -> Option<Amount> {
         if let Some((tx, script)) = self.collab_settlement_tx {
             return Some(extract_payout_amount(tx, script));
         }
@@ -241,7 +241,7 @@ impl Aggregated {
             .latest_dlc
             .as_ref()
             .expect("dlc to be present when we have a cet");
-        let script = dlc.script_pubkey_for(role);
+        let script = dlc.script_pubkey();
 
         Some(extract_payout_amount(tx, script))
     }
@@ -531,7 +531,7 @@ impl Cfd {
 
     fn with_current_quote(self, latest_quote: Option<xtra_bitmex_price_feed::Quote>) -> Self {
         // If we have a dedicated closing price, use that one.
-        if let Some(payout) = self.aggregated.clone().payout(self.role) {
+        if let Some(payout) = self.aggregated.clone().payout() {
             let payout = payout
                 .to_signed()
                 .expect("Amount to fit into signed amount");
@@ -693,7 +693,7 @@ impl Cfd {
 
         let url = TxUrl::from_transaction(
             &dlc.refund.0,
-            &dlc.script_pubkey_for(self.role),
+            &dlc.script_pubkey(),
             network,
             TxLabel::Refund,
         );
@@ -705,8 +705,7 @@ impl Cfd {
         let tx = self.aggregated.cet.as_ref()?;
         let dlc = self.aggregated.latest_dlc.as_ref()?;
 
-        let url =
-            TxUrl::from_transaction(tx, &dlc.script_pubkey_for(self.role), network, TxLabel::Cet);
+        let url = TxUrl::from_transaction(tx, &dlc.script_pubkey(), network, TxLabel::Cet);
 
         Some(url)
     }

--- a/daemon/src/rollover_maker.rs
+++ b/daemon/src/rollover_maker.rs
@@ -16,7 +16,6 @@ use model::FundingFee;
 use model::FundingRate;
 use model::Identity;
 use model::OrderId;
-use model::Role;
 use model::TxFeeRate;
 use tokio_tasks::Tasks;
 use xtra::prelude::MessageChannel;
@@ -196,7 +195,6 @@ impl Actor {
             receiver,
             (self.oracle_pk, announcement),
             rollover_params,
-            Role::Maker,
             dlc,
             self.n_payouts,
         );

--- a/daemon/src/rollover_taker.rs
+++ b/daemon/src/rollover_taker.rs
@@ -18,7 +18,6 @@ use model::Dlc;
 use model::FundingFee;
 use model::FundingRate;
 use model::OrderId;
-use model::Role;
 use model::Timestamp;
 use model::TxFeeRate;
 use std::time::Duration;
@@ -127,7 +126,6 @@ impl Actor {
             receiver,
             (self.oracle_pk, announcement),
             rollover_params,
-            Role::Taker,
             dlc,
             self.n_payouts,
         );

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -44,6 +44,7 @@ use model::olivia;
 use model::Cet;
 use model::Dlc;
 use model::Leverage;
+use model::Position;
 use model::RevokedCommit;
 use model::Role;
 use model::RolloverParams;
@@ -69,6 +70,7 @@ pub async fn new(
     build_party_params_channel: Box<dyn MessageChannel<wallet::BuildPartyParams>>,
     sign_channel: Box<dyn MessageChannel<wallet::Sign>>,
     role: Role,
+    position: Position,
     n_payouts: usize,
 ) -> Result<Dlc> {
     let (sk, pk) = keypair::new(&mut rand::thread_rng());
@@ -336,6 +338,7 @@ pub async fn new(
         revoked_commit: Vec::new(),
         settlement_event_id,
         refund_timelock: setup_params.refund_timelock,
+        own_position: position,
     })
 }
 
@@ -642,6 +645,7 @@ pub async fn roll_over(
         revoked_commit,
         settlement_event_id: announcement.id,
         refund_timelock: rollover_params.refund_timelock,
+        own_position: dlc.own_position,
     })
 }
 

--- a/daemon/src/setup_maker.rs
+++ b/daemon/src/setup_maker.rs
@@ -101,6 +101,7 @@ impl Actor {
             self.build_party_params.clone_channel(),
             self.sign.clone_channel(),
             Role::Maker,
+            self.order.position_maker,
             self.n_payouts,
         );
 

--- a/daemon/src/setup_maker.rs
+++ b/daemon/src/setup_maker.rs
@@ -16,7 +16,6 @@ use model::olivia::Announcement;
 use model::Dlc;
 use model::Identity;
 use model::Order;
-use model::Role;
 use model::Usd;
 use tokio_tasks::Tasks;
 use xtra::prelude::MessageChannel;
@@ -100,7 +99,6 @@ impl Actor {
             setup_params,
             self.build_party_params.clone_channel(),
             self.sign.clone_channel(),
-            Role::Maker,
             self.order.position_maker,
             self.n_payouts,
         );

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -16,7 +16,6 @@ use maia::secp256k1_zkp::schnorrsig;
 use model::olivia::Announcement;
 use model::Dlc;
 use model::Order;
-use model::Role;
 use model::Usd;
 use std::time::Duration;
 use tokio_tasks::Tasks;
@@ -98,7 +97,6 @@ impl Actor {
             setup_params,
             self.build_party_params.clone_channel(),
             self.sign.clone_channel(),
-            Role::Taker,
             self.order.position_maker.counter_position(),
             self.n_payouts,
         );

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -194,7 +194,7 @@ where
         let addr = setup_taker::Actor::new(
             self.db.clone(),
             self.process_manager_actor.clone(),
-            (cfd.id(), cfd.quantity(), self.n_payouts),
+            (order_to_take, cfd.quantity(), self.n_payouts),
             (self.oracle_pk, announcement),
             &self.wallet,
             &self.wallet,

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -65,9 +65,9 @@ pub mod taker_to_maker {
         Propose {
             timestamp: Timestamp,
             #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
-            taker: Amount,
+            long: Amount,
             #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
-            maker: Amount,
+            short: Amount,
             price: Price,
         },
         Initiate {

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -918,11 +918,15 @@ impl Cfd {
         proposal: SettlementProposal,
         sig_taker: Signature,
     ) -> Result<CollaborativeSettlement> {
+        anyhow::ensure!(
+            self.role == Role::Maker,
+            "Only the maker can create complete collaborative settlement signing"
+        );
+
         let dlc = self
             .dlc
             .as_ref()
-            .context("dlc has to be available for collab settlemment")?
-            .clone();
+            .context("Collaborative close without DLC")?;
 
         let (tx, sig_maker) = dlc.close_transaction(&proposal)?;
         let spend_tx = dlc.finalize_spend_transaction((tx, sig_maker), sig_taker)?;
@@ -1309,6 +1313,11 @@ impl Cfd {
         &self,
         proposal: &SettlementProposal,
     ) -> Result<(Transaction, Signature, Script)> {
+        anyhow::ensure!(
+            self.role == Role::Taker,
+            "Only the taker can start collaborative settlement signing"
+        );
+
         let dlc = self
             .dlc
             .as_ref()

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -357,7 +357,11 @@ impl CfdEvent {
     }
 }
 
-/// CfdEvents used by the maker and taker, some events are only for one role
+/// Types of events related to a CFD which can be emitted by both
+/// maker and taker.
+///
+/// Unfortunately, despite being a shared type some of the variants
+/// are only relevant for specific roles.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(tag = "name", content = "data")]
 pub enum EventKind {

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1691,21 +1691,6 @@ impl Dlc {
         Ok(spend_tx)
     }
 
-    pub fn refund_amount(&self, role: Role) -> Amount {
-        let our_script_pubkey = match role {
-            Role::Taker => self.taker_address.script_pubkey(),
-            Role::Maker => self.maker_address.script_pubkey(),
-        };
-
-        self.refund
-            .0
-            .output
-            .iter()
-            .find(|output| output.script_pubkey == our_script_pubkey)
-            .map(|output| Amount::from_sat(output.value))
-            .unwrap_or_default()
-    }
-
     pub fn script_pubkey_for(&self, role: Role) -> Script {
         match role {
             Role::Maker => self.maker_address.script_pubkey(),

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1636,6 +1636,8 @@ pub struct Dlc {
     // and create an internal structure that depicts this properly and avoids duplication.
     pub settlement_event_id: BitMexPriceEventId,
     pub refund_timelock: u32,
+
+    pub own_position: Position,
 }
 
 impl Dlc {
@@ -3464,6 +3466,7 @@ mod tests {
                     None => dummy_event_id(),
                 },
                 refund_timelock: 0,
+                own_position: dummy_position(),
             }
         }
     }
@@ -3502,6 +3505,10 @@ mod tests {
 
     pub fn dummy_event_id() -> BitMexPriceEventId {
         BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc())
+    }
+
+    fn dummy_position() -> Position {
+        Position::Long
     }
 
     fn extract_payout_amount(tx: Transaction, script: Script) -> Amount {

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -577,7 +577,9 @@ pub enum ConversionError {
     Overflow,
 }
 
-/// Opening fee is always payed from taker to maker
+/// Fee paid for the right to open a CFD.
+///
+/// This fee is paid by the taker to the maker.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(transparent)]
 pub struct OpeningFee {

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1105,7 +1105,7 @@ mod tests {
     }
 
     #[test]
-    fn given_positive_rate_then_negative_maker_short_balance() {
+    fn given_positive_rate_then_negative_short_maker_balance() {
         let funding_fee = FundingFee::new(
             Amount::from_sat(500),
             FundingRate::new(dec!(0.001)).unwrap(),
@@ -1135,7 +1135,7 @@ mod tests {
     }
 
     #[test]
-    fn given_negative_rate_then_positive_maker_short_balance() {
+    fn given_negative_rate_then_positive_short_maker_balance() {
         let funding_fee = FundingFee::new(
             Amount::from_sat(500),
             FundingRate::new(dec!(-0.001)).unwrap(),

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -33,16 +33,11 @@ pub use cfd::*;
 pub use contract_setup::SetupParams;
 pub use rollover::RolloverParams;
 
-/// The interval until the cfd gets settled, i.e. the attestation happens
+/// The time-to-live of a CFD after it is first created or rolled
+/// over.
 ///
-/// This variable defines at what point in time the oracle event id will be chose to settle the cfd.
-/// Hence, this constant defines how long a cfd is open (until it gets either settled or rolled
-/// over).
-///
-/// Multiple code parts align on this constant:
-/// - How the oracle event id is chosen when creating an order (maker)
-/// - The sliding window of cached oracle announcements (maker, taker)
-/// - The auto-rollover time-window (taker)
+/// This variable determines what oracle event ID will be associated
+/// with the non-collaborative settlement of the CFD.
 pub const SETTLEMENT_INTERVAL: time::Duration = time::Duration::hours(24);
 
 #[derive(thiserror::Error, Debug, Clone, Copy)]


### PR DESCRIPTION
Fixes #1580.
Fixes #1482.

Blocked by https://github.com/comit-network/maia/issues/16. (We have to amend the last commit and depend on latest `maia` after https://github.com/comit-network/maia/pull/21 is merged).

With this change we also fix the fact that we were (wrongly) only using the `calculate_payouts_long_taker` API. With the new semantics, we can always call the generic `calculate_payouts` API since it accepts arguments based on long/short.

The main drawback of this change is that we've elected to introduce the `Position` into the `Dlc` which is now duplicated across `Cfd` and `Dlc`. This may not be the final solution, but it helps in being able to use ours/theirs and long/short semantics with the data inside of `Dlc`.

The hardest pill to swallow might be the changes to the tests in `cfd.rs`, where a few test APIs have been modified to be able to pass through the `Position`.