### PR TITLE
User interface improvements

### DIFF
--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -51,6 +51,12 @@ export interface Offer {
     leverage: number;
 }
 
+// TODO: Evaluate moving these globals into the theme to make them accessible through that
+export const VIEWPORT_WIDTH = 1000;
+export const VIEWPORT_WIDTH_PX = VIEWPORT_WIDTH + "px";
+export const BG_LIGHT = "gray.50";
+export const BG_DARK = "gray.800";
+
 export const App = () => {
     const toast = useToast();
 
@@ -169,68 +175,78 @@ export const App = () => {
                 nextFundingEvent={nextFundingEvent}
                 referencePrice={referencePrice}
             />
-            <Box textAlign="center" padding={3} bg={useColorModeValue("gray.50", "gray.800")}>
-                <Center marginTop={20}>
-                    <Routes>
-                        <Route path="/">
-                            <Route
-                                path="wallet"
-                                element={
-                                    <>
-                                        <Wallet walletInfo={walletInfo} />
-                                    </>
-                                }
-                            />
-                            <Route
-                                element={
-                                    // @ts-ignore: ts-lint thinks that {children} is missing but react router is taking care of this for us
-
-
-                                        <PageLayout
-                                            cfds={cfds}
-                                            connectedToMaker={connectedToMaker}
-                                            showPromoBanner={isWithinPromoPeriod}
-                                        />
-
-                                }
+            <Box>
+                <Center>
+                    <Box
+                        maxWidth={(VIEWPORT_WIDTH + 200) + "px"}
+                        width={"100%"}
+                        height={"100%"}
+                        bgGradient={useColorModeValue(
+                            "linear(to-r, white 5%, gray.800, white 95%)",
+                            "linear(to-r, gray.800, white, gray.800)",
+                        )}
+                    >
+                        <Center>
+                            <Box
+                                textAlign="center"
+                                padding={3}
+                                bg={useColorModeValue(BG_LIGHT, BG_DARK)}
+                                maxWidth={VIEWPORT_WIDTH_PX}
+                                width={"100%"}
+                                marginTop={"100px"}
                             >
-                                <Route
-                                    path="long"
-                                    element={
-                                        <>
-                                            <Trade
-                                                offer={longOffer}
-                                                connectedToMaker={connectedToMaker}
-                                                walletBalance={walletInfo ? walletInfo.balance : 0}
-                                                isLong={true}
+                                <Routes>
+                                    <Route path="/">
+                                        <Route
+                                            path="wallet"
+                                            element={<Wallet walletInfo={walletInfo} />}
+                                        />
+                                        <Route
+                                            element={
+                                                // @ts-ignore: ts-lint thinks that {children} is missing but react router is taking care of this for us
+
+
+                                                    <PageLayout
+                                                        cfds={cfds}
+                                                        connectedToMaker={connectedToMaker}
+                                                        showPromoBanner={isWithinPromoPeriod}
+                                                    />
+
+                                            }
+                                        >
+                                            <Route
+                                                path="long"
+                                                element={
+                                                    <Trade
+                                                        offer={longOffer}
+                                                        connectedToMaker={connectedToMaker}
+                                                        walletBalance={walletInfo ? walletInfo.balance : 0}
+                                                        isLong={true}
+                                                    />
+                                                }
                                             />
-                                        </>
-                                    }
-                                />
-                                <Route
-                                    path="short"
-                                    element={
-                                        <>
-                                            <Trade
-                                                offer={shortOffer}
-                                                connectedToMaker={connectedToMaker}
-                                                walletBalance={walletInfo ? walletInfo.balance : 0}
-                                                isLong={false}
+                                            <Route
+                                                path="short"
+                                                element={
+                                                    <Trade
+                                                        offer={shortOffer}
+                                                        connectedToMaker={connectedToMaker}
+                                                        walletBalance={walletInfo ? walletInfo.balance : 0}
+                                                        isLong={false}
+                                                    />
+                                                }
                                             />
-                                        </>
-                                    }
-                                />
-                            </Route>
-                            <Route index element={<Navigate to="long" />} />
-                        </Route>
-                        <Route
-                            path="/*"
-                            element={
-                                <>
-                                </>
-                            }
-                        />
-                    </Routes>
+                                        </Route>
+                                        <Route index element={<Navigate to="long" />} />
+                                    </Route>
+                                    <Route
+                                        path="/*"
+                                        element={<Navigate to="long" />}
+                                    />
+                                </Routes>
+                            </Box>
+                        </Center>
+                    </Box>
                 </Center>
             </Box>
             <Footer />
@@ -273,7 +289,7 @@ function HistoryLayout({ cfds, connectedToMaker }: HistoryLayoutProps) {
 
             {closedPositions.length > 0
                 && (
-                    <Accordion allowToggle width={"80%"}>
+                    <Accordion allowToggle maxWidth={VIEWPORT_WIDTH_PX} width={"100%"}>
                         <AccordionItem>
                             <h2>
                                 <AccordionButton>

--- a/taker-frontend/src/components/AlertBox.tsx
+++ b/taker-frontend/src/components/AlertBox.tsx
@@ -1,4 +1,3 @@
-import { ExternalLinkIcon } from "@chakra-ui/icons";
 import { Alert, AlertDescription, AlertIcon, AlertStatus, AlertTitle, Link } from "@chakra-ui/react";
 import * as React from "react";
 import { Link as ReachLink } from "react-router-dom";
@@ -21,7 +20,6 @@ export default function AlertBox({ title, description, status = "error", reachLi
                         <AlertDescription textDecor={"underline"}>
                             {description}
                         </AlertDescription>
-                        <ExternalLinkIcon marginLeft={1} marginBottom={1} />
                     </Link>
                 )
                 : (

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -1,26 +1,27 @@
-import { HamburgerIcon, MoonIcon, SunIcon } from "@chakra-ui/icons";
+import { Icon, MoonIcon, SunIcon, WarningIcon } from "@chakra-ui/icons";
 import {
     Box,
     Button,
+    ButtonGroup,
+    Center,
     Divider,
     Flex,
     Heading,
     HStack,
     Image,
     Link,
-    Menu,
-    MenuButton,
-    MenuItem,
-    MenuList,
     Skeleton,
     Stack,
     Text,
     Tooltip,
     useColorMode,
     useColorModeValue,
+    VStack,
 } from "@chakra-ui/react";
 import * as React from "react";
-import { useNavigate } from "react-router-dom";
+import { FaHome, FaWallet } from "react-icons/all";
+import { Link as ReachLink, useLocation, useNavigate } from "react-router-dom";
+import { BG_DARK, BG_LIGHT, VIEWPORT_WIDTH_PX } from "../App";
 import logoBlack from "../images/logo_nav_bar_black.svg";
 import logoWhite from "../images/logo_nav_bar_white.svg";
 import { ConnectionCloseReason, ConnectionStatus, WalletInfo } from "../types";
@@ -51,100 +52,205 @@ export default function Nav({ walletInfo, connectedToMaker, nextFundingEvent, re
         <SunIcon />,
     );
 
-    let connectionMessage = connectedToMaker.online
-        ? { label: "Online", color: { light: "green.600", dark: "green.500" } }
-        : { label: "Offline", color: { light: "red.600", dark: "red.500" } };
-
-    if (connectedToMaker.connection_close_reason) {
-        switch (connectedToMaker.connection_close_reason) {
-            case ConnectionCloseReason.MAKER_VERSION_OUTDATED:
-                connectionMessage.label = connectionMessage
-                    .label + ": the maker is running an outdated version, please reach out to ItchySats!";
-                break;
-            case ConnectionCloseReason.TAKER_VERSION_OUTDATED:
-                connectionMessage.label = connectionMessage.label
-                    + ": you are running an incompatible version, please upgrade!";
-                break;
+    const connectionStatus = (connectedToMaker: ConnectionStatus) => {
+        if (connectedToMaker.connection_close_reason) {
+            switch (connectedToMaker.connection_close_reason) {
+                case ConnectionCloseReason.MAKER_VERSION_OUTDATED:
+                    return {
+                        warn: true,
+                        light: "yellow.800",
+                        dark: "yellow.200",
+                        tooltip: "The maker is running an outdated version, please reach out to ItchySats!",
+                    };
+                case ConnectionCloseReason.TAKER_VERSION_OUTDATED:
+                    return {
+                        warn: true,
+                        light: "yellow.800",
+                        dark: "yellow.200",
+                        tooltip: "You are running an incompatible version, please upgrade!",
+                    };
+            }
         }
-    }
+
+        if (connectedToMaker.online) {
+            return {
+                warn: false,
+                light: "green.600",
+                dark: "green.400",
+                tooltip: "The maker is online",
+            };
+        }
+
+        return {
+            warn: false,
+            light: "red.600",
+            dark: "red.400",
+            tooltip: "The maker is offline",
+        };
+    };
+
+    const connectionStatusDisplay = connectionStatus(connectedToMaker);
+
+    const connectionStatusIconColor = useColorModeValue(
+        connectionStatusDisplay.light,
+        connectionStatusDisplay.dark,
+    );
 
     return (
         <>
-            <Box bg={useColorModeValue("gray.100", "gray.900")} px={4} position={"fixed"} width={"100%"} zIndex={"100"}>
-                <Flex h={16} alignItems={"center"} justifyContent={"space-between"}>
-                    <Flex justifyContent={"flex-left"} width={"180px"}>
-                        <Menu>
-                            <MenuButton
-                                as={Button}
-                                variant={"link"}
-                                cursor={"pointer"}
-                                minW={0}
-                            >
-                                <HamburgerIcon w={"32px"} />
-                            </MenuButton>
-                            <MenuList alignItems={"center"}>
-                                <MenuItem onClick={() => navigate("/")}>Home</MenuItem>
-                                <MenuItem onClick={() => navigate("/wallet")}>Wallet</MenuItem>
-                            </MenuList>
-                        </Menu>
-                    </Flex>
-                    <HStack>
-                        <Text>{"Maker: "}</Text>
-                        <Heading
-                            size={"sm"}
-                            color={useColorModeValue(connectionMessage.color.light, connectionMessage.color.dark)}
+            <VStack spacing={0} position={"fixed"} width={"100%"} zIndex={"100"} height={"100px"}>
+                <Box bg={useColorModeValue("gray.100", "gray.900")} width={"100%"}>
+                    <Center>
+                        <Box
+                            paddingBottom={2}
+                            bg={useColorModeValue("gray.100", "gray.900")}
+                            width={"100%"}
+                            maxWidth={VIEWPORT_WIDTH_PX}
                         >
-                            {connectionMessage.label}
-                        </Heading>
-                        <TextDivider />
-                        <Text>{"Next funding event: "}</Text>
-                        <Skeleton
-                            isLoaded={nextFundingEvent != null}
-                            height={"20px"}
-                            display={"flex"}
-                            alignItems={"center"}
-                        >
-                            <Tooltip
-                                label={"The next time your CFDs will be extended and the funding fee will be collected based on the hourly rate."}
-                                hasArrow
-                            >
-                                <HStack minWidth={"80px"}>
-                                    <Heading size={"sm"}>{nextFundingEvent}</Heading>
+                            <Flex alignItems={"center"} justifyContent={"space-between"} padding={2}>
+                                <Flex justifyContent={"flex-left"}>
+                                    <NavigationButtons />
+                                </Flex>
+                                <Flex alignItems={"center"}>
+                                    <Stack direction={"row"} spacing={7}>
+                                        <Button onClick={toggleColorMode} variant={"unstyled"}>
+                                            {toggleIcon}
+                                        </Button>
+                                        <Box>
+                                            <Button bg={"transparent"} onClick={() => navigate("/")}>
+                                                {navBarLog}
+                                            </Button>
+                                        </Box>
+                                    </Stack>
+                                </Flex>
+                            </Flex>
+                        </Box>
+                    </Center>
+                </Box>
+
+                <Box
+                    paddingTop={2}
+                    bg={useColorModeValue(BG_LIGHT, BG_DARK)}
+                    width={"100%"}
+                    maxWidth={VIEWPORT_WIDTH_PX}
+                    height={"100%"}
+                >
+                    <Center>
+                        <HStack>
+                            <Tooltip label={connectionStatusDisplay.tooltip}>
+                                <HStack>
+                                    <Text>{"Maker: "}</Text>
+                                    {connectionStatusDisplay.warn
+                                        ? (
+                                            <WarningIcon
+                                                color={connectionStatusIconColor}
+                                            />
+                                        )
+                                        : (
+                                            <Icon
+                                                viewBox="0 0 200 200"
+                                                color={connectionStatusIconColor}
+                                            >
+                                                <path
+                                                    fill="currentColor"
+                                                    d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0"
+                                                />
+                                            </Icon>
+                                        )}
                                 </HStack>
                             </Tooltip>
-                        </Skeleton>
-                        <TextDivider />
-                        <Text>{"Reference price: "}</Text>
-                        <Skeleton
-                            isLoaded={referencePrice !== undefined}
-                            height={"20px"}
-                            display={"flex"}
-                            alignItems={"center"}
-                        >
-                            <Tooltip label={"The price the Oracle attests to, the BitMEX BXBT index price"} hasArrow>
-                                <Link href={"https://outcome.observer/h00.ooo/x/BitMEX/BXBT"} target={"_blank"}>
-                                    {/* The minWidth helps with not letting the elements in Nav jump because the width changes*/}
-                                    <Heading size={"sm"} minWidth={"90px"}>
-                                        <DollarAmount amount={referencePrice || 0} />
-                                    </Heading>
-                                </Link>
-                            </Tooltip>
-                        </Skeleton>
-                    </HStack>
-                    <Flex alignItems={"center"}>
-                        <Stack direction={"row"} spacing={7}>
-                            <Button onClick={toggleColorMode} variant={"unstyled"}>
-                                {toggleIcon}
-                            </Button>
-                            <Box>
-                                <Button bg={"transparent"} onClick={() => navigate("/")}>
-                                    {navBarLog}
-                                </Button>
-                            </Box>
-                        </Stack>
-                    </Flex>
-                </Flex>
-            </Box>
+                            <TextDivider />
+                            <Text>{"Funding: "}</Text>
+                            <Skeleton
+                                isLoaded={nextFundingEvent != null}
+                                height={"20px"}
+                                display={"flex"}
+                                alignItems={"center"}
+                            >
+                                <Tooltip
+                                    label={"The next time your CFDs will be extended and the funding fee will be collected based on the hourly rate."}
+                                    hasArrow
+                                >
+                                    <HStack minWidth={"80px"}>
+                                        <Heading size={"sm"}>{nextFundingEvent}</Heading>
+                                    </HStack>
+                                </Tooltip>
+                            </Skeleton>
+                            <TextDivider />
+                            <Text>{"Ref price: "}</Text>
+                            <Skeleton
+                                isLoaded={referencePrice !== undefined}
+                                height={"20px"}
+                                display={"flex"}
+                                alignItems={"center"}
+                            >
+                                <Tooltip
+                                    label={"The price the Oracle attests to, the BitMEX BXBT index price"}
+                                    hasArrow
+                                >
+                                    <Link href={"https://outcome.observer/h00.ooo/x/BitMEX/BXBT"} target={"_blank"}>
+                                        {/* The minWidth helps with not letting the elements in Nav jump because the width changes*/}
+                                        <Heading size={"sm"} minWidth={"90px"}>
+                                            <DollarAmount amount={referencePrice || 0} />
+                                        </Heading>
+                                    </Link>
+                                </Tooltip>
+                            </Skeleton>
+                        </HStack>
+                    </Center>
+                </Box>
+            </VStack>
         </>
+    );
+}
+
+function NavigationButtons() {
+    const location = useLocation();
+    const isWalletSelected = location.pathname.includes("wallet");
+    const isHomeSelected = !isWalletSelected;
+
+    const unSelectedButton = "transparent";
+    const selectedButton = useColorModeValue("grey.400", "black.400");
+    const buttonBorder = useColorModeValue("grey.400", "black.400");
+    const buttonText = useColorModeValue("black", "white");
+
+    const width = "100px";
+    const borderWidth = 2;
+
+    return (
+        <HStack>
+            <Center>
+                <ButtonGroup spacing="3">
+                    <Button
+                        as={ReachLink}
+                        to="/long"
+                        color={isHomeSelected ? selectedButton : unSelectedButton}
+                        bg={isHomeSelected ? selectedButton : unSelectedButton}
+                        border={buttonBorder}
+                        borderWidth={borderWidth}
+                        isActive={isHomeSelected}
+                        w={width}
+                        leftIcon={<FaHome color={buttonText} />}
+                        boxShadow={"md"}
+                    >
+                        <Text fontSize={"md"} color={buttonText}>Home</Text>
+                    </Button>
+                    <Button
+                        as={ReachLink}
+                        to="/wallet"
+                        color={isWalletSelected ? selectedButton : unSelectedButton}
+                        bg={isWalletSelected ? selectedButton : unSelectedButton}
+                        border={buttonBorder}
+                        borderWidth={borderWidth}
+                        isActive={isWalletSelected}
+                        w={width}
+                        leftIcon={<FaWallet color={buttonText} />}
+                        boxShadow={"md"}
+                    >
+                        <Text fontSize={"md"} color={buttonText}>Wallet</Text>
+                    </Button>
+                </ButtonGroup>
+            </Center>
+        </HStack>
     );
 }

--- a/taker-frontend/src/components/Trade.tsx
+++ b/taker-frontend/src/components/Trade.tsx
@@ -1,4 +1,3 @@
-import { ExternalLinkIcon } from "@chakra-ui/icons";
 import { BoxProps } from "@chakra-ui/layout";
 import {
     Box,
@@ -36,6 +35,7 @@ import {
 import { motion } from "framer-motion";
 import * as React from "react";
 import { useEffect, useState } from "react";
+import { FaWallet } from "react-icons/all";
 import { useNavigate } from "react-router-dom";
 import { Offer } from "../App";
 import { CfdOrderRequestPayload, ConnectionStatus } from "../types";
@@ -225,7 +225,7 @@ export default function Trade({
                                                 <IconButton
                                                     variant={"unstyled"}
                                                     aria-label="Go to wallet"
-                                                    icon={<ExternalLinkIcon marginBottom={1} />}
+                                                    icon={<FaWallet />}
                                                     onClick={() => navigate("/wallet")}
                                                 />
                                             </Tooltip>
@@ -264,6 +264,7 @@ export default function Trade({
                                 onClick={onOpen}
                                 h={16}
                                 w={"80%"}
+                                id={isLong ? "longButton" : "shortButton"}
                             >
                                 <VStack>
                                     <Text fontSize={"md"}>{isLong ? "Long" : "Short"}</Text>


### PR DESCRIPTION
Adapted the user interface to be more intuitive and scale better

![image](https://user-images.githubusercontent.com/5557790/165961659-e8bd85e7-1efa-48f2-9bbd-30bc2a14cb92.png)

After having trouble with the hamburger menu when working on the guided tour @klochowicz and me took a step back and concluded that it was never intuitive on the first place (at least on desktop), so it was replaced with a switch button  between `home` and `wallet`.
As part of changing that the top-bar was split into two sections where one is for navigation and controlls and the other one is information (i.e. maker status, funding, reference price).

The new layout locks a viewport in the middle. We can consider using the `gray.200` area for a branding pattern (was somewhat inspired by https://www.uxmatters.com/mt/archives/2020/07/designing-mobile-tables.php)