### PR TITLE
Add `/open_cfds` endpoint

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -510,7 +510,8 @@ impl Cfd {
 
                 self.aggregated.state = CfdState::PendingCommit;
 
-                // We argue that a decrypted CET being available will eventually lead to the joint output being spent.
+                // We argue that a decrypted CET being available will eventually lead to the joint
+                // output being spent.
                 self.aggregated.has_unspent_joint_output = false;
             }
             OracleAttestedPostCetTimelock { cet, price, .. } => {

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -509,6 +509,9 @@ impl Cfd {
                 self.closing_price = Some(price);
 
                 self.aggregated.state = CfdState::PendingCommit;
+
+                // We argue that a decrypted CET being available will eventually lead to the joint output being spent.
+                self.aggregated.has_unspent_joint_output = false;
             }
             OracleAttestedPostCetTimelock { cet, price, .. } => {
                 self.aggregated.cet = Some(cet);

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -262,6 +262,7 @@ async fn main() -> Result<()> {
                 routes::get_health_check,
                 routes::post_withdraw_request,
                 routes::get_cfds,
+                routes::get_open_cfds,
                 routes::get_takers,
                 routes::get_metrics,
             ],


### PR DESCRIPTION
We define "open" as "has a confirmed, unspent joint output". Our
definition of "confirmed" for these purposes is "having a transaction"
that can create such an output. This is the case after contract-setup
has finished but before we try to broadcast the transaction. Failing to
broadcast the transaction is extremely unlikely because our software is
in control of the wallet and should in normal operation prevent double-
spending.

If we ever extend our monitoring - and in a further step the event model
to account for transactions in mempool - we can potentially redefine
this as "transaction must have been successfully broadcasted".

## Note to reviewers

I set the boolean only where I deemed it necessary. Please pay close attention to whether or not it is set in all places correctly.