### PR TITLE
Roundtrip insertion of transactions into DB

### DIFF
--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -899,7 +899,7 @@ impl str::FromStr for TxFeeRate {
 
 impl_sqlx_type_display_from_str!(TxFeeRate);
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Txid(bdk::bitcoin::Txid);
 
 impl Txid {
@@ -931,7 +931,7 @@ impl From<Txid> for bdk::bitcoin::Txid {
 
 impl_sqlx_type_display_from_str!(Txid);
 
-#[derive(Debug, Clone, Copy, sqlx::Type)]
+#[derive(Debug, Clone, Copy, sqlx::Type, PartialEq)]
 #[sqlx(transparent)]
 pub struct Vout(u32);
 
@@ -1012,7 +1012,7 @@ impl From<&Contracts> for i64 {
 
 impl_sqlx_type_integer!(Contracts);
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Payout(Amount);
 
 impl Payout {


### PR DESCRIPTION
Adding these tests revealed a bug that is also fixed in this patch:

In the `cets` table, we were inserting the value of the `vout` column in the `payout` column (and vice-versa). This was possible (without hard errors) because those two columns share the same underlying type i.e. integer.