### PR TITLE
Set the `commit_tx` in the model if available upon oracle attestation

### DIFF
--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1438,8 +1438,15 @@ impl Cfd {
                 self.during_contract_setup = false;
             }
             OracleAttestedPostCetTimelock { cet, .. } => self.cet = Some(cet),
-            OracleAttestedPriorCetTimelock { timelocked_cet, .. } => {
+            OracleAttestedPriorCetTimelock {
+                timelocked_cet,
+                commit_tx,
+                ..
+            } => {
                 self.cet = Some(timelocked_cet);
+                if self.commit_tx.is_none() {
+                    self.commit_tx = commit_tx;
+                }
             }
             ContractSetupFailed { .. } => {
                 self.during_contract_setup = false;


### PR DESCRIPTION
I am not sure if we actually have edge cases where not setting this caused problems, but it is definitely more correct to apply it in case it only becomes available with the attestation (and not upon manual commit).
Note that we have to apply it only if it was not set previously, otherwise we might overwrite `Some` with `None`.


Note: In the projection this was already handled (without actually using the field, but it is correct). Oracle and monitor don't reason about this event.