### PR TITLE
Re-introduce filter for confirmed spend when loading open

### DIFF
--- a/daemon/sqlx-data.json
+++ b/daemon/sqlx-data.json
@@ -1,6 +1,7 @@
 {
   "db": "SQLite",
   "14144da0cf79fcc6fa955b05b10ecad32375d4c74cba2a1dcd608703a7b3d1a0": {
+    "query": "\n        SELECT\n            commit_txs.txid as \"commit_txid: model::Txid\",\n            refund_txs.txid as \"txid: model::Txid\",\n            refund_txs.vout as \"vout: model::Vout\",\n            refund_txs.payout as \"payout: model::Payout\"\n        FROM\n            refund_txs\n        JOIN\n            commit_txs on commit_txs.id = refund_txs.cfd_id\n        JOIN\n            closed_cfds on closed_cfds.id = refund_txs.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        ",
     "describe": {
       "columns": [
         {
@@ -24,29 +25,29 @@
           "type_info": "Int64"
         }
       ],
+      "parameters": {
+        "Right": 1
+      },
       "nullable": [
         false,
         false,
         false,
         false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n        SELECT\n            commit_txs.txid as \"commit_txid: model::Txid\",\n            refund_txs.txid as \"txid: model::Txid\",\n            refund_txs.vout as \"vout: model::Vout\",\n            refund_txs.payout as \"payout: model::Payout\"\n        FROM\n            refund_txs\n        JOIN\n            commit_txs on commit_txs.id = refund_txs.cfd_id\n        JOIN\n            closed_cfds on closed_cfds.id = refund_txs.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        "
+      ]
+    }
   },
   "16d1dd8c374c41c479594214f1bc927759195f743d17f489d328040bb2a66b5f": {
+    "query": "\n        INSERT INTO commit_txs\n        (\n            cfd_id,\n            txid\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2\n        )\n        ",
     "describe": {
       "columns": [],
-      "nullable": [],
       "parameters": {
         "Right": 2
-      }
-    },
-    "query": "\n        INSERT INTO commit_txs\n        (\n            cfd_id,\n            txid\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2\n        )\n        "
+      },
+      "nullable": []
+    }
   },
   "1d4eb923917f299cba01fcdbb9c2a4b976432168fea82dc5e5d33d36dcddb5f0": {
+    "query": "\n                SELECT\n                    uuid as \"uuid: model::OrderId\"\n                FROM\n                    closed_cfds\n                ",
     "describe": {
       "columns": [
         {
@@ -54,17 +55,17 @@
           "ordinal": 0,
           "type_info": "Text"
         }
-      ],
-      "nullable": [
-        false
       ],
       "parameters": {
         "Right": 0
-      }
-    },
-    "query": "\n                SELECT\n                    uuid as \"uuid: model::OrderId\"\n                FROM\n                    closed_cfds\n                "
+      },
+      "nullable": [
+        false
+      ]
+    }
   },
   "58c86fddae29a8f0b7feb421d8566b14a41d5da18de07e1adc258a57376f56d4": {
+    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: model::OrderId\"\n            from\n                cfds\n            where exists (\n                select id from EVENTS as events\n                where events.cfd_id = cfds.id and\n                (\n                    events.name = $1 or\n                    events.name = $2 or\n                    events.name= $3\n                )\n            )\n            ",
     "describe": {
       "columns": [
         {
@@ -78,71 +79,47 @@
           "type_info": "Text"
         }
       ],
+      "parameters": {
+        "Right": 3
+      },
       "nullable": [
         true,
         false
-      ],
-      "parameters": {
-        "Right": 3
-      }
-    },
-    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: model::OrderId\"\n            from\n                cfds\n            where exists (\n                select id from EVENTS as events\n                where events.cfd_id = cfds.id and\n                (\n                    events.name = $1 or\n                    events.name = $2 or\n                    events.name= $3\n                )\n            )\n            "
+      ]
+    }
   },
   "6705894784db563cfc16ca0ac9c2a4eb152fe6f9111c068c4c077e7de930e0a0": {
+    "query": "\n        DELETE FROM\n            cfds\n        WHERE\n            cfds.uuid = $1\n        ",
     "describe": {
       "columns": [],
-      "nullable": [],
       "parameters": {
         "Right": 1
-      }
-    },
-    "query": "\n        DELETE FROM\n            cfds\n        WHERE\n            cfds.uuid = $1\n        "
+      },
+      "nullable": []
+    }
   },
   "6eb26ec9a02d29ae5e2d8335cc8a12bfef55fa1adb19d8089f5fbe307ffc8ba2": {
+    "query": "\n        INSERT INTO refund_txs\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2, $3, $4\n        )\n        ",
     "describe": {
       "columns": [],
-      "nullable": [],
       "parameters": {
         "Right": 4
-      }
-    },
-    "query": "\n        INSERT INTO refund_txs\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2, $3, $4\n        )\n        "
-  },
-  "6f62c7955e78812e603c5240cbcf888125d4afff2e43bbd4d37cbe043f561250": {
-    "describe": {
-      "columns": [
-        {
-          "name": "cfd_id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "uuid: model::OrderId",
-          "ordinal": 1,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        true,
-        false
-      ],
-      "parameters": {
-        "Right": 2
-      }
-    },
-    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: model::OrderId\"\n            from\n                cfds\n            where not exists (\n                select id from EVENTS as events\n                where events.cfd_id = cfds.id and\n                (\n                    events.name = $1 or\n                    events.name = $2\n                )\n            )\n            "
+      },
+      "nullable": []
+    }
   },
   "8192c50dcb3342b01b9ab39daadcbc73f75d3b7f48ae18dfe4d936ebf8725fb4": {
+    "query": "\n            INSERT INTO event_log (\n                cfd_id,\n                name,\n                created_at\n            )\n            VALUES\n            (\n                (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n                $2, $3\n            )\n            ",
     "describe": {
       "columns": [],
-      "nullable": [],
       "parameters": {
         "Right": 3
-      }
-    },
-    "query": "\n            INSERT INTO event_log (\n                cfd_id,\n                name,\n                created_at\n            )\n            VALUES\n            (\n                (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n                $2, $3\n            )\n            "
+      },
+      "nullable": []
+    }
   },
   "84874628e39ec1e5817555f4241fbb6925e19fccdcea20030249e01f159aab11": {
+    "query": "\n        SELECT\n            commit_txs.txid as \"commit_txid: model::Txid\",\n            cets.txid as \"txid: model::Txid\",\n            cets.vout as \"vout: model::Vout\",\n            cets.payout as \"payout: model::Payout\",\n            cets.price as \"price: model::Price\"\n        FROM\n            cets\n        JOIN\n            commit_txs on commit_txs.id = cets.cfd_id\n        JOIN\n            closed_cfds on closed_cfds.id = cets.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        ",
     "describe": {
       "columns": [
         {
@@ -171,40 +148,40 @@
           "type_info": "Text"
         }
       ],
+      "parameters": {
+        "Right": 1
+      },
       "nullable": [
         false,
         false,
         false,
         false,
         false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n        SELECT\n            commit_txs.txid as \"commit_txid: model::Txid\",\n            cets.txid as \"txid: model::Txid\",\n            cets.vout as \"vout: model::Vout\",\n            cets.payout as \"payout: model::Payout\",\n            cets.price as \"price: model::Price\"\n        FROM\n            cets\n        JOIN\n            commit_txs on commit_txs.id = cets.cfd_id\n        JOIN\n            closed_cfds on closed_cfds.id = cets.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        "
+      ]
+    }
   },
   "8be24a7ddeb039a60c0600232d742f9ba75c02cde7bf536bb190525be07f0d5b": {
+    "query": "\n        INSERT INTO collaborative_settlement_txs\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout,\n            price\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2, $3, $4, $5\n        )\n        ",
     "describe": {
       "columns": [],
-      "nullable": [],
       "parameters": {
         "Right": 5
-      }
-    },
-    "query": "\n        INSERT INTO collaborative_settlement_txs\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout,\n            price\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2, $3, $4, $5\n        )\n        "
+      },
+      "nullable": []
+    }
   },
   "9189ea1221610d712f3567ecf0aaf0ac201e9795de1fa5d6397996ac7cedfadb": {
+    "query": "\n        INSERT INTO closed_cfds\n        (\n            uuid,\n            position,\n            initial_price,\n            taker_leverage,\n            n_contracts,\n            counterparty_network_identity,\n            role,\n            fees,\n            expiry_timestamp,\n            lock_txid,\n            lock_dlc_vout\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n        ",
     "describe": {
       "columns": [],
-      "nullable": [],
       "parameters": {
         "Right": 11
-      }
-    },
-    "query": "\n        INSERT INTO closed_cfds\n        (\n            uuid,\n            position,\n            initial_price,\n            taker_leverage,\n            n_contracts,\n            counterparty_network_identity,\n            role,\n            fees,\n            expiry_timestamp,\n            lock_txid,\n            lock_dlc_vout\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n        "
+      },
+      "nullable": []
+    }
   },
   "a97c0728390b1d1bd516874a60f00fbd0f5d7cbd33fea156b760e42544710d71": {
+    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: model::OrderId\",\n                position as \"position: model::Position\",\n                initial_price as \"initial_price: model::Price\",\n                leverage as \"leverage: model::Leverage\",\n                settlement_time_interval_hours,\n                quantity_usd as \"quantity_usd: model::Usd\",\n                counterparty_network_identity as \"counterparty_network_identity: model::Identity\",\n                role as \"role: model::Role\",\n                opening_fee as \"opening_fee: model::OpeningFee\",\n                initial_funding_rate as \"initial_funding_rate: model::FundingRate\",\n                initial_tx_fee_rate as \"initial_tx_fee_rate: model::TxFeeRate\"\n            from\n                cfds\n            where\n                cfds.uuid = $1\n            ",
     "describe": {
       "columns": [
         {
@@ -268,6 +245,9 @@
           "type_info": "Null"
         }
       ],
+      "parameters": {
+        "Right": 1
+      },
       "nullable": [
         true,
         false,
@@ -281,14 +261,11 @@
         false,
         false,
         false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: model::OrderId\",\n                position as \"position: model::Position\",\n                initial_price as \"initial_price: model::Price\",\n                leverage as \"leverage: model::Leverage\",\n                settlement_time_interval_hours,\n                quantity_usd as \"quantity_usd: model::Usd\",\n                counterparty_network_identity as \"counterparty_network_identity: model::Identity\",\n                role as \"role: model::Role\",\n                opening_fee as \"opening_fee: model::OpeningFee\",\n                initial_funding_rate as \"initial_funding_rate: model::FundingRate\",\n                initial_tx_fee_rate as \"initial_tx_fee_rate: model::TxFeeRate\"\n            from\n                cfds\n            where\n                cfds.uuid = $1\n            "
+      ]
+    }
   },
   "ad1226a1cd097ba070294b41e818228e4a9ed07ce8b69bd1583eb854c4c84f0e": {
+    "query": "\n\n        select\n            name,\n            data,\n            created_at as \"created_at: model::Timestamp\"\n        from\n            events\n        join\n            cfds c on c.id = events.cfd_id\n        where\n            uuid = $1\n        limit $2,-1\n            ",
     "describe": {
       "columns": [
         {
@@ -307,18 +284,18 @@
           "type_info": "Text"
         }
       ],
+      "parameters": {
+        "Right": 2
+      },
       "nullable": [
         false,
         false,
         false
-      ],
-      "parameters": {
-        "Right": 2
-      }
-    },
-    "query": "\n\n        select\n            name,\n            data,\n            created_at as \"created_at: model::Timestamp\"\n        from\n            events\n        join\n            cfds c on c.id = events.cfd_id\n        where\n            uuid = $1\n        limit $2,-1\n            "
+      ]
+    }
   },
   "adcc764462a8cd428c52595130b9e5c7c3cf9438b97e90efa0f0da3446d12eb4": {
+    "query": "\n        SELECT\n            collaborative_settlement_txs.txid as \"txid: model::Txid\",\n            collaborative_settlement_txs.vout as \"vout: model::Vout\",\n            collaborative_settlement_txs.payout as \"payout: model::Payout\",\n            collaborative_settlement_txs.price as \"price: model::Price\"\n        FROM\n            collaborative_settlement_txs\n        JOIN\n            closed_cfds on closed_cfds.id = collaborative_settlement_txs.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        ",
     "describe": {
       "columns": [
         {
@@ -342,19 +319,19 @@
           "type_info": "Text"
         }
       ],
+      "parameters": {
+        "Right": 1
+      },
       "nullable": [
         false,
         false,
         false,
         false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n        SELECT\n            collaborative_settlement_txs.txid as \"txid: model::Txid\",\n            collaborative_settlement_txs.vout as \"vout: model::Vout\",\n            collaborative_settlement_txs.payout as \"payout: model::Payout\",\n            collaborative_settlement_txs.price as \"price: model::Price\"\n        FROM\n            collaborative_settlement_txs\n        JOIN\n            closed_cfds on closed_cfds.id = collaborative_settlement_txs.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        "
+      ]
+    }
   },
   "b633a4c59c3a069175bfc104961c1f9d27524ebfd00da4c7572feb3d7bf8f869": {
+    "query": "\n                SELECT\n                    uuid as \"uuid: model::OrderId\"\n                FROM\n                    cfds\n                ",
     "describe": {
       "columns": [
         {
@@ -363,26 +340,50 @@
           "type_info": "Text"
         }
       ],
-      "nullable": [
-        false
-      ],
       "parameters": {
         "Right": 0
-      }
-    },
-    "query": "\n                SELECT\n                    uuid as \"uuid: model::OrderId\"\n                FROM\n                    cfds\n                "
+      },
+      "nullable": [
+        false
+      ]
+    }
   },
