### PR TITLE
Taker checks for offer sanity

### DIFF
--- a/daemon/src/maker_inc_connections.rs
+++ b/daemon/src/maker_inc_connections.rs
@@ -142,7 +142,7 @@ impl Connection {
                             min_quantity: order.min_quantity,
                             max_quantity: order.max_quantity,
                             leverage_taker: order.leverage_taker,
-                            creation_timestamp: order.creation_timestamp,
+                            creation_timestamp: order.creation_timestamp_maker,
                             settlement_interval: order.settlement_interval,
                             liquidation_price: model::calculate_long_liquidation_price(
                                 order.leverage_taker,

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -1057,7 +1057,7 @@ impl TryFrom<Order> for CfdOrder {
             margin_per_lot,
             taker_leverage_choices: order.leverage_taker,
             liquidation_price,
-            creation_timestamp: order.creation_timestamp,
+            creation_timestamp: order.creation_timestamp_maker,
             settlement_time_interval_in_secs: order
                 .settlement_interval
                 .whole_seconds()

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -6,7 +6,8 @@ use crate::process_manager;
 use crate::projection;
 use crate::setup_taker;
 use crate::wallet;
-use anyhow::Context as _;
+use anyhow::bail;
+use anyhow::Context;
 use anyhow::Result;
 use async_trait::async_trait;
 use bdk::bitcoin::secp256k1::schnorrsig;
@@ -18,6 +19,7 @@ use model::Origin;
 use model::Price;
 use model::Role;
 use model::Usd;
+use time::OffsetDateTime;
 use tokio_tasks::Tasks;
 use xtra::Actor as _;
 use xtra_productivity::xtra_productivity;
@@ -167,7 +169,18 @@ where
             .take_order(order_id);
 
         let order_to_take = order_to_take.context("Order to take could not be found in current maker offers, you might have an outdated offer")?;
+
+        // The offer we are instructed to take is removed from the
+        // set of available offers immediately so that we don't attempt
+        // to take it more than once
         self.current_maker_offers.replace(maker_offers);
+
+        if !order_to_take.is_safe_to_take(OffsetDateTime::now_utc()) {
+            bail!(
+                "The maker's offer appears to be outdated, refusing to take: {:?}",
+                &order_to_take
+            );
+        }
 
         tracing::info!("Taking current order: {:?}", &order_to_take);
 

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -230,7 +230,9 @@ pub struct Order {
     #[serde(rename = "leverage")]
     pub leverage_taker: Leverage,
 
-    pub creation_timestamp: Timestamp,
+    /// The creation timestamp as set by the maker
+    #[serde(rename = "creation_timestamp")]
+    pub creation_timestamp_maker: Timestamp,
 
     /// The duration that will be used for calculating the settlement timestamp
     pub settlement_interval: Duration,
@@ -271,7 +273,7 @@ impl Order {
             leverage_taker: leverage_choices_for_taker,
             trading_pair: TradingPair::BtcUsd,
             position_maker,
-            creation_timestamp: Timestamp::now(),
+            creation_timestamp_maker: Timestamp::now(),
             settlement_interval,
             origin,
             oracle_event_id,
@@ -295,6 +297,41 @@ impl Order {
             self.funding_rate,
             self.opening_fee,
         )
+    }
+
+    /// Defines when we consider an order to be outdated
+    ///
+    /// If the maker's offer creation timestamp is older than `OUTDATED_AFTER_MINS` minutes then we
+    /// consider an order to be outdated.
+    const OUTDATED_AFTER_MINS: i64 = 10;
+
+    /// Defines when we consider the order to be outdated.
+    ///
+    /// This is used as a safety net to prevent the taker from taking an outdated order.
+    pub fn is_safe_to_take(&self, now: OffsetDateTime) -> bool {
+        !self.is_creation_timestamp_outdated(now) && self.is_oracle_event_timestamp_sane(now)
+    }
+
+    /// Check if the the maker's offer creation timestamp is outdated
+    ///
+    /// If the creation timestamp is older than `OUTDATED_AFTER_MINS` minutes the offer is
+    /// considered outdated
+    fn is_creation_timestamp_outdated(&self, now: OffsetDateTime) -> bool {
+        self.creation_timestamp_maker.seconds() + (Self::OUTDATED_AFTER_MINS * 60)
+            < now.unix_timestamp()
+    }
+
+    /// Check the oracle event's timestamp for sanity
+    ///
+    /// An id within [25h, 23h] from now is considered sane.
+    fn is_oracle_event_timestamp_sane(&self, now: OffsetDateTime) -> bool {
+        let event_id_timestamp = self.oracle_event_id.timestamp();
+
+        let settlement_interval_minus_one_hour = now + SETTLEMENT_INTERVAL - Duration::HOUR;
+        let settlement_interval_plus_one_hour = now + SETTLEMENT_INTERVAL + Duration::HOUR;
+
+        event_id_timestamp >= settlement_interval_minus_one_hour
+            && event_id_timestamp <= settlement_interval_plus_one_hour
     }
 }
 
@@ -1962,6 +1999,7 @@ mod tests {
     use bdk_ext::SecretKeyExt;
     use maia::lock_descriptor;
     use proptest::prelude::*;
+    use rand::thread_rng;
     use rust_decimal_macros::dec;
     use std::collections::BTreeMap;
     use std::str::FromStr;
@@ -3069,7 +3107,6 @@ mod tests {
         (taker_payout.as_sat(), maker_payout.as_sat())
     }
 
-    use rand::thread_rng;
     proptest! {
         #[test]
         fn rollover_funding_fee_collected_incrementally_should_not_be_smaller_than_collected_once_per_settlement_interval(quantity in 1u64..100_000u64) {
@@ -3101,6 +3138,111 @@ mod tests {
             total_balance_when_collected_hourly - total_balance_when_collected_for_whole_interval < SignedAmount::from_sat(30), "we should not overcharge"
        );
     }
+    }
+
+    #[test]
+    fn given_order_creation_timestamp_outdated_then_order_outdated() {
+        let creation_timestamp = Timestamp::now();
+        let order = Order::dummy_short().with_creation_timestamp(creation_timestamp);
+
+        let now =
+            OffsetDateTime::now_utc() + Duration::seconds(Order::OUTDATED_AFTER_MINS * 60 + 1);
+
+        assert!(order.is_creation_timestamp_outdated(now))
+    }
+
+    #[test]
+    fn given_order_creation_timestamp_not_outdated_then_order_not_outdated() {
+        let creation_timestamp = Timestamp::now();
+        let order = Order::dummy_short().with_creation_timestamp(creation_timestamp);
+
+        let now =
+            OffsetDateTime::now_utc() + Duration::seconds(Order::OUTDATED_AFTER_MINS * 60 - 1);
+
+        assert!(!order.is_creation_timestamp_outdated(now))
+    }
+
+    #[test]
+    fn given_oracle_event_id_is_24h_in_the_future_then_sane_to_take() {
+        // --|---------|---------|----------------------------------|--> time
+        //   -1h       |         +1h                                24h
+        // --|---------|<--------|--------------------------------->|--
+        //             now
+
+        let order = Order::dummy_short().with_oracle_event_id(BitMexPriceEventId::with_20_digits(
+            datetime!(2021-11-19 10:00:00).assume_utc(),
+        ));
+
+        let sane =
+            order.is_oracle_event_timestamp_sane(datetime!(2021-11-18 10:00:00).assume_utc());
+        assert!(sane)
+    }
+
+    #[test]
+    fn given_oracle_event_id_is_23h_in_the_future_then_sane_to_take() {
+        // --|---------|---------|----------------------------------|--> time
+        //   -1h       |         +1h                                24h
+        // --|---------|<--------|--------------------------------->|--
+        //                       now
+
+        let order = Order::dummy_short().with_oracle_event_id(BitMexPriceEventId::with_20_digits(
+            datetime!(2021-11-19 10:00:00).assume_utc(),
+        ));
+
+        let sane =
+            order.is_oracle_event_timestamp_sane(datetime!(2021-11-18 11:00:00).assume_utc());
+        assert!(sane, "the oracle event id is outdated")
+    }
+
+    #[test]
+    fn given_oracle_event_id_is_25h_in_the_future_then_sane_to_take() {
+        // --|---------|---------|----------------------------------|--> time
+        //   -1h       |         +1h                                24h
+        // --|---------|<--------|--------------------------------->|--
+        //   now
+
+        let order = Order::dummy_short().with_oracle_event_id(BitMexPriceEventId::with_20_digits(
+            datetime!(2021-11-19 10:00:00).assume_utc(),
+        ));
+
+        let sane =
+            order.is_oracle_event_timestamp_sane(datetime!(2021-11-18 09:00:00).assume_utc());
+        assert!(sane, "the oracle event id is to far in the future")
+    }
+
+    #[test]
+    fn given_oracle_event_id_is_more_than_25h_in_the_future_then_not_sane_to_take() {
+        // --|---------|---------|----------------------------------|--> time
+        //   -1h1s     |         +1h                                24h
+        // --|---------|<--------|--------------------------------->|--
+        //   now
+
+        let order = Order::dummy_short().with_oracle_event_id(BitMexPriceEventId::with_20_digits(
+            datetime!(2021-11-19 10:00:00).assume_utc(),
+        ));
+
+        let sane =
+            order.is_oracle_event_timestamp_sane(datetime!(2021-11-18 08:59:59).assume_utc());
+        assert!(
+            !sane,
+            "an oracle event id that is too far in the future got accepted"
+        )
+    }
+
+    #[test]
+    fn given_oracle_event_id_is_less_than_23h_in_the_future_then_not_sane_to_take() {
+        // --|---------|---------|----------------------------------|--> time
+        //   -1h       |         +1h1s                              24h
+        // --|---------|<--------|--------------------------------->|--
+        //                       now
+
+        let order = Order::dummy_short().with_oracle_event_id(BitMexPriceEventId::with_20_digits(
+            datetime!(2021-11-19 10:00:00).assume_utc(),
+        ));
+
+        let sane =
+            order.is_oracle_event_timestamp_sane(datetime!(2021-11-18 11:00:01).assume_utc());
+        assert!(!sane, "an oracle event id that is outdated got accepted")
     }
 
     impl CfdEvent {
@@ -3455,6 +3597,16 @@ mod tests {
 
         fn with_funding_rate(mut self, funding_rate: FundingRate) -> Self {
             self.funding_rate = funding_rate;
+            self
+        }
+
+        fn with_creation_timestamp(mut self, creation_timestamp: Timestamp) -> Self {
+            self.creation_timestamp_maker = creation_timestamp;
+            self
+        }
+
+        fn with_oracle_event_id(mut self, event_id: BitMexPriceEventId) -> Self {
+            self.oracle_event_id = event_id;
             self
         }
     }


### PR DESCRIPTION
Motivation: 
Besides our discussion ensuring sanity on the maker side, given that we are in the P2P world, the more important issue is actually the taker ensuring sanity as good as possible. 

Implementation:
First we check that the maker offer's creation timestamp is not outdated. We consider a creation timestamp that is older than 10 minutes as outdated, i.e. if we don't receive a new offer from the maker within 10 minutes the taker will consider the offer as outdated when taking.
I think it is fair to assume that there will be *any* change that triggers the creation of new `MakerOffers` within 10 minutes.
Note: We currently trust the maker to send a sane `creation_timestamp`.

Furthermore, the oracle event id sent by the maker is checked for sanity.
The oracle event id is considered sane if it is within the interval: [25h,23h]
We choose 25h because we always ceil to the next full hour.
The maker cannot go back in time, as soon as the maker is past the full hour the next oracle event ID will be picked (anything else would be insane).
See tests for logic details.

If the taker's sanity check fails the offer will be removed on the taker side and an error is returned that indicates that the offer is outdated.
The taker does not start a contract setup if the sanity check fails, i.e. the taker does not send any messages to the maker if the sanity check fails.