### PR TITLE
Treat collab settlement accepted as IncomingSettlementProposal

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -262,7 +262,7 @@ impl Aggregated {
                     Role::Maker => CfdState::IncomingSettlementProposal,
                     Role::Taker => CfdState::OutgoingSettlementProposal,
                 },
-                ProtocolNegotiationState::Accepted => CfdState::PendingClose,
+                ProtocolNegotiationState::Accepted => CfdState::IncomingSettlementProposal,
             };
         };
         if let Some(rollover_state) = self.rollover_state {


### PR DESCRIPTION
`PendingClose` represents a state in which the maker is ready to publish (or has published) the collaborative close transaction. The maker is not ready to do so by the time he accepts the collaborative settlement protocol. Therefore, we stay in the
`IncomingSettlementProposal` state to prevent clients from drawing incorrect conclusions about the state of the CFD.

As a side-effect, we will report that the `AcceptSettlement` and `RejectSettlement` actions are still available for the maker even
after the collaborative settlement has been accepted once. We prefer this over introducing a new state because it only has implications on the `maker-automation-rs` client, which already protects against performing the same action repeatedly. Furthermore, the `collab_settlement_maker::Actor` guards against accepting twice.