### PR TITLE
Change trigger for `add-new-pull-requests-to-project-board` action

### DIFF
--- a/.github/workflows/add-new-pull-requests-to-project-board.yml
+++ b/.github/workflows/add-new-pull-requests-to-project-board.yml
@@ -1,7 +1,7 @@
 name: Add new pull requests to project board
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
Fixes #1804.

Triggering this action on `pull_request_target` should grant `dependabot` access to the `secrets` environment variable. See
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.