### PR TITLE
Add metrics for position size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,6 +769,8 @@ dependencies = [
  "snow",
  "sqlx",
  "statrs",
+ "strum",
+ "strum_macros",
  "test-case",
  "thiserror",
  "time 0.3.9",
@@ -3958,6 +3960,25 @@ checksum = "b73800bcca56045d5ab138a48cd28a96093335335deaa916f22b5749c4150c79"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -35,6 +35,8 @@ sha2 = "0.10"
 snow = "0.9"
 sqlx = { version = "0.5", features = ["offline", "sqlite", "uuid", "runtime-tokio-rustls"] }
 statrs = "0.15"
+strum = "0.24"
+strum_macros = "0.24"
 thiserror = "1"
 time = { version = "0.3", features = ["serde", "macros", "parsing", "formatting", "serde-well-known"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }

--- a/daemon/src/cfd_metrics.rs
+++ b/daemon/src/cfd_metrics.rs
@@ -1,0 +1,116 @@
+use crate::projection::Cfd;
+use model::Position;
+use model::Usd;
+use rust_decimal::prelude::ToPrimitive;
+use std::collections::HashMap;
+
+const DIRECTION_LABEL: &str = "direction";
+const DIRECTION_LONG_LABEL: &str = "long";
+const DIRECTION_SHORT_LABEL: &str = "short";
+const STATUS_LABEL: &str = "status";
+const STATUS_OPEN_LABEL: &str = "open";
+const STATUS_CLOSED_LABEL: &str = "closed";
+const STATUS_FAILED_LABEL: &str = "failed";
+
+static POSITION_SIZE_GAUGE: conquer_once::Lazy<prometheus::GaugeVec> =
+    conquer_once::Lazy::new(|| {
+        prometheus::register_gauge_vec!(
+            "position_size_quantity",
+            "Total quantity of positions on itchsyats.",
+            &[DIRECTION_LABEL, STATUS_LABEL]
+        )
+        .unwrap()
+    });
+
+pub(crate) fn update_position_metrics(cfds: &[Cfd]) {
+    {
+        let open_cfds = cfds.iter().filter(|cfd| cfd.is_open());
+        let (open_long, open_short): (Vec<_>, Vec<_>) =
+            open_cfds.partition(|cfd| cfd.position == Position::Long);
+
+        POSITION_SIZE_GAUGE
+            .with(&HashMap::from([
+                (DIRECTION_LABEL, DIRECTION_LONG_LABEL),
+                (STATUS_LABEL, STATUS_OPEN_LABEL),
+            ]))
+            .set(
+                sum_amounts(&open_long)
+                    .into_decimal()
+                    .to_f64()
+                    .unwrap_or_default(),
+            );
+        POSITION_SIZE_GAUGE
+            .with(&HashMap::from([
+                (DIRECTION_LABEL, DIRECTION_SHORT_LABEL),
+                (STATUS_LABEL, STATUS_OPEN_LABEL),
+            ]))
+            .set(
+                sum_amounts(&open_short)
+                    .into_decimal()
+                    .to_f64()
+                    .unwrap_or_default(),
+            );
+    }
+
+    {
+        let closed_cfds = cfds.iter().filter(|cfd| cfd.is_closed());
+        let (closed_long, closed_short): (Vec<_>, Vec<_>) =
+            closed_cfds.partition(|cfd| cfd.position == Position::Long);
+
+        POSITION_SIZE_GAUGE
+            .with(&HashMap::from([
+                (DIRECTION_LABEL, DIRECTION_LONG_LABEL),
+                (STATUS_LABEL, STATUS_CLOSED_LABEL),
+            ]))
+            .set(
+                sum_amounts(&closed_long)
+                    .into_decimal()
+                    .to_f64()
+                    .unwrap_or_default(),
+            );
+        POSITION_SIZE_GAUGE
+            .with(&HashMap::from([
+                (DIRECTION_LABEL, DIRECTION_SHORT_LABEL),
+                (STATUS_LABEL, STATUS_CLOSED_LABEL),
+            ]))
+            .set(
+                sum_amounts(&closed_short)
+                    .into_decimal()
+                    .to_f64()
+                    .unwrap_or_default(),
+            );
+    }
+    {
+        let failed_cfds = cfds.iter().filter(|cfd| cfd.is_failed());
+        let (failed_long, failed_short): (Vec<_>, Vec<_>) =
+            failed_cfds.partition(|cfd| cfd.position == Position::Long);
+
+        POSITION_SIZE_GAUGE
+            .with(&HashMap::from([
+                (DIRECTION_LABEL, DIRECTION_LONG_LABEL),
+                (STATUS_LABEL, STATUS_FAILED_LABEL),
+            ]))
+            .set(
+                sum_amounts(&failed_long)
+                    .into_decimal()
+                    .to_f64()
+                    .unwrap_or_default(),
+            );
+        POSITION_SIZE_GAUGE
+            .with(&HashMap::from([
+                (DIRECTION_LABEL, DIRECTION_SHORT_LABEL),
+                (STATUS_LABEL, STATUS_FAILED_LABEL),
+            ]))
+            .set(
+                sum_amounts(&failed_short)
+                    .into_decimal()
+                    .to_f64()
+                    .unwrap_or_default(),
+            );
+    }
+}
+
+fn sum_amounts(cfds: &[&Cfd]) -> Usd {
+    cfds.iter()
+        .fold(Usd::ZERO, |sum, cfd| cfd.quantity_usd + sum)
+}

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -31,6 +31,7 @@ pub use bdk;
 pub use maia;
 
 pub mod auto_rollover;
+pub mod cfd_metrics;
 mod close_cfds;
 pub mod collab_settlement_maker;
 pub mod collab_settlement_taker;

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -1,3 +1,4 @@
+use crate::cfd_metrics::update_position_metrics;
 use crate::db;
 use crate::db::Settlement;
 use crate::Order;
@@ -730,7 +731,7 @@ impl Cfd {
         Some(url)
     }
 
-    fn is_open(&self) -> bool {
+    pub fn is_open(&self) -> bool {
         let in_open_state = vec![
             CfdState::PendingOpen,
             CfdState::Open,
@@ -752,7 +753,7 @@ impl Cfd {
         in_open_state && not_expired
     }
 
-    fn is_closed(&self) -> bool {
+    pub fn is_closed(&self) -> bool {
         if self.is_failed() {
             // a failed position is not closed
             return false;
@@ -760,7 +761,7 @@ impl Cfd {
         !self.is_open()
     }
 
-    fn is_failed(&self) -> bool {
+    pub fn is_failed(&self) -> bool {
         self.state == CfdState::SetupFailed
     }
 }
@@ -790,8 +791,9 @@ impl Tx {
                     &a.aggregated.creation_timestamp,
                 )
             })
-            .collect();
+            .collect::<Vec<_>>();
 
+        update_position_metrics(cfds_with_quote.as_slice());
         let _ = self.cfds.send(Some(cfds_with_quote));
     }
 

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -55,6 +55,8 @@ pub enum Error {
 pub struct Usd(Decimal);
 
 impl Usd {
+    pub const ZERO: Usd = Usd(Decimal::ZERO);
+
     pub fn new(value: Decimal) -> Self {
         Self(value)
     }


### PR DESCRIPTION
Concept ACK request: we want to move metrics from maker-metrics into the daemon for simplicity reasons and reduction of duplicating logic. 
The question is, "where" in the daemon should we derive the metrics from. 

If concept ack I'll remove some duplication and make the metrics function a bit nicer. 

Looks like this. 

```
# HELP position_size_quantity Total quantity of positions on itchsyats.
# TYPE position_size_quantity gauge
position_size_quantity{direction="long",status="closed"} 300
position_size_quantity{direction="long",status="failed"} 0
position_size_quantity{direction="long",status="open"} 0
position_size_quantity{direction="short",status="closed"} 700
position_size_quantity{direction="short",status="failed"} 0
position_size_quantity{direction="short",status="open"} 0
```