### PR TITLE
Remove duplicate rollover received log

### DIFF
--- a/daemon/src/maker_cfd.rs
+++ b/daemon/src/maker_cfd.rs
@@ -270,8 +270,6 @@ where
         taker_id: Identity,
         version: RolloverVersion,
     ) -> Result<()> {
-        tracing::info!(%order_id, %taker_id,  "Received rollover proposal from taker");
-
         let rollover_actor_addr = rollover_maker::Actor::new(
             order_id,
             self.n_payouts,

--- a/daemon/src/rollover_maker.rs
+++ b/daemon/src/rollover_maker.rs
@@ -267,9 +267,11 @@ impl xtra::Actor for Actor {
     type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let order_id = self.order_id;
+        let taker_id = self.taker_id;
 
         tracing::info!(
             %order_id,
+            %taker_id,
             "Received rollover proposal"
         );
 


### PR DESCRIPTION
This is already logged inside `rollover_maker::Actor`.