### PR TITLE
Startup optimization

### DIFF
--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -25,7 +25,6 @@ use model::CET_TIMELOCK;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::time::Duration;
-use tokio::time::sleep;
 use tokio_tasks::Tasks;
 use xtra_productivity::xtra_productivity;
 use xtras::SendInterval;
@@ -621,16 +620,6 @@ impl xtra::Actor for Actor {
                             None => continue,
                             Some(params) => params,
                         };
-
-                        // NOTE: this is a band-aid fix.
-                        // It is possible for an attestation to be available when the refund
-                        // timelock has expired, for example, when the daemon goes down and is
-                        // restarted. In this case we want to prioritise
-                        // broadcasting the cet over the refund transaction.
-                        // We wait at least 30 seconds after the monitor actor is initialised before
-                        // reinitialising monitoring to give the daemon time to fetch and decrypt
-                        // the cet from the oracle if it is available.
-                        sleep(Duration::from_secs(30)).await;
 
                         this.send(ReinitMonitoring {
                             id,


### PR DESCRIPTION
When initialize monitoring we used to load cfds from the db twice in parallel. The problem is that the cache might not have been initialized when starting the second loop (they are processed in parallel). Hence, we unnecessarily load cfds twice from the db. This resulted in necessary load on our machine. Combining these two loops results in a huge optimization.

logs showing this is loaded twice: 
```
2022-04-20 00:48:13 DEBUG daemon::db: Applying new events to CFD order_id=0fdfe886-52cf-4409-bd9f-ca47f3450d1d aggregate=daemon::monitor::Cfd cfd_version=0 num_events=554
2022-04-20 00:48:13 DEBUG daemon::db: Applying new events to CFD order_id=0fdfe886-52cf-4409-bd9f-ca47f3450d1d aggregate=daemon::projection::Cfd cfd_version=0 num_events=554
2022-04-20 00:48:13 DEBUG daemon::db: Applying new events to CFD order_id=0fdfe886-52cf-4409-bd9f-ca47f3450d1d aggregate=daemon::oracle::Cfd cfd_version=0 num_events=554
2022-04-20 00:48:13 DEBUG daemon::db: Applying new events to CFD order_id=0fdfe886-52cf-4409-bd9f-ca47f3450d1d aggregate=daemon::monitor::Cfd cfd_version=0 num_events=554
```

Fun fact, loading this CFD from the DB in particular took 32seconds!!!