### PR TITLE
Enhance logs a bit

### DIFF
--- a/daemon/src/rollover_maker.rs
+++ b/daemon/src/rollover_maker.rs
@@ -156,8 +156,6 @@ impl Actor {
 
         self.sent_from_taker = Some(sender);
 
-        tracing::debug!(%order_id, rollover_version = %self.version, "Maker accepts a rollover proposal");
-
         let (rollover_params, dlc, position, interval, funding_rate) = self
             .executor
             .execute(self.order_id, |cfd| {
@@ -172,6 +170,9 @@ impl Actor {
                 Ok((event, params, dlc, position, interval, funding_rate))
             })
             .await?;
+
+        tracing::debug!(%order_id, rollover_version = %self.version,
+            interval_in_hours = %interval.whole_hours(), "Maker accepting a rollover proposal");
 
         let oracle_event_id =
             oracle::next_announcement_after(time::OffsetDateTime::now_utc() + interval);

--- a/daemon/src/rollover_maker.rs
+++ b/daemon/src/rollover_maker.rs
@@ -156,7 +156,7 @@ impl Actor {
 
         self.sent_from_taker = Some(sender);
 
-        tracing::debug!(%order_id, "Maker accepts a rollover proposal");
+        tracing::debug!(%order_id, rollover_version = %self.version, "Maker accepts a rollover proposal");
 
         let (rollover_params, dlc, position, interval, funding_rate) = self
             .executor

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -872,14 +872,8 @@ impl Cfd {
         }
 
         let hours_to_charge = match version {
-            rollover::Version::V1 => {
-                tracing::debug!("Rollover V1");
-                1
-            }
-            rollover::Version::V2 => {
-                tracing::debug!("Rollover V2");
-                self.hours_to_extend_in_rollover()?
-            }
+            rollover::Version::V1 => 1,
+            rollover::Version::V2 => self.hours_to_extend_in_rollover()?,
         };
 
         let funding_fee = calculate_funding_fee(

--- a/model/src/rollover.rs
+++ b/model/src/rollover.rs
@@ -20,6 +20,15 @@ pub enum Version {
     V2,
 }
 
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Version::V1 => write!(f, "V1"),
+            Version::V2 => write!(f, "V2"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct RolloverParams {
     pub price: Price,


### PR DESCRIPTION
The log message `Rollover V2` or `Rollover V1` is not helpful by itself especially if there are multiple rollovers happening in parallel.