### PR TITLE
Upgrade rustfmt dprint plugin

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -14,7 +14,7 @@
   "excludes": ["**/target", "**/sqlx-data.json", "maker-frontend/dist", "taker-frontend/dist", "**/node_modules"],
   "plugins": [
     "https://plugins.dprint.dev/markdown-0.9.2.wasm",
-    "https://plugins.dprint.dev/rustfmt-0.4.0.exe-plugin@c6bb223ef6e5e87580177f6461a0ab0554ac9ea6b54f78ea7ae8bf63b14f5bc2",
+    "https://plugins.dprint.dev/rustfmt-0.6.0.exe-plugin@8b65ed724170bd227e92a2f01d867e452ef7f26e78dc691999ffa37a276df27c",
     "https://plugins.dprint.dev/toml-0.4.0.wasm",
     "https://plugins.dprint.dev/typescript-0.35.0.wasm",
     "https://plugins.dprint.dev/json-0.7.2.wasm",


### PR DESCRIPTION
Note: you will need to upgrade your local dprint version!