### PR TITLE
Restore compatibility of wire protocol with version 2.0.0

### DIFF
--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -570,6 +570,9 @@ impl Actor {
                     .log_failure("Failed to forward current order from maker")
                     .await;
             }
+            wire::MakerToTaker::CurrentOrder(_) => {
+                // no-op, we support `CurrentOffers` message and can ignore this one.
+            }
             wire::MakerToTaker::Hello(_) => {
                 tracing::warn!("Ignoring unexpected Hello message from maker. Hello is only expected when opening a new connection.")
             }


### PR DESCRIPTION
By sending out _short_ offers to all takers as well, we can retain
compatibility with the old wire protocol. An older taker will
receive both messages and fail to deserialize one of them. This
is not a hard error so the app will still function. A new taker
will also receive both messages but simply drop the old message.