### PR TITLE
Bid/ask for closing price instead of average

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -420,13 +420,10 @@ where
             .context("Price feed not available")?
             .context("No quote available")?;
 
-        let current_price = Price::new(latest_quote.for_taker())?;
         let quote_timestamp = latest_quote
             .timestamp
             .format(&time::format_description::well_known::Rfc3339)
             .context("Failed to format timestamp")?;
-
-        tracing::debug!(%order_id, %current_price, %quote_timestamp, "Proposing settlement of contract");
 
         let threshold = QUOTE_INTERVAL_MINUTES.minutes() * 2;
 
@@ -440,7 +437,9 @@ where
         self.cfd_actor
             .send(taker_cfd::ProposeSettlement {
                 order_id,
-                current_price,
+                bid: Price::new(latest_quote.bid())?,
+                ask: Price::new(latest_quote.ask())?,
+                quote_timestamp,
             })
             .await?
     }

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1469,6 +1469,23 @@ pub fn long_and_short_leverage(
     }
 }
 
+/// Decide the closing price according to role and position
+///
+/// Depending on role and position the closing price is determined from bid and ask price of the
+/// maker.
+/// Taker is long: When closing the taker sells short to close the position, i.e. the bid price
+/// applies.
+/// Taker is short: When closing the taker buys long to close the position, i.e. the
+/// ask price applies.
+/// In order to show the same closing price for maker and taker we need to take the counter-position
+/// for the maker.
+pub fn closing_price(bid: Price, ask: Price, role: Role, position: Position) -> Price {
+    match (role, position) {
+        (Role::Taker, Position::Long) | (Role::Maker, Position::Short) => bid,
+        (Role::Taker, Position::Short) | (Role::Maker, Position::Long) => ask,
+    }
+}
+
 /// Calculates the margin in BTC
 ///
 /// The initial margin represents the collateral both parties have to come up with

--- a/xtra-bitmex-price-feed/src/lib.rs
+++ b/xtra-bitmex-price-feed/src/lib.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use rust_decimal::Decimal;
-use rust_decimal_macros::dec;
 use std::fmt;
 use time::OffsetDateTime;
 use tokio_tasks::Tasks;
@@ -153,16 +152,12 @@ impl Quote {
         }))
     }
 
-    pub fn for_maker(&self) -> Decimal {
+    pub fn bid(&self) -> Decimal {
+        self.bid
+    }
+
+    pub fn ask(&self) -> Decimal {
         self.ask
-    }
-
-    pub fn for_taker(&self) -> Decimal {
-        self.mid_range()
-    }
-
-    fn mid_range(&self) -> Decimal {
-        (self.bid + self.ask) / dec!(2)
     }
 
     pub fn is_older_than(&self, duration: time::Duration) -> bool {
@@ -201,6 +196,7 @@ mod wire {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
     use time::ext::NumericalDuration;
 
     #[test]


### PR DESCRIPTION
Instead of using an average price we decide the closing price according to role and position.
This is mostly relevant for the taker, as the taker proposes the closing price. However, since we use the closing price for determining P/L, we have to be able to match the price on the maker side as well for sane values of P/L.