### PR TITLE
Generate ed25519 keypair from the seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,8 @@ dependencies = [
  "futures",
  "hkdf",
  "itertools",
+ "libp2p-core",
+ "libp2p-noise",
  "maia",
  "model",
  "parse-display",

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -182,7 +182,7 @@ impl Maker {
 
         let settlement_interval = SETTLEMENT_INTERVAL;
 
-        let (identity_pk, identity_sk) = config.seed.derive_identity();
+        let identities = config.seed.derive_identities();
 
         let (projection_actor, projection_context) = xtra::Context::new(None);
 
@@ -208,7 +208,7 @@ impl Maker {
             settlement_interval,
             config.n_payouts,
             projection_actor,
-            identity_sk,
+            identities.clone(),
             config.heartbeat_interval,
             address,
         )
@@ -227,7 +227,7 @@ impl Maker {
         Self {
             system: maker,
             feeds,
-            identity: model::Identity::new(identity_pk),
+            identity: model::Identity::new(identities.identity_pk),
             listen_addr: address,
             mocks,
             _tasks: tasks,
@@ -292,7 +292,7 @@ impl Taker {
         maker_address: SocketAddr,
         maker_identity: Identity,
     ) -> Self {
-        let (identity_pk, identity_sk) = config.seed.derive_identity();
+        let identities = config.seed.derive_identities();
 
         let db = db::memory().await.unwrap();
 
@@ -312,7 +312,7 @@ impl Taker {
             db.clone(),
             wallet_addr,
             config.oracle_pk,
-            identity_sk,
+            identities.clone(),
             |executor| {
                 let (oracle, mock) = OracleActor::new(executor);
                 oracle_mock = Some(mock);
@@ -353,7 +353,7 @@ impl Taker {
         ));
 
         Self {
-            id: model::Identity::new(identity_pk),
+            id: model::Identity::new(identities.identity_pk),
             system: taker,
             feeds,
             mocks,

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -19,6 +19,8 @@ derivative = "2"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hkdf = "0.12"
 itertools = "0.10"
+libp2p-core = { version = "0.32", default-features = false }
+libp2p-noise = "0.35"
 maia = "0.1.0"
 model = { path = "../model" }
 parse-display = "0.5.5"

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -18,6 +18,7 @@ use model::Price;
 use model::Role;
 use model::TxFeeRate;
 use model::Usd;
+use seed::Identities;
 use std::net::SocketAddr;
 use std::time::Duration;
 use time::ext::NumericalDuration;
@@ -93,7 +94,7 @@ where
         settlement_interval: time::Duration,
         n_payouts: usize,
         projection_actor: Address<projection::Actor>,
-        identity: x25519_dalek::StaticSecret,
+        identity: Identities,
         heartbeat_interval: Duration,
         p2p_socket: SocketAddr,
     ) -> Result<Self>
@@ -143,7 +144,7 @@ where
             Box::new(cfd_actor_addr.clone()),
             Box::new(cfd_actor_addr.clone()),
             Box::new(cfd_actor_addr.clone()),
-            identity,
+            identity.identity_sk,
             heartbeat_interval,
             p2p_socket,
         )));
@@ -296,7 +297,7 @@ where
         db: db::Connection,
         wallet_actor_addr: Address<W>,
         oracle_pk: schnorrsig::PublicKey,
-        identity_sk: x25519_dalek::StaticSecret,
+        identity: Identities,
         oracle_constructor: impl FnOnce(command::Executor) -> O,
         monitor_constructor: impl FnOnce(command::Executor) -> Result<M>,
         price_feed_constructor: impl (Fn() -> P) + Send + 'static,
@@ -370,7 +371,7 @@ where
         tasks.add(connection_actor_ctx.run(connection::Actor::new(
             maker_online_status_feed_sender,
             &cfd_actor_addr,
-            identity_sk,
+            identity.identity_sk,
             taker_heartbeat_timeout,
             connect_timeout,
         )));

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -191,11 +191,12 @@ async fn main() -> Result<()> {
     let auth_username = rocket_basicauth::Username("itchysats");
     let auth_password = seed.derive_auth_password::<rocket_basicauth::Password>();
 
-    let (identity_pk, identity_sk) = seed.derive_identity();
+    let identities = seed.derive_identities();
 
-    let hex_pk = hex::encode(identity_pk.to_bytes());
+    let peer_id = identities.peer_id();
+    let hex_pk = hex::encode(identities.identity_pk.to_bytes());
     tracing::info!(
-        "Authentication details: username='{auth_username}' password='{auth_password}', noise_public_key='{hex_pk}'",
+        "Authentication details: username='{auth_username}' password='{auth_password}', noise_public_key='{hex_pk}', peer_id='{peer_id}'",
     );
 
     let figment = rocket::Config::figment()
@@ -226,7 +227,7 @@ async fn main() -> Result<()> {
         SETTLEMENT_INTERVAL,
         N_PAYOUTS,
         projection_actor.clone(),
-        identity_sk,
+        identities,
         HEARTBEAT_INTERVAL,
         p2p_socket,
     )?;

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -244,20 +244,20 @@ async fn main() -> Result<()> {
     let maker_identity = Identity::new(maker_id);
 
     let bitcoin_network = network.bitcoin_network();
-    let (ext_priv_key, identity_sk, web_password) = match opts.umbrel_seed {
+    let (ext_priv_key, identities, web_password) = match opts.umbrel_seed {
         Some(seed_bytes) => {
             let seed = UmbrelSeed::from(seed_bytes);
             let ext_priv_key = seed.derive_extended_priv_key(bitcoin_network)?;
-            let (_, identity_sk) = seed.derive_identity();
+            let identities = seed.derive_identities();
             let web_password = opts.password.unwrap_or_else(|| seed.derive_auth_password());
-            (ext_priv_key, identity_sk, web_password)
+            (ext_priv_key, identities, web_password)
         }
         None => {
             let seed = RandomSeed::initialize(&data_dir.join("taker_seed")).await?;
             let ext_priv_key = seed.derive_extended_priv_key(bitcoin_network)?;
-            let (_, identity_sk) = seed.derive_identity();
+            let identities = seed.derive_identities();
             let web_password = opts.password.unwrap_or_else(|| seed.derive_auth_password());
-            (ext_priv_key, identity_sk, web_password)
+            (ext_priv_key, identities, web_password)
         }
     };
 
@@ -302,7 +302,7 @@ async fn main() -> Result<()> {
         db.clone(),
         wallet.clone(),
         *olivia::PUBLIC_KEY,
-        identity_sk,
+        identities,
         |executor| oracle::Actor::new(db.clone(), executor, SETTLEMENT_INTERVAL),
         {
             |executor| {


### PR DESCRIPTION
Pass it trough to the actor systems.

Unfortunately, it turned out to be impossible to derive peer id from maker id,
so we will need an additional CLI option on the taker side.
After this gets merged, we'll be able to easily add a default argument for the
taker based on maker logs.