### PR TITLE
Tiny step towards fixing the versioning mess

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -29,15 +29,6 @@ jobs:
           git config user.name "${{ secrets.ITCHY_NAME }}"
           git config user.email ${{ secrets.ITCHY_EMAIL }}
 
-      - name: Bump version in Cargo.toml
-        uses: thomaseizinger/set-crate-version@1.0.0
-        with:
-          version: ${{ github.event.inputs.version }}
-          manifest: daemon/Cargo.toml
-
-      - name: Update Cargo.lock
-        run: cargo update --workspace
-
       - name: Update changelog
         uses: thomaseizinger/keep-a-changelog-new-release@v1
         with:
@@ -49,7 +40,7 @@ jobs:
           curl -fsSL https://dprint.dev/install.sh | sh
           /home/runner/.dprint/bin/dprint fmt
 
-          git add Cargo.lock daemon/Cargo.toml CHANGELOG.md
+          git add CHANGELOG.md
           git commit --message "Prepare release ${{ github.event.inputs.version }}"
 
           echo "::set-output name=commit::$(git rev-parse HEAD)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "daemon"
-version = "0.4.7"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "maker"
-version = "0.4.7"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "taker"
-version = "0.4.7"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/daemon-tests/Cargo.toml
+++ b/daemon-tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "daemon-tests"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "daemon"
-version = "0.4.7"
+version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 anyhow = "1"

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "maker"
-version = "0.4.7"
+version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/shared-bin/Cargo.toml
+++ b/shared-bin/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shared-bin"
 version = "0.1.0"
 edition = "2021"
+publish = false
 description = "Code that is shared between the daemons but application specific and thus does not go into the `daemon` library."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/taker/Cargo.toml
+++ b/taker/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "taker"
-version = "0.4.7"
+version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Regardless of the outcome of https://github.com/itchysats/architecture/pull/16, setting the manifest version does nothing other than adding confusion.