### PR TITLE
Use refund TX to calculate payout in projection

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -261,11 +261,7 @@ impl Aggregated {
         }
 
         let tx = self.cet.or(self.timelocked_cet)?;
-        let dlc = self
-            .latest_dlc
-            .as_ref()
-            .expect("dlc to be present when we have a cet");
-        let script = dlc.script_pubkey_for(role);
+        let script = self.latest_dlc?.script_pubkey_for(role);
 
         Some(extract_payout_amount(tx, script))
     }


### PR DESCRIPTION
Although exceedingly rare, a CFD's payout can come from a refund transaction