### PR TITLE
Mark `add_opening_fee` and `add_funding_fee` as `must_use`

### DIFF
--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -864,7 +864,7 @@ impl ClosedCfdInputAggregate {
             RolloverCompleted { dlc, funding_fee } => {
                 self.own_script_pubkey = Some(dlc.script_pubkey_for(self.role));
 
-                self.fee_account.add_funding_fee(funding_fee);
+                self.fee_account = self.fee_account.add_funding_fee(funding_fee);
 
                 self.expiry_timestamp = Some(dlc.settlement_event_id.timestamp());
             }

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -807,6 +807,7 @@ impl FeeAccount {
         self.balance
     }
 
+    #[must_use]
     pub fn add_opening_fee(self, opening_fee: OpeningFee) -> Self {
         let fee: i64 = opening_fee
             .fee
@@ -829,6 +830,7 @@ impl FeeAccount {
         }
     }
 
+    #[must_use]
     pub fn add_funding_fee(self, funding_fee: FundingFee) -> Self {
         let fee: i64 = funding_fee
             .fee


### PR DESCRIPTION
These methods don't do anything to the original value i.e. they're immutable, so we must use the return value.

Adding the attribute to `add_funding_fee` reveals that we had a bug when moving CFDs to the `closed_cfds` table: we were ignoring the funding fee for every rollover that had occurred.