### PR TITLE
Split sensitive authentication details from public ids

### DIFF
--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -196,7 +196,7 @@ async fn main() -> Result<()> {
     let peer_id = identities.peer_id();
     let hex_pk = hex::encode(identities.identity_pk.to_bytes());
     tracing::info!("Authentication details: username='{auth_username}' password='{auth_password}'");
-    tracing::info!("Details for takers: maker_id='{hex_pk}', peer_id='{peer_id}'");
+    tracing::info!("Connection details: maker_id='{hex_pk}', peer_id='{peer_id}'");
 
     let figment = rocket::Config::figment()
         .merge(("address", opts.http_address.ip()))

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -195,9 +195,8 @@ async fn main() -> Result<()> {
 
     let peer_id = identities.peer_id();
     let hex_pk = hex::encode(identities.identity_pk.to_bytes());
-    tracing::info!(
-        "Authentication details: username='{auth_username}' password='{auth_password}', noise_public_key='{hex_pk}', peer_id='{peer_id}'",
-    );
+    tracing::info!("Authentication details: username='{auth_username}' password='{auth_password}'");
+    tracing::info!("Details for takers: maker_id='{hex_pk}', peer_id='{peer_id}'");
 
     let figment = rocket::Config::figment()
         .merge(("address", opts.http_address.ip()))


### PR DESCRIPTION
We filter sensitive details out, making in unnecessarily hard to find public
maker details.
Rename `noise_public_key` to maker_id (as it's referred elsewhere in the codebase)