### PR TITLE
Allow 5 minutes for the taker to initiate collaborative settlement

### DIFF
--- a/daemon/src/collab_settlement_maker.rs
+++ b/daemon/src/collab_settlement_maker.rs
@@ -22,7 +22,7 @@ use xtras::address_map::IPromiseIamReturningStopAllFromStopping;
 /// If the taker does not come back with `Initiate` until the timeout is triggered we fail the
 /// settlement. If the taker does come back with `Initiate` before the timeout is reached, we don't
 /// fail the settlement even if the timeout is triggered.
-const INITIATE_TIMEOUT: Duration = Duration::from_secs(60);
+const INITIATE_TIMEOUT: Duration = Duration::from_secs(60 * 5);
 
 pub struct Actor {
     proposal: SettlementProposal,


### PR DESCRIPTION
In production, we saw scenarios where the timeout was triggered after 60s, but the taker never triggered a rollover again.
This could mean that the taker did send `Initiate` with the signature, but it did not arrive at the maker's collab settlement actor in time before the timeout was triggered, resulting in the taker to believe the settlement was "finished" (i.e. handled bt the maker), but the maker actually timed out.
As a quick fix this allows for 5 minutes to receive `Initiate` on the maker side instead of 1 minute.