### PR TITLE
Don't make clients think our DB is empty

### DIFF
--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -75,7 +75,9 @@ pub async fn feed(
         yield quote.to_sse_event();
 
         let cfds = rx_cfds.borrow().clone();
-        yield cfds.to_sse_event();
+        if let Some(cfds) = cfds {
+            yield cfds.to_sse_event()
+        }
 
         loop{
             select! {
@@ -94,7 +96,9 @@ pub async fn feed(
                 }
                 Ok(()) = rx_cfds.changed() => {
                     let cfds = rx_cfds.borrow().clone();
-                    yield cfds.to_sse_event();
+                    if let Some(cfds) = cfds {
+                        yield cfds.to_sse_event()
+                    }
                 }
                 Ok(()) = rx_quote.changed() => {
                     let quote = rx_quote.borrow().clone();


### PR DESCRIPTION
Triggered by discussion: https://github.com/itchysats/maker-automation-rs/pull/124#discussion_r837068347

During startup, it can take a while to load the CFDs from the database.
Instead of lying to our clients during this time and presenting them an
empty list, we:

a) Don't emit the list on the feed
b) We return a 500 from the `/cfds` endpoint

There is nothing the client can do about this, hence it is not a 400.
Once the CFDs are loaded, the request will be fulfilled properly.

Fixes #1716.