### PR TITLE
Remove CFDs moved to `closed_cfds` table from aggregate cache

### DIFF
--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -122,7 +122,7 @@ pub struct Actor {
 
 /// Read-model of the CFD for the monitoring actor.
 #[derive(Clone)]
-struct Cfd {
+pub struct Cfd {
     id: OrderId,
     params: Option<MonitorParams>,
 

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -65,7 +65,7 @@ struct NewAttestationFetched {
 }
 
 #[derive(Default, Clone)]
-struct Cfd {
+pub struct Cfd {
     pending_attestation: Option<BitMexPriceEventId>,
     version: u32,
 }


### PR DESCRIPTION
Fixes #1851.

It's a draft because I'm not convinced we need this and I don't love the way the solution is implemented.

Even if we "wrongly" load a CFD in `closed_cfds` from the aggregate cache, nothing bad should happen. This is similar to loading a closed CFD in `cfds`. The difference is that for the former we would be unable to append new superfluous events to the database, and might log some misleading warnings.

The downsides of the changes in this PR are:

- We cannot programmatically ensure that we are removing from all caches (if we add new ones in the future).
- We have to make public types that were implementation details of certain modules.

Perhaps there's a better way to approach this, because cache invalidation is a [famously hard](https://www.martinfowler.com/bliki/TwoHardThings.html) problem.