### PR TITLE
Dispatch projection update async

### DIFF
--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -218,7 +218,7 @@ impl<O, T, W> Actor<O, T, W> {
 
     async fn update_connected_takers(&mut self) -> Result<()> {
         self.projection
-            .send(projection::Update(
+            .send_async_safe(projection::Update(
                 self.connected_takers
                     .clone()
                     .into_iter()


### PR DESCRIPTION
We don't need to wait for this to complete and doing so diffuses the
metrics on how long the `TakerConnected` handlers takes. It also blocks
things like the `OfferParams` message.