### PR TITLE
Introduce `projection::CfdState::RolloverSetup` variant

### DIFF
--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -422,7 +422,7 @@ async fn rollover_an_open_cfd(maker_position: Position) {
 
     maker.system.accept_rollover(order_id).await.unwrap();
 
-    wait_next_state!(order_id, maker, taker, CfdState::ContractSetup);
+    wait_next_state!(order_id, maker, taker, CfdState::RolloverSetup);
     wait_next_state!(order_id, maker, taker, CfdState::Open);
 }
 
@@ -509,7 +509,7 @@ async fn maker_accepts_rollover_after_commit_finality() {
         maker,
         taker,
         // FIXME: Maker wrongly changes state even when rollover does not happen
-        CfdState::ContractSetup,
+        CfdState::RolloverSetup,
         CfdState::OpenCommitted
     );
 }

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -275,7 +275,7 @@ impl Aggregated {
                     Role::Maker => CfdState::IncomingRolloverProposal,
                     Role::Taker => CfdState::OutgoingRolloverProposal,
                 },
-                ProtocolNegotiationState::Accepted => CfdState::ContractSetup,
+                ProtocolNegotiationState::Accepted => CfdState::RolloverSetup,
             };
         };
         self.state
@@ -656,6 +656,7 @@ impl Cfd {
             }
             (CfdState::IncomingRolloverProposal, Role::Taker) => HashSet::new(),
             (CfdState::OutgoingRolloverProposal, _) => HashSet::new(),
+            (CfdState::RolloverSetup, _) => HashSet::new(),
             (CfdState::Closed, _) => HashSet::new(),
             (CfdState::PendingRefund, _) => HashSet::new(),
             (CfdState::Refunded, _) => HashSet::new(),
@@ -1129,6 +1130,7 @@ pub enum CfdState {
     OutgoingSettlementProposal,
     IncomingRolloverProposal,
     OutgoingRolloverProposal,
+    RolloverSetup,
     Closed,
     PendingRefund,
     Refunded,

--- a/maker-frontend/src/components/Types.tsx
+++ b/maker-frontend/src/components/Types.tsx
@@ -99,6 +99,8 @@ export class State {
                 return "Rollover Proposed";
             case StateKey.OUTGOING_ROLLOVER_PROPOSAL:
                 return "Rollover Proposed";
+            case StateKey.ROLLOVER_SETUP:
+                return "Rollover Setup";
             case StateKey.PENDING_REFUND:
                 return "Pending Refund";
             case StateKey.REFUNDED:
@@ -139,6 +141,7 @@ export class State {
             case StateKey.INCOMING_SETTLEMENT_PROPOSAL:
             case StateKey.INCOMING_ROLLOVER_PROPOSAL:
             case StateKey.OUTGOING_ROLLOVER_PROPOSAL:
+            case StateKey.ROLLOVER_SETUP:
             case StateKey.PENDING_OPEN:
             case StateKey.REFUNDED:
             case StateKey.SETUP_FAILED:
@@ -170,6 +173,7 @@ export class State {
                 return StateGroupKey.PENDING_SETTLEMENT;
 
             case StateKey.INCOMING_ROLLOVER_PROPOSAL:
+            case StateKey.ROLLOVER_SETUP:
                 return StateGroupKey.PENDING_ROLLOVER;
 
             case StateKey.REJECTED:
@@ -207,6 +211,7 @@ const enum StateKey {
     INCOMING_SETTLEMENT_PROPOSAL = "IncomingSettlementProposal",
     OUTGOING_ROLLOVER_PROPOSAL = "OutgoingRolloverProposal",
     INCOMING_ROLLOVER_PROPOSAL = "IncomingRolloverProposal",
+    ROLLOVER_SETUP = "RolloverSetup",
     PENDING_REFUND = "PendingRefund",
     REFUNDED = "Refunded",
     SETUP_FAILED = "SetupFailed",

--- a/taker-frontend/src/types.ts
+++ b/taker-frontend/src/types.ts
@@ -122,6 +122,8 @@ export class State {
                 return "Funding";
             case StateKey.OUTGOING_ROLLOVER_PROPOSAL:
                 return "Funding";
+            case StateKey.ROLLOVER_SETUP:
+                return "Rollover Setup";
             case StateKey.PENDING_REFUND:
                 return "Refunding";
             case StateKey.REFUNDED:
@@ -164,6 +166,7 @@ export class State {
             case StateKey.CONTRACT_SETUP:
             case StateKey.OUTGOING_SETTLEMENT_PROPOSAL:
             case StateKey.INCOMING_SETTLEMENT_PROPOSAL:
+            case StateKey.ROLLOVER_SETUP:
             case StateKey.REFUNDED:
             case StateKey.CLOSED:
                 return default_color;
@@ -191,6 +194,7 @@ export class State {
                 return StateGroupKey.PENDING_SETTLEMENT;
 
             case StateKey.INCOMING_ROLLOVER_PROPOSAL:
+            case StateKey.ROLLOVER_SETUP:
                 return StateGroupKey.PENDING_ROLLOVER;
 
             case StateKey.REJECTED:
@@ -216,6 +220,7 @@ export const enum StateKey {
     INCOMING_SETTLEMENT_PROPOSAL = "IncomingSettlementProposal",
     OUTGOING_ROLLOVER_PROPOSAL = "OutgoingRolloverProposal",
     INCOMING_ROLLOVER_PROPOSAL = "IncomingRolloverProposal",
+    ROLLOVER_SETUP = "RolloverSetup",
     PENDING_REFUND = "PendingRefund",
     REFUNDED = "Refunded",
     SETUP_FAILED = "SetupFailed",


### PR DESCRIPTION
Fixes https://github.com/itchysats/itchysats/issues/1701.

So that we no longer reuse the `CfdState::ContractSetup` variant after the rollover protocol has been accepted but not yet completed.

This change does not introduce any clever behaviour into the frontend. We simply treat this new state as if the rollover was still
pending (which is technically true).