### PR TITLE
Correct liquidation price in the UI

### DIFF
--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -169,6 +169,9 @@ fn assert_eq_orders(mut published: CfdOrder, received: CfdOrder) {
     // align initial_funding_fee_per_lot so we can assert on the order
     published.initial_funding_fee_per_lot = received.initial_funding_fee_per_lot;
 
+    // align liquidation price so we can assert on the order
+    published.liquidation_price = received.liquidation_price;
+
     assert_eq!(published, received);
 
     // Hard-coded to match the dummy_new_order()

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -976,7 +976,7 @@ pub struct CfdOrder {
     #[serde(rename = "leverage")]
     pub taker_leverage_choices: Leverage,
 
-    /// Own liquidation price according to the position
+    /// Own liquidation price according to position and leverage
     #[serde(with = "round_to_two_dp")]
     pub liquidation_price: Price,
 
@@ -1004,6 +1004,7 @@ impl TryFrom<Order> for CfdOrder {
     fn try_from(order: Order) -> std::result::Result<Self, Self::Error> {
         let lot_size = Usd::new(dec!(100)); // TODO: Have the maker tell us this.
 
+        let role = order.origin.into();
         let own_position = match order.origin {
             // we are the maker, the order's position is our position
             Origin::Ours => order.position_maker,
@@ -1012,7 +1013,7 @@ impl TryFrom<Order> for CfdOrder {
         };
 
         let (long_leverage, short_leverage) =
-            long_and_short_leverage(order.leverage_taker, order.origin.into(), own_position);
+            long_and_short_leverage(order.leverage_taker, role, own_position);
 
         let initial_funding_fee_per_lot = calculate_funding_fee(
             order.price,
@@ -1025,16 +1026,21 @@ impl TryFrom<Order> for CfdOrder {
         .context("unable to calculate initial funding fee")?;
 
         // Use a temporary fee account to define the funding fee's sign
-        let temp_fee_account = FeeAccount::new(own_position, order.origin.into());
+        let temp_fee_account = FeeAccount::new(own_position, role);
         let initial_funding_fee_per_lot = temp_fee_account
             .add_funding_fee(initial_funding_fee_per_lot)
             .balance();
 
-        // We cannot just send over liquidation price of the maker, but have to send the one of the
-        // own position for it to make sense for display.
+        // Liquidation price is dependent on one's own leverage
         let liquidation_price = match own_position {
             Position::Long => calculate_long_liquidation_price(long_leverage, order.price),
             Position::Short => calculate_short_liquidation_price(short_leverage, order.price),
+        };
+
+        // Margin per lot price is dependent on one's own leverage
+        let margin_per_lot = match own_position {
+            Position::Long => calculate_margin(order.price, lot_size, long_leverage),
+            Position::Short => calculate_margin(order.price, lot_size, short_leverage),
         };
 
         Ok(Self {
@@ -1045,12 +1051,7 @@ impl TryFrom<Order> for CfdOrder {
             min_quantity: order.min_quantity,
             max_quantity: order.max_quantity,
             lot_size,
-            margin_per_lot: match order.origin {
-                // we are the maker
-                Origin::Ours => calculate_margin(order.price, lot_size, Leverage::ONE),
-                // we are the taker
-                Origin::Theirs => calculate_margin(order.price, lot_size, order.leverage_taker),
-            },
+            margin_per_lot,
             taker_leverage_choices: order.leverage_taker,
             liquidation_price,
             creation_timestamp: order.creation_timestamp,

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -230,9 +230,6 @@ pub struct Order {
     #[serde(rename = "leverage")]
     pub leverage_taker: Leverage,
 
-    // TODO: Remove from order, can be calculated
-    pub liquidation_price: Price,
-
     pub creation_timestamp: Timestamp,
 
     /// The duration that will be used for calculating the settlement timestamp
@@ -266,11 +263,6 @@ impl Order {
     ) -> Self {
         let leverage_choices_for_taker = Leverage::TWO;
 
-        let liquidation_price = match position_maker {
-            Position::Short => calculate_short_liquidation_price(leverage_choices_for_taker, price),
-            Position::Long => calculate_long_liquidation_price(leverage_choices_for_taker, price),
-        };
-
         Order {
             id: OrderId::default(),
             price,
@@ -278,7 +270,6 @@ impl Order {
             max_quantity,
             leverage_taker: leverage_choices_for_taker,
             trading_pair: TradingPair::BtcUsd,
-            liquidation_price,
             position_maker,
             creation_timestamp: Timestamp::now(),
             settlement_interval,


### PR DESCRIPTION
Fixes https://github.com/itchysats/itchysats/issues/1641

The liquidation price is only relevant for the UI:
- Remove the liquidation price from the `Order` (finally...)
- Send the liquidation price according to own position in the projection (the only thing that makes sense)