### PR TITLE
Fix skeleton loading if `funding rate == 0`

### DIFF
--- a/taker-frontend/src/components/Trade.tsx
+++ b/taker-frontend/src/components/Trade.tsx
@@ -242,7 +242,7 @@ export default function Trade({
                                         disabled={!fundingRateHourly}
                                     >
                                         <Td isNumeric>
-                                            <Skeleton isLoaded={!!fundingRateHourly}>
+                                            <Skeleton isLoaded={fundingRateHourly != null}>
                                                 Hourly @ {fundingRateHourly}%
                                             </Skeleton>
                                         </Td>


### PR DESCRIPTION
`null == undefined` is true, hence, `variable == null` will catch `variable == undefined && variable == null`

`!variable` would cast `undefined` to a boolean, so in general `!!undefined==false` BUT for us it was not working when `funding_rate=0`, because `!!funding_rate --> !!0--> !1 --> 0` 🙈

Differently said: 
after this fix, when we have a funding rate of 0

![image](https://user-images.githubusercontent.com/224613/161365253-5184fb52-fda5-4cd7-9b79-4abf82ba6e50.png)

will be 

![image](https://user-images.githubusercontent.com/224613/161365234-51abb8f9-8600-441a-a382-c406a5f7eac9.png)

