### PR TITLE
Ensure our message enums are forwards compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "snow",
  "sqlx",
  "statrs",
+ "test-case",
  "thiserror",
  "time 0.3.7",
  "tokio",
@@ -3610,6 +3611,19 @@ name = "termtree"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+
+[[package]]
+name = "test-case"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7d58e237f65d5fe5eaf1105188c94c9a441e1fbc298ed5df45ec9c9af236d3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "textwrap"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -47,6 +47,7 @@ xtras = { path = "../xtras" }
 [dev-dependencies]
 pretty_assertions = "1"
 serde_test = "1"
+test-case = "2"
 time = { version = "0.3", features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "tracing-log"] }
 

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -581,6 +581,10 @@ impl Actor {
             wire::MakerToTaker::Hello(_) => {
                 tracing::warn!("Ignoring unexpected Hello message from maker. Hello is only expected when opening a new connection.")
             }
+            wire::MakerToTaker::Unknown => {
+                // Ignore unknown message to be forwards-compatible. We are logging it above on
+                // `trace` level already.
+            }
         }
         KeepRunning::Yes
     }

--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -685,6 +685,9 @@ where
             wire::TakerToMaker::HelloV2 { .. } => {
                 unreachable!("The HelloV2 message is not sent to the cfd actor")
             }
+            wire::TakerToMaker::Unknown => {
+                // Ignore unknown message to be forwards-compatible.
+            }
         }
     }
 }


### PR DESCRIPTION
By annotating a variant with `serde(other)`, we can gracefully fail to
deserialize unknown variants.