### PR TITLE
Reuse reqwest::Client in oracle::Actor

### DIFF
--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -27,6 +27,7 @@ pub struct Actor {
     announcement_lookahead: Duration,
     tasks: Tasks,
     db: SqlitePool,
+    client: reqwest::Client,
 }
 
 #[derive(Clone, Copy)]
@@ -101,6 +102,7 @@ impl Actor {
             announcement_lookahead,
             tasks: Tasks::default(),
             db,
+            client: reqwest::Client::new(),
         }
     }
 
@@ -118,6 +120,7 @@ impl Actor {
                 continue;
             }
             let this = ctx.address().expect("self to be alive");
+            let client = self.client.clone();
 
             self.tasks.add_fallible(
                 async move {
@@ -125,7 +128,9 @@ impl Actor {
 
                     tracing::debug!("Fetching announcement for {event_id}");
 
-                    let response = reqwest::get(url.clone())
+                    let response = client
+                        .get(url.clone())
+                        .send()
                         .await
                         .with_context(|| format!("Failed to GET {url}"))?;
 
@@ -164,6 +169,7 @@ impl Actor {
             }
 
             let this = ctx.address().expect("self to be alive");
+            let client = self.client.clone();
 
             self.tasks.add_fallible(
                 async move {
@@ -171,7 +177,9 @@ impl Actor {
 
                     tracing::debug!("Fetching attestation for {event_id}");
 
-                    let response = reqwest::get(url.clone())
+                    let response = client
+                        .get(url.clone())
+                        .send()
                         .await
                         .with_context(|| format!("Failed to GET {url}"))?;
 


### PR DESCRIPTION
Analysis with flamegraphs show that we spend > 1% of our CPU time with
re-constructing `reqwest::Client`s. There is no need to do this, we can
reuse the same client for multiple requests.

The client uses an `Arc` internally so it is cheap to clone.

Based on my flamegraphing, this reduces the relative CPU time spent on the `ensure_having_announcements` function from **1.61%** to **0.65%**.

[flamegraphs.zip](https://github.com/itchysats/itchysats/files/8347794/flamegraphs.zip)