### PR TITLE
Remove protobuf dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,7 +2226,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "protobuf",
  "thiserror",
 ]
 
@@ -2246,12 +2245,6 @@ dependencies = [
  "rand_xorshift 0.3.0",
  "regex-syntax",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "quick-error"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.10"
 maia = "0.1.0"
 model = { path = "../model" }
 parse-display = "0.5.5"
-prometheus = "0.13"
+prometheus = { version = "0.13", default-features = false }
 rand = "0.6"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
 rust_decimal = { version = "1.22", features = ["serde-with-float"] }

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -12,7 +12,7 @@ daemon = { path = "../daemon" }
 hex = "0.4"
 http-api-problem = { version = "0.51.0", features = ["rocket"] }
 model = { path = "../model" }
-prometheus = "0.13"
+prometheus = { version = "0.13", default-features = false }
 rocket = { version = "0.5.0-rc.1", features = ["json", "uuid"] }
 rocket-basicauth = { path = "../rocket-basicauth" }
 rust-embed = "6.3"


### PR DESCRIPTION
We are not using the protobuf encoding for metrics so we can
disable this feature flag.