### PR TITLE
Demote warn to debug

### DIFF
--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -348,7 +348,7 @@ impl Actor {
         let this = ctx.address().expect("we are alive");
 
         if self.connections.contains_key(&identity) {
-            tracing::warn!(
+            tracing::debug!(
                 taker_id = %identity,
                 "Refusing to accept 2nd connection from already connected taker!"
             );


### PR DESCRIPTION
It is worth monitoring this log because it may mean that a user has a
weird setup where they try to connect with the same seed from different
machines or something like that.

However, it is not worth printing a `warn` because it is in no way
critical to the application's health.