### PR TITLE
Use rayon to deserialize CFD events in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg 1.1.0",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +819,7 @@ dependencies = [
  "pretty_assertions",
  "prometheus",
  "rand 0.6.5",
+ "rayon",
  "reqwest",
  "rust_decimal",
  "rust_decimal_macros",
@@ -1863,6 +1899,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg 1.1.0",
+]
 
 [[package]]
 name = "mime"
@@ -3004,6 +3049,30 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+dependencies = [
+ "autocfg 1.1.0",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
 
 [[package]]
 name = "rdrand"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -26,6 +26,7 @@ model = { path = "../model" }
 parse-display = "0.5.5"
 prometheus = { version = "0.13", default-features = false }
 rand = "0.6"
+rayon = "1.5"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
 rust_decimal = { version = "1.23", features = ["serde-with-float"] }
 rust_decimal_macros = "1.23"

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -1088,12 +1088,14 @@ async fn load_cfd_row(conn: &mut Transaction<'_, Sqlite>, id: OrderId) -> Result
 ///
 /// The version of a CFD is the number of events that have been applied. If we have an aggregate
 /// instance in version 3, we can avoid loading the first 3 events and only apply the ones after.
+///
+/// Events will be sorted in chronological order.
 async fn load_cfd_events(
     conn: &mut Transaction<'_, Sqlite>,
     id: OrderId,
     from_version: u32,
 ) -> Result<Vec<CfdEvent>> {
-    let events = sqlx::query!(
+    let mut events = sqlx::query!(
         r#"
 
         select
@@ -1122,6 +1124,8 @@ async fn load_cfd_events(
         })
     })
     .collect::<Result<Vec<_>>>()?;
+
+    events.sort_unstable_by(CfdEvent::chronologically);
 
     Ok(events)
 }

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -33,6 +33,7 @@ use model::Txid;
 use model::Usd;
 use model::Vout;
 use model::SETTLEMENT_INTERVAL;
+use rayon::prelude::*;
 use sqlx::migrate::MigrateError;
 use sqlx::pool::PoolConnection;
 use sqlx::sqlite::SqliteConnectOptions;
@@ -1112,7 +1113,7 @@ async fn load_cfd_events(
     )
     .fetch_all(&mut *conn)
     .await?
-    .into_iter()
+    .into_par_iter()
     .map(|row| {
         Ok(CfdEvent {
             timestamp: row.created_at,

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -53,6 +53,7 @@ use rust_decimal_macros::dec;
 use serde::de::Error as _;
 use serde::Deserialize;
 use serde::Serialize;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::ops::RangeInclusive;
@@ -377,6 +378,32 @@ impl CfdEvent {
             id,
             event,
         }
+    }
+
+    /// Comparison function to order two events chronologically.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use model::{CfdEvent, Timestamp, EventKind, OrderId};
+    ///
+    /// # let id = OrderId::default();
+    /// # let make_event_at = move |seconds| CfdEvent {
+    /// #    timestamp: Timestamp::new(seconds),
+    /// #    id,
+    /// #    event: EventKind::LockConfirmed,
+    /// # };
+    /// #
+    /// let first = make_event_at(2000);
+    /// let second = make_event_at(3000);
+    ///
+    /// let mut events = vec![second.clone(), first.clone()];
+    /// events.sort_unstable_by(CfdEvent::chronologically);
+    ///
+    /// assert_eq!(events, vec![first, second])
+    /// ```
+    pub fn chronologically(left: &CfdEvent, right: &CfdEvent) -> Ordering {
+        left.timestamp.cmp(&right.timestamp)
     }
 }
 


### PR DESCRIPTION
Rayon is a parallel data processing library. By replacing `into_iter`
with `into_par_iter`, we are constructing a parallel iterator that is
baked by a thread-pool which defaults to a number of threads equal to
the logical cores of the system.

On my local machine (8 logical cores), this speeds up the
`projection::Initialize` handler from 83 to 28 seconds for a 2.8 GB
database.