### PR TITLE
Fix arithmetic error

### DIFF
--- a/xtra-libp2p-ping/src/lib.rs
+++ b/xtra-libp2p-ping/src/lib.rs
@@ -129,7 +129,7 @@ impl Actor {
 
         tracing::trace!(%peer, %latency_milliseconds, "Received pong");
 
-        let latency_seconds = (latency_milliseconds as f64) * 1000.0;
+        let latency_seconds = (latency_milliseconds as f64) / 1000.0;
         PEER_LATENCY_HISTOGRAM.observe(latency_seconds);
     }
 


### PR DESCRIPTION
To go from milliseconds to seconds, we need to divide, not multiply.