### PR TITLE
Make rollover 0.4.7 compatible with current master

### DIFF
--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -304,7 +304,7 @@ impl Actor {
         } = msg;
 
         self.state
-            .send(wire::TakerToMaker::ProposeRollover {
+            .send(wire::TakerToMaker::ProposeRolloverV2 {
                 order_id,
                 timestamp,
             })

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -100,6 +100,10 @@ pub enum TakerToMaker {
         order_id: OrderId,
         timestamp: Timestamp,
     },
+    ProposeRolloverV2 {
+        order_id: OrderId,
+        timestamp: Timestamp,
+    },
     Protocol {
         order_id: OrderId,
         msg: SetupMsg,
@@ -127,6 +131,7 @@ impl TakerToMaker {
                 SetupMsg::Msg3(_) => "TakerToMaker::Protocol::Msg3",
             },
             TakerToMaker::ProposeRollover { .. } => "TakerToMaker::ProposeRollover",
+            TakerToMaker::ProposeRolloverV2 { .. } => "TakerToMaker::ProposeRolloverV2",
             TakerToMaker::RolloverProtocol { msg, .. } => match msg {
                 RolloverMsg::Msg0(_) => "TakerToMaker::RolloverProtocol::Msg0",
                 RolloverMsg::Msg1(_) => "TakerToMaker::RolloverProtocol::Msg1",

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -836,8 +836,14 @@ impl Cfd {
         }
 
         let hours_to_charge = match version {
-            rollover::Version::V1 => 1,
-            rollover::Version::V2 => self.hours_to_extend_in_rollover()?,
+            rollover::Version::V1 => {
+                tracing::debug!("Rollover V1");
+                1
+            }
+            rollover::Version::V2 => {
+                tracing::debug!("Rollover V2");
+                self.hours_to_extend_in_rollover()?
+            }
         };
 
         let funding_fee = calculate_funding_fee(
@@ -860,6 +866,7 @@ impl Cfd {
                 tx_fee_rate,
                 self.fee_account,
                 funding_fee,
+                version,
             ),
             self.dlc.clone().context("No DLC present")?,
             self.position,
@@ -903,6 +910,7 @@ impl Cfd {
                 tx_fee_rate,
                 self.fee_account,
                 funding_fee,
+                rollover::Version::V2,
             ),
             self.dlc.clone().context("No DLC present")?,
             self.position,

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -33,6 +33,7 @@ mod rollover;
 pub use cfd::*;
 pub use contract_setup::SetupParams;
 pub use rollover::RolloverParams;
+pub use rollover::Version as RolloverVersion;
 
 /// The time-to-live of a CFD after it is first created or rolled
 /// over.

--- a/model/src/rollover.rs
+++ b/model/src/rollover.rs
@@ -6,6 +6,21 @@ use crate::TxFeeRate;
 use crate::Usd;
 
 #[derive(Debug, Clone, Copy)]
+pub enum Version {
+    /// Version one of the rollover protocol
+    ///
+    /// This version cannot handle charging for "missed" rollovers yet, i.e. the hours to charge is
+    /// always set to 1 hour. This version is needed for clients that are <= daemon version
+    /// `0.4.7`.
+    V1,
+    /// Version two of the rollover protocol
+    ///
+    /// This version can handle charging for "missed" rollovers, i.e. we calculate the hours to
+    /// charge based on the oracle event timestamp of the last successful rollover.
+    V2,
+}
+
+#[derive(Debug, Clone, Copy)]
 pub struct RolloverParams {
     pub price: Price,
     pub quantity: Usd,

--- a/model/src/rollover.rs
+++ b/model/src/rollover.rs
@@ -30,6 +30,7 @@ pub struct RolloverParams {
     pub fee_rate: TxFeeRate,
     pub fee_account: FeeAccount,
     pub current_fee: FundingFee,
+    pub version: Version,
 }
 
 impl RolloverParams {
@@ -43,6 +44,7 @@ impl RolloverParams {
         fee_rate: TxFeeRate,
         fee_account: FeeAccount,
         current_fee: FundingFee,
+        version: Version,
     ) -> Self {
         Self {
             price,
@@ -53,6 +55,7 @@ impl RolloverParams {
             fee_rate,
             fee_account,
             current_fee,
+            version,
         }
     }
 


### PR DESCRIPTION
Introduce `ProposeRolloverV2` message on the wire:

- The taker sends `ProposeRolloverV2`
- The maker can handle both `ProposeRolloverV2` and `ProposeRollover`

Introduce `RolloverVersion` to distinguish code paths in `rollover_maker` actor and `accept_rollover_proposal` for the maker.

I opted for having `RolloverVersion` because the decision logic is simple, and we have to store the version in the `rollover_maker` actor because the proposal does not need the decision logic, only after accepting we decide. It might still be somewhat cleaner to duplicate `accept_rollover_proposal` and deprecate one of the functions - but since I needed the `RolloverVersion` anyway I pulled it in there. 
We could also duplicate all code on the way: the `rollover_maker` actor and  `accept_rollover_proposal` in `model::cfd::Cfd` and mark all duplicated code as deprecated. But I found that a bit of an overkill.