### PR TITLE
Remodel `Hello` messages as version negotiation and transform messages based on negotiated version

### DIFF
--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -349,7 +349,7 @@ impl Actor {
             Framed::new(connection, EncryptedJsonCodec::new(noise)).split()
         };
 
-        let proposed_version = Version::current();
+        let proposed_version = Version::latest();
         write
             .send(wire::TakerToMaker::HelloV2 {
                 proposed_wire_version: proposed_version.clone(),

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -349,7 +349,7 @@ impl Actor {
             Framed::new(connection, EncryptedJsonCodec::new(noise)).split()
         };
 
-        let proposed_version = Version::latest();
+        let proposed_version = Version::LATEST;
         write
             .send(wire::TakerToMaker::HelloV2 {
                 proposed_wire_version: proposed_version.clone(),

--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -581,7 +581,7 @@ async fn negotiate_wire_version(
     >,
     proposed_wire_version: Version,
 ) -> Result<Version> {
-    let our_wire_version = Version::current();
+    let our_wire_version = Version::latest();
     write
         .send(wire::MakerToTaker::Hello(our_wire_version.clone()))
         .await?;

--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -581,7 +581,7 @@ async fn negotiate_wire_version(
     >,
     proposed_wire_version: Version,
 ) -> Result<Version> {
-    let our_wire_version = Version::latest();
+    let our_wire_version = Version::LATEST;
     write
         .send(wire::MakerToTaker::Hello(our_wire_version.clone()))
         .await?;

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -50,7 +50,7 @@ pub type Write<D, E> = SplitSink<Framed<TcpStream, EncryptedJsonCodec<D, E>>, E>
 pub struct Version(semver::Version);
 
 impl Version {
-    pub fn current() -> Self {
+    pub fn latest() -> Self {
         Self(semver::Version::new(2, 0, 0))
     }
 }

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -50,7 +50,8 @@ pub type Write<D, E> = SplitSink<Framed<TcpStream, EncryptedJsonCodec<D, E>>, E>
 pub struct Version(semver::Version);
 
 impl Version {
-    pub const LATEST: Version = Version(semver::Version::new(2, 0, 0));
+    pub const LATEST: Version = Version(semver::Version::new(2, 1, 0));
+    pub const V2_0_0: Version = Version(semver::Version::new(2, 0, 0));
 }
 
 impl fmt::Display for Version {

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -50,9 +50,7 @@ pub type Write<D, E> = SplitSink<Framed<TcpStream, EncryptedJsonCodec<D, E>>, E>
 pub struct Version(semver::Version);
 
 impl Version {
-    pub fn latest() -> Self {
-        Self(semver::Version::new(2, 0, 0))
-    }
+    pub const LATEST: Version = Version(semver::Version::new(2, 0, 0));
 }
 
 impl fmt::Display for Version {

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -89,7 +89,7 @@ pub enum TakerToMaker {
     /// Deprecated, used by takers up to v0.4.7
     Hello(Version),
     HelloV2 {
-        wire_version: Version,
+        proposed_wire_version: Version,
         daemon_version: String,
     },
     TakeOrder {

--- a/shared-bin/src/to_sse_event.rs
+++ b/shared-bin/src/to_sse_event.rs
@@ -67,9 +67,9 @@ impl ToSseEvent for connection::ConnectionStatus {
             connection::ConnectionStatus::Offline { reason } => ConnectionStatus {
                 online: false,
                 connection_close_reason: reason.as_ref().map(|g| match g {
-                    connection::ConnectionCloseReason::VersionMismatch {
-                        maker_version,
-                        taker_version,
+                    connection::ConnectionCloseReason::VersionNegotiationFailed {
+                        actual_version: maker_version,
+                        proposed_version: taker_version,
                     } => {
                         if *maker_version < *taker_version {
                             MakerVersionOutdated


### PR DESCRIPTION
This is an attempt at relaxing the version requirements of our wire protocol. What we have currently in master **does not** work  (for 0.4.7, sorry for not testing this better first :grimacing: ).

Here is screenshot of this branch in action:

![image](https://user-images.githubusercontent.com/5486389/158546554-b9e19c81-857e-4951-9626-5960b4a6bdbc.png)
