### PR TITLE
Only set `commit_tx` if it was not already set already

### DIFF
--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -947,10 +947,12 @@ impl ClosedCfdInputAggregate {
                 commit_tx,
                 price,
             } => {
-                self.commit = commit_tx.map(|tx| Commit {
-                    txid: Txid::new(tx.txid()),
-                    timestamp: event.timestamp,
-                });
+                if self.commit.is_none() {
+                    self.commit = commit_tx.map(|tx| Commit {
+                        txid: Txid::new(tx.txid()),
+                        timestamp: event.timestamp,
+                    });
+                }
 
                 let own_script_pubkey = self
                     .own_script_pubkey


### PR DESCRIPTION
fixes https://github.com/itchysats/itchysats/issues/1842

`OracleAttestedPriorCetTimelock` only contains the `commit_tx` to be published if it was not published by `ManualCommit` yet.
While this is not good event design we cannot easily change this, but the `ClosedCfdInputAggregate` has to take this fact into account.
For cases where we have a `ManualCommit` event and then `OracleAttestedPriorCetTimelock` we have to apply `OracleAttestedPriorCetTimelock`'s `commit_tx` only if the `commit_tx` is `None` at that point, otherwise we might overwrite `Some` with `None`.

Note: I will evaluate the correctness of the other `Aggregates` because it appears we don't deal with this optional `commit_tx` in any of them.