### PR TITLE
Update the feed after the offer changed

### DIFF
--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -199,10 +199,7 @@ where
             .await?;
 
         if !order_to_take.is_safe_to_take(OffsetDateTime::now_utc()) {
-            bail!(
-                "The maker's offer appears to be outdated, refusing to take: {:?}",
-                &order_to_take
-            );
+            bail!("The maker's offer appears to be outdated, refusing to take offer",);
         }
 
         tracing::info!("Taking current order: {:?}", &order_to_take);


### PR DESCRIPTION
If we don't do that we might run into the problem that the UI does not reflect what actually happened in the daemon.