### PR TITLE
Don't treat rollover accepted as contract setup

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -271,7 +271,12 @@ impl Aggregated {
                     Role::Maker => CfdState::IncomingRolloverProposal,
                     Role::Taker => CfdState::OutgoingRolloverProposal,
                 },
-                ProtocolNegotiationState::Accepted => CfdState::ContractSetup,
+                // TODO: we should have an own state here indicating that the position is being
+                // rolled over.
+                ProtocolNegotiationState::Accepted => match role {
+                    Role::Maker => CfdState::IncomingRolloverProposal,
+                    Role::Taker => CfdState::OutgoingRolloverProposal,
+                },
             };
         };
         self.state


### PR DESCRIPTION
The issue with this is that we need to distinguish between an open / not open CFD. It is not good that the same state is being used for while a CFD is being openend and while it is rolled over.

quick fix for #1701. A better solution is needed though. 

Please check closely if this can have some side effects I'm not aware of 