### PR TITLE
Distinguish major and minor wire versions when checking for compatibility

### DIFF
--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -365,7 +365,7 @@ impl Actor {
             })?
             .with_context(|| format!("Failed to read first message from maker {maker_identity}"))? {
             Some(wire::MakerToTaker::Hello(maker_version)) => {
-                if our_version != maker_version {
+                if !Version::is_compatible(&our_version, &maker_version) {
                     self.status_sender
                         .send(ConnectionStatus::Offline {
                             reason: Some(ConnectionCloseReason::VersionMismatch {

--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -529,7 +529,7 @@ async fn upgrade(
                 .send(wire::MakerToTaker::Hello(our_version.clone()))
                 .await?;
 
-            if our_version != taker_version {
+            if !Version::is_compatible(&taker_version, &our_version) {
                 bail!(
                     "Network version mismatch, we are on version {our_version} but taker is on version {taker_version}",
                 );

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -70,11 +70,6 @@ impl Version {
             return false;
         }
 
-        if taker.patch > maker.patch {
-            // taker's patch version is ahead of taker, that is not allowed
-            return false;
-        }
-
         true
     }
 }
@@ -620,41 +615,9 @@ mod tests {
     }
 
     #[test]
-    fn given_maker_patch_ahead_of_taker_then_versions_compatible() {
-        let maker_version = Version(semver::Version::new(2, 0, 1));
-        let taker_version = Version(semver::Version::new(2, 0, 0));
-
-        assert!(Version::is_compatible(&taker_version, &maker_version));
-    }
-
-    #[test]
-    fn given_maker_minor_and_patch_ahead_of_taker_then_versions_compatible() {
-        let maker_version = Version(semver::Version::new(2, 1, 1));
-        let taker_version = Version(semver::Version::new(2, 0, 0));
-
-        assert!(Version::is_compatible(&taker_version, &maker_version));
-    }
-
-    #[test]
     fn given_taker_minor_ahead_of_maker_then_versions_incompatible() {
         let maker_version = Version(semver::Version::new(2, 0, 0));
         let taker_version = Version(semver::Version::new(2, 1, 0));
-
-        assert!(!Version::is_compatible(&taker_version, &maker_version));
-    }
-
-    #[test]
-    fn given_taker_patch_ahead_of_maker_then_versions_incompatible() {
-        let maker_version = Version(semver::Version::new(2, 0, 0));
-        let taker_version = Version(semver::Version::new(2, 0, 1));
-
-        assert!(!Version::is_compatible(&taker_version, &maker_version));
-    }
-
-    #[test]
-    fn given_taker_minor_and_patch_ahead_of_maker_then_versions_incompatible() {
-        let maker_version = Version(semver::Version::new(2, 0, 0));
-        let taker_version = Version(semver::Version::new(2, 1, 1));
 
         assert!(!Version::is_compatible(&taker_version, &maker_version));
     }


### PR DESCRIPTION
- Major version has to match exactly.
- Taker cannot be ahead of maker for the minor or patch version. -> I am not entirely sure about this one. We could also allow that, but it would be quite odd of a taker runs a newer version than the maker. That would mean that the maker was not updated correctly and the taker should potentially contact us.