### PR TITLE
Fix the gradient in dark mode

### DIFF
--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -183,7 +183,7 @@ export const App = () => {
                         height={"100%"}
                         bgGradient={useColorModeValue(
                             "linear(to-r, white 5%, gray.800, white 95%)",
-                            "linear(to-r, gray.800, white, gray.800)",
+                            "linear(to-r, gray.800 5%, white, gray.800 95%)",
                         )}
                     >
                         <Center>


### PR DESCRIPTION
I missed that one when changing the gradient settings for light mode.

Looks like this now:

![image](https://user-images.githubusercontent.com/5557790/166578499-07c840a0-a77a-4678-9eda-5086572062ee.png)
