### PR TITLE
Introduce facilities for deprecating endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "prometheus",
  "rocket",
  "rocket-basicauth",
+ "rocket-deprecation",
  "rust-embed",
  "rust-embed-rocket",
  "serde",
@@ -2654,6 +2655,14 @@ dependencies = [
  "hex",
  "rocket",
  "void",
+]
+
+[[package]]
+name = "rocket-deprecation"
+version = "0.1.0"
+dependencies = [
+ "rocket",
+ "time 0.3.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "bdk-ext",
   "model",
   "btsieve",
+  "rocket-deprecation",
 ]
 resolver = "2"
 

--- a/bors.toml
+++ b/bors.toml
@@ -13,6 +13,7 @@ status = [
   "clippy (model)",
   "clippy (xtra-bitmex-price-feed)",
   "clippy (btsieve)",
+  "clippy (rocket-deprecation)",
   "lint-commits",
   "frontend (maker)",
   "frontend (taker)",

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -15,6 +15,7 @@ model = { path = "../model" }
 prometheus = "0.13"
 rocket = { version = "0.5.0-rc.1", features = ["json", "uuid"] }
 rocket-basicauth = { path = "../rocket-basicauth" }
+rocket-deprecation = { path = "../rocket-deprecation" }
 rust-embed = "6.3"
 rust-embed-rocket = { path = "../rust-embed-rocket" }
 serde = { version = "1", features = ["derive"] }

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -302,6 +302,7 @@ pub async fn get_cfds<'r>(rx: &State<Feeds>, _auth: Authenticated) -> Json<Vec<C
 
 #[rocket::get("/takers")]
 pub async fn get_takers<'r>(rx: &State<Feeds>, _auth: Authenticated) -> Json<Vec<Identity>> {
+    tracing::warn!(target: "deprecated", "The GET /takers endpoint is deprecated. Use the `p2p_connections_total` prometheus metrics instead.");
     let rx = rx.inner();
     let rx_connected_takers = rx.connected_takers.clone();
     let takers = rx_connected_takers.borrow().clone();

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -27,6 +27,7 @@ use rocket::response::Responder;
 use rocket::serde::json::Json;
 use rocket::State;
 use rocket_basicauth::Authenticated;
+use rocket_deprecation::Deprecation;
 use rust_embed::RustEmbed;
 use rust_embed_rocket::EmbeddedFileExt;
 use serde::Deserialize;
@@ -301,13 +302,18 @@ pub async fn get_cfds<'r>(rx: &State<Feeds>, _auth: Authenticated) -> Json<Vec<C
 }
 
 #[rocket::get("/takers")]
-pub async fn get_takers<'r>(rx: &State<Feeds>, _auth: Authenticated) -> Json<Vec<Identity>> {
+pub async fn get_takers<'r>(
+    rx: &State<Feeds>,
+    _auth: Authenticated,
+) -> Deprecation<Json<Vec<Identity>>> {
     tracing::warn!(target: "deprecated", "The GET /takers endpoint is deprecated. Use the `p2p_connections_total` prometheus metrics instead.");
     let rx = rx.inner();
     let rx_connected_takers = rx.connected_takers.clone();
     let takers = rx_connected_takers.borrow().clone();
 
-    Json(takers)
+    Deprecation::new(Json(takers)).with_deprecation_link(rocket::uri!(
+        "https://github.com/itchysats/itchysats/issues/1609"
+    ))
 }
 
 #[rocket::get("/metrics")]

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -292,27 +292,21 @@ pub async fn post_withdraw_request(
 }
 
 #[rocket::get("/cfds")]
-pub async fn get_cfds<'r>(
-    rx: &State<Feeds>,
-    _auth: Authenticated,
-) -> Result<Json<Vec<Cfd>>, HttpApiProblem> {
+pub async fn get_cfds<'r>(rx: &State<Feeds>, _auth: Authenticated) -> Json<Vec<Cfd>> {
     let rx = rx.inner();
     let rx_cfds = rx.cfds.clone();
     let cfds = rx_cfds.borrow().clone();
 
-    Ok(Json(cfds))
+    Json(cfds)
 }
 
 #[rocket::get("/takers")]
-pub async fn get_takers<'r>(
-    rx: &State<Feeds>,
-    _auth: Authenticated,
-) -> Result<Json<Vec<Identity>>, HttpApiProblem> {
+pub async fn get_takers<'r>(rx: &State<Feeds>, _auth: Authenticated) -> Json<Vec<Identity>> {
     let rx = rx.inner();
     let rx_connected_takers = rx.connected_takers.clone();
     let takers = rx_connected_takers.borrow().clone();
 
-    Ok(Json(takers))
+    Json(takers)
 }
 
 #[rocket::get("/metrics")]

--- a/rocket-deprecation/Cargo.toml
+++ b/rocket-deprecation/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rocket-deprecation"
+version = "0.1.0"
+edition = "2021"
+description = "Utilities for deprecating rocket handlers."
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rocket = "0.5.0-rc.1"
+time = { version = "0.3", features = ["formatting"] }

