### PR TITLE
Remove `vout` from `commit_txs` table

### DIFF
--- a/daemon/migrations/20220404113202_create_closed_cfds_tables.sql
+++ b/daemon/migrations/20220404113202_create_closed_cfds_tables.sql
@@ -28,7 +28,6 @@ CREATE TABLE IF NOT EXISTS commit_txs (
     id integer PRIMARY KEY autoincrement,
     cfd_id integer NOT NULL,
     txid text NOT NULL,
-    vout integer NOT NULL,
     timestamp text NOT NULL,
     FOREIGN KEY (cfd_id) REFERENCES closed_cfds (id)
 );


### PR DESCRIPTION
Commit transactions only have one output, so it's pointless to include this information in this table.

Fixes this error reported in the logs:

> Failed to move closed CFD: error returned from database: NOT NULL constraint failed: commit_txs.vout: NOT NULL constraint failed: commit_txs.vout

The database expected a field that our model rightly does not support.