-  "d248ffbb2d38a6a8f6475f7b5e2f2ee1ab5798149ba8b70aff3a6cc9457382ef": {
+  "cdc44ed0a0e4485f61b83ea31159360116ae2406c13a766443aeeed76587286d": {
+    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: model::OrderId\"\n            from\n                cfds\n            where not exists (\n                select id from EVENTS as events\n                where events.cfd_id = cfds.id and\n                (\n                    events.name = $1 or\n                    events.name = $2 or\n                    events.name= $3 or\n                    events.name= $4 or\n                    events.name= $5\n                )\n            )\n            ",
     "describe": {
-      "columns": [],
-      "nullable": [],
+      "columns": [
+        {
+          "name": "cfd_id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "uuid: model::OrderId",
+          "ordinal": 1,
+          "type_info": "Text"
+        }
+      ],
       "parameters": {
         "Right": 5
-      }
-    },
-    "query": "\n        INSERT INTO cets\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout,\n            price\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2, $3, $4, $5\n        )\n        "
+      },
+      "nullable": [
+        true,
+        false
+      ]
+    }
+  },
+  "d248ffbb2d38a6a8f6475f7b5e2f2ee1ab5798149ba8b70aff3a6cc9457382ef": {
+    "query": "\n        INSERT INTO cets\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout,\n            price\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2, $3, $4, $5\n        )\n        ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 5
+      },
+      "nullable": []
+    }
   },
   "da7431dcc9aa5d799bf29bef7fb6a8b31469fb2deb4eab99a518f03f79eabbf4": {
+    "query": "\n            SELECT\n                uuid as \"uuid: model::OrderId\",\n                position as \"position: model::Position\",\n                initial_price as \"initial_price: model::Price\",\n                taker_leverage as \"taker_leverage: model::Leverage\",\n                n_contracts as \"n_contracts: model::Contracts\",\n                counterparty_network_identity as \"counterparty_network_identity: model::Identity\",\n                role as \"role: model::Role\",\n                fees as \"fees: model::Fees\",\n                expiry_timestamp,\n                lock_txid as \"lock_txid: model::Txid\",\n                lock_dlc_vout as \"lock_dlc_vout: model::Vout\"\n            FROM\n                closed_cfds\n            WHERE\n                closed_cfds.uuid = $1\n            ",
     "describe": {
       "columns": [
         {
@@ -441,6 +442,9 @@
           "type_info": "Int64"
         }
       ],
+      "parameters": {
+        "Right": 1
+      },
       "nullable": [
         false,
         false,
@@ -453,21 +457,17 @@
         false,
         false,
         false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n            SELECT\n                uuid as \"uuid: model::OrderId\",\n                position as \"position: model::Position\",\n                initial_price as \"initial_price: model::Price\",\n                taker_leverage as \"taker_leverage: model::Leverage\",\n                n_contracts as \"n_contracts: model::Contracts\",\n                counterparty_network_identity as \"counterparty_network_identity: model::Identity\",\n                role as \"role: model::Role\",\n                fees as \"fees: model::Fees\",\n                expiry_timestamp,\n                lock_txid as \"lock_txid: model::Txid\",\n                lock_dlc_vout as \"lock_dlc_vout: model::Vout\"\n            FROM\n                closed_cfds\n            WHERE\n                closed_cfds.uuid = $1\n            "
+      ]
+    }
   },
   "fc7e8992943cd5c64d307272eb1951e4c7c645308b20245d5f2818aaaf3b265b": {
+    "query": "\n        DELETE FROM\n            events\n        WHERE events.cfd_id IN\n            (SELECT id FROM cfds WHERE cfds.uuid = $1)\n        ",
     "describe": {
       "columns": [],
-      "nullable": [],
       "parameters": {
         "Right": 1
-      }
-    },
-    "query": "\n        DELETE FROM\n            events\n        WHERE events.cfd_id IN\n            (SELECT id FROM cfds WHERE cfds.uuid = $1)\n        "
+      },
+      "nullable": []
+    }
   }
 }

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -385,10 +385,16 @@ impl Connection {
                 where events.cfd_id = cfds.id and
                 (
                     events.name = $1 or
-                    events.name = $2
+                    events.name = $2 or
+                    events.name= $3 or
+                    events.name= $4 or
+                    events.name= $5
                 )
             )
             "#,
+            EventKind::COLLABORATIVE_SETTLEMENT_CONFIRMED,
+            EventKind::CET_CONFIRMED,
+            EventKind::REFUND_CONFIRMED,
             EventKind::CONTRACT_SETUP_FAILED,
             EventKind::OFFER_REJECTED
         )


### PR DESCRIPTION
If we don't do this an initial startup can take significant time (because we load all CFDs including closed ones in oracle and monitor again processing really a lot of attestations, ...).
This filter does not do any harm and is also valid when keeping the application running, because we only trigger the move to `closed_cfds` on some interval.