### PR TITLE
Do not apply current quote to a closed `projection::Cfd`

### DIFF
--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -1728,18 +1728,23 @@ mod tests {
             .await
             .unwrap();
 
-        let projection_open = db
-            .load_open_cfd::<crate::projection::Cfd>(order_id, bdk::bitcoin::Network::Testnet)
-            .await
-            .unwrap();
-        let projection_open = projection_open.with_current_quote(None); // to update payout-related fields
+        let projection_open = {
+            let projection_open = db
+                .load_open_cfd::<crate::projection::Cfd>(order_id, bdk::bitcoin::Network::Testnet)
+                .await
+                .unwrap();
+            projection_open.with_current_quote(None) // unconditional processing in `projection`
+        };
 
         db.move_to_closed_cfds().await.unwrap();
 
-        let projection_closed = db
-            .load_closed_cfd::<crate::projection::Cfd>(order_id, bdk::bitcoin::Network::Testnet)
-            .await
-            .unwrap();
+        let projection_closed = {
+            let projection_closed = db
+                .load_closed_cfd::<crate::projection::Cfd>(order_id, bdk::bitcoin::Network::Testnet)
+                .await
+                .unwrap();
+            projection_closed.with_current_quote(None) // unconditional processing in `projection`
+        };
 
         // this comparison actually omits the `aggregated` field on
         // `projection::Cfd` because it is not used when aggregating

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -556,6 +556,11 @@ impl Cfd {
     }
 
     pub fn with_current_quote(self, latest_quote: Option<xtra_bitmex_price_feed::Quote>) -> Self {
+        // Closed CFDs should not be modified by the current quote
+        if self.aggregated.state == CfdState::Closed {
+            return self;
+        }
+
         // If we have a dedicated closing price, use that one.
         if let Some(payout) = self.aggregated.clone().payout(self.role) {
             let payout = payout


### PR DESCRIPTION
Fixes a bug mentioned here: https://github.com/itchysats/itchysats/pull/1916#discussion_r860547648.

When the `closed_cfds` DB table was introduced, we added a test to check that the changes had not affected `projection`.

Unfortunately, we missed the fact that all CFDs, whether loaded on the initialisation of the `projection::Actor` or updated on reception of a `CfdChanged` message, actually go through the `with_current_quote` method. Originally we thought that closed CFDs, which can never receive updates, did not go through `with_current_quote`.

This caused a bug because `with_current_quote` overwrites the `profit_btc`, `profit_percent` and `payout` fields. These are already set correctly when closed CFDs are loaded from the database.

