### PR TITLE
Initiate timeout for the maker's collab settlement

### DIFF
--- a/daemon/src/collab_settlement_taker.rs
+++ b/daemon/src/collab_settlement_taker.rs
@@ -176,11 +176,11 @@ impl xtra::Actor for Actor {
             async move {
                 tokio::time::sleep(MAKER_RESPONSE_TIMEOUT).await;
 
-                this.send(MakerResponseTimeoutReached {
-                    timeout: MAKER_RESPONSE_TIMEOUT,
-                })
-                .await
-                .expect("can send to ourselves");
+                let _ = this
+                    .send(MakerResponseTimeoutReached {
+                        timeout: MAKER_RESPONSE_TIMEOUT,
+                    })
+                    .await;
             }
         };
 
@@ -243,7 +243,7 @@ impl Actor {
             .await
         {
             tracing::warn!(
-                "Failed to execute `fail_collaborative_settlement` command: {:#}",
+                order_id=%self.order_id, "Failed to execute `fail_collaborative_settlement` command: {:#}",
                 e
             );
         }

--- a/daemon/src/rollover_taker.rs
+++ b/daemon/src/rollover_taker.rs
@@ -223,11 +223,11 @@ impl xtra::Actor for Actor {
             async move {
                 tokio::time::sleep(MAKER_RESPONSE_TIMEOUT).await;
 
-                this.send(MakerResponseTimeoutReached {
-                    timeout: MAKER_RESPONSE_TIMEOUT,
-                })
-                .await
-                .expect("can send to ourselves");
+                let _ = this
+                    .send(MakerResponseTimeoutReached {
+                        timeout: MAKER_RESPONSE_TIMEOUT,
+                    })
+                    .await;
             }
         };
 

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -227,11 +227,11 @@ impl xtra::Actor for Actor {
             async move {
                 tokio::time::sleep(MAKER_RESPONSE_TIMEOUT).await;
 
-                this.send(MakerResponseTimeoutReached {
-                    timeout: MAKER_RESPONSE_TIMEOUT,
-                })
-                .await
-                .expect("can send to ourselves");
+                let _ = this
+                    .send(MakerResponseTimeoutReached {
+                        timeout: MAKER_RESPONSE_TIMEOUT,
+                    })
+                    .await;
             }
         };
 


### PR DESCRIPTION
If the taker never comes back to the maker with an `Initiate` message the maker's collaborative settlement actor will never finish.
We add a timeout after accept that ensures that we receive an `Initiate` message within 60 seconds after accepting.
Upon receiving `Initiate` we record that `Initiate` was received.

If the timeout is reached we only abort if `Initiate` was not received, because if it was received we can be sure the actor will finish.