### PR TITLE
Remove event JSON deserialization cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,6 @@ dependencies = [
  "bdk-ext",
  "btsieve",
  "bytes",
- "cached",
  "chashmap-async",
  "conquer-once",
  "derivative",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -13,7 +13,6 @@ bdk = { version = "0.18", default-features = false, features = ["electrum"] }
 bdk-ext = { path = "../bdk-ext" }
 btsieve = { path = "../btsieve" }
 bytes = "1"
-cached = { version = "0.34.0", default-features = false, features = ["proc_macro"] }
 chashmap-async = "0.1"
 conquer-once = "0.3"
 derivative = "2"


### PR DESCRIPTION
With the introduction of an in-memory cache for aggregates, each
event is at most deserialized once. This JSON deserialization cache thus
no longer serves much purpose.

Certain events - in particular those of open CFDs - will still be
deserialized several times. That is because the aggregate cache is
partitioned by _TypeId_ of the aggregate, meaning there is a separate
cache entry for the oracle::Cfd and monitor::Cfd for example.

Differently said, each event will be deserialized once per aggregate type.
For open CFDs, this will happen multiple times during startup as that is
where the aggregates in the `oracle` and `monitor` module are used.

This will likely negatively impact startup performance mildly. We choose
to accept this in favor of simplicity by removing the deserialization cache
in the model crate.