--- a/rocket-deprecation/src/lib.rs
+++ b/rocket-deprecation/src/lib.rs
@@ -1,0 +1,140 @@
+use rocket::http::uri;
+use rocket::http::Header;
+use rocket::response::Responder;
+use rocket::Request;
+use time::OffsetDateTime;
+
+/// A rocket responder for deprecating endpoints using the `Deprecation` header defined in https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header.
+pub struct Deprecation<TInner> {
+    /// The inner responder that creates the actual response.
+    inner: TInner,
+
+    /// The `Deprecation` header that will be set in the response.
+    deprecation: Header<'static>,
+
+    /// Links added to the response.
+    links: Vec<Header<'static>>,
+}
+
+impl<'r, TInner> Responder<'r, 'static> for Deprecation<TInner>
+where
+    TInner: Responder<'r, 'static>,
+{
+    fn respond_to(self, request: &'r Request<'_>) -> rocket::response::Result<'static> {
+        let mut response = self.inner.respond_to(request)?;
+
+        response.set_header(self.deprecation);
+
+        for link in self.links {
+            response.adjoin_header(link);
+        }
+
+        Ok(response)
+    }
+}
+
+impl<TInner> Deprecation<TInner> {
+    /// Wraps another response, adding the `Deprecation: true` header.
+    pub fn new(response: TInner) -> Self {
+        Self {
+            inner: response,
+            deprecation: Header::new(HEADER_NAME, "true"),
+            links: vec![],
+        }
+    }
+
+    /// Wraps another response, adding the `Deprecation` header set to the given timestamp.
+    pub fn with_timestamp(response: TInner, timestamp: OffsetDateTime) -> Self {
+        let timestamp = timestamp
+            .format(&time::format_description::well_known::Rfc2822)
+            .expect("date to format");
+
+        Self {
+            inner: response,
+            deprecation: Header::new(HEADER_NAME, timestamp),
+            links: vec![],
+        }
+    }
+
+    /// Adds a `Link` header with `rel="deprecation"` to the response.
+    ///
+    /// For more information, see https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header#section-3.
+    pub fn with_deprecation_link(mut self, link: uri::Absolute) -> Self {
+        self.links.push(Header::new(
+            "Link",
+            format!(r#"<{link}>; rel="deprecation""#),
+        ));
+
+        self
+    }
+
+    // TODO: Add support for other link relations: https://datatracker.ietf.org/doc/html/draft-dalal-deprecation-header-03#section-4
+}
+
+const HEADER_NAME: &str = "Deprecation";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocket::local::blocking::Client;
+    use rocket::uri;
+    use rocket::Build;
+    use rocket::Rocket;
+
+    #[test]
+    fn route_has_deprecation_header_true() {
+        let client = Client::tracked(rocket()).unwrap();
+
+        let response = client.get("/test").dispatch();
+
+        assert_eq!(response.headers().get_one("Deprecation"), Some("true"));
+    }
+
+    #[test]
+    fn route_has_deprecation_header_with_timestamp() {
+        let client = Client::tracked(rocket()).unwrap();
+
+        let response = client.get("/test2").dispatch();
+
+        assert_eq!(
+            response.headers().get_one("Deprecation"),
+            Some("Thu, 01 Jan 1970 00:00:00 +0000")
+        );
+    }
+
+    #[test]
+    fn route_has_deprecation_header_with_link() {
+        let client = Client::tracked(rocket()).unwrap();
+
+        let response = client.get("/test3").dispatch();
+
+        assert_eq!(
+            response.headers().get_one("Link"),
+            Some(r#"<http://example.com/deprecated-resources/test2>; rel="deprecation""#)
+        );
+    }
+
+    #[rocket::get("/test")]
+    async fn deprecated_true() -> Deprecation<()> {
+        Deprecation::new(())
+    }
+
+    #[rocket::get("/test2")]
+    async fn deprecated_with_time() -> Deprecation<()> {
+        Deprecation::with_timestamp((), OffsetDateTime::UNIX_EPOCH)
+    }
+
+    #[rocket::get("/test3")]
+    async fn deprecated_with_link() -> Deprecation<()> {
+        Deprecation::new(())
+            .with_deprecation_link(uri!("http://example.com/deprecated-resources/test2"))
+    }
+
+    /// Constructs a Rocket instance for testing.
+    fn rocket() -> Rocket<Build> {
+        rocket::build().mount(
+            "/",
+            rocket::routes![deprecated_true, deprecated_with_time, deprecated_with_link],
+        )
+    }
+}


### PR DESCRIPTION
Breaking APIs causes friction for clients. Where possible we try to avoid breaking APIs and deprecate them instead whilst adding alternative ones or new versions.

Once deprecated, we need to migrate clients off the deprecated endpoint. To make this easier, we implement some basic rocket facilities for adding a `Deprecation` header. Such header can be parsed by clients and be used to alert monitoring systems that there is code in place which hits deprecated resources. Once alerted, developers can go in and transition to a new endpoint.