### PR TITLE
Fetch everything when building a release binary

### DIFF
--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Checkout tagged commit
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           ref: ${{ github.event.release.target_commitish }}
           token: ${{ secrets.ITCHY_GITHUB_TOKEN }}
 


### PR DESCRIPTION
Our testnet maker which uses this workflow keeps reporting it's running v0.1.0,
which is incorrect. As the version is based on the last git tag, it must
have not fetched the tags correctly.

Note: building a release might take slightly longer because of this change, as
    the checkout will take a bit longer.

For more information see: https://github.com/actions/checkout/issues/290