### PR TITLE
Calculate liquidation price for short position

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -18,6 +18,7 @@ use model::calculate_long_liquidation_price;
 use model::calculate_margin;
 use model::calculate_profit;
 use model::calculate_profit_at_price;
+use model::calculate_short_liquidation_price;
 use model::long_and_short_leverage;
 use model::CfdEvent;
 use model::Dlc;
@@ -315,9 +316,10 @@ impl Cfd {
         let margin_counterparty =
             calculate_margin(initial_price, quantity_usd, counterparty_leverage);
 
-        // TODO: Change this to reflect that we can be short! - does this make sense for short? What
-        // should the taker UI display?
-        let liquidation_price = calculate_long_liquidation_price(our_leverage, initial_price);
+        let liquidation_price = match position {
+            Position::Long => calculate_long_liquidation_price(our_leverage, initial_price),
+            Position::Short => calculate_short_liquidation_price(our_leverage, initial_price),
+        };
 
         let (long_leverage, short_leverage) =
             long_and_short_leverage(taker_leverage, role, position);

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -9,6 +9,7 @@ use rust_decimal::Decimal;
 use serde::de::Error as _;
 use serde::Deserialize;
 use serde::Serialize;
+use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::fmt;
 use std::num::NonZeroU8;
@@ -95,6 +96,8 @@ pub struct Price(Decimal);
 impl_sqlx_type_display_from_str!(Price);
 
 impl Price {
+    const INFINITE: Price = Price(rust_decimal_macros::dec!(21_000_000));
+
     pub fn new(value: Decimal) -> Result<Self, Error> {
         if value == Decimal::ZERO {
             return Result::Err(Error::ZeroPrice);
@@ -372,6 +375,14 @@ impl Add<u8> for Leverage {
     }
 }
 
+impl Sub<u8> for Leverage {
+    type Output = Leverage;
+
+    fn sub(self, rhs: u8) -> Self::Output {
+        Self(self.0 - rhs)
+    }
+}
+
 impl Add<Leverage> for u8 {
     type Output = Leverage;
 
@@ -385,6 +396,36 @@ impl Div<Leverage> for Leverage {
 
     fn div(self, rhs: Leverage) -> Self::Output {
         Decimal::from(self.0) / Decimal::from(rhs.0)
+    }
+}
+
+impl PartialEq<u8> for Leverage {
+    #[inline]
+    fn eq(&self, other: &u8) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialOrd<u8> for Leverage {
+    #[inline]
+    fn partial_cmp(&self, other: &u8) -> Option<Ordering> {
+        self.0.partial_cmp(other)
+    }
+    #[inline]
+    fn lt(&self, other: &u8) -> bool {
+        self.0.lt(other)
+    }
+    #[inline]
+    fn le(&self, other: &u8) -> bool {
+        self.0.le(other)
+    }
+    #[inline]
+    fn gt(&self, other: &u8) -> bool {
+        self.0.gt(other)
+    }
+    #[inline]
+    fn ge(&self, other: &u8) -> bool {
+        self.0.ge(other)
     }
 }
 


### PR DESCRIPTION
Resolves #1589

Note: the order in the UI has the wrong liquidation price since it still relies on global params which only takes long position into account. This will be fixed in #1582