### PR TITLE
Body pushes footer to the bottom

### DIFF
--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -177,80 +177,78 @@ export const App = () => {
                 nextFundingEvent={nextFundingEvent}
                 referencePrice={referencePrice}
             />
-            <Box height={"100%"}>
-                <Center>
-                    <Box
-                        maxWidth={(VIEWPORT_WIDTH + 200) + "px"}
-                        width={"100%"}
-                        bgGradient={useColorModeValue(
-                            "linear(to-r, white 5%, gray.800, white 95%)",
-                            "linear(to-r, gray.800 5%, white, gray.800 95%)",
-                        )}
-                    >
-                        <Center>
-                            <Box
-                                textAlign="center"
-                                padding={3}
-                                bg={useColorModeValue(BG_LIGHT, BG_DARK)}
-                                maxWidth={VIEWPORT_WIDTH_PX}
-                                marginTop={`${HEADER_HEIGHT}px`}
-                                minHeight={`calc(100vh - ${FOOTER_HEIGHT}px - ${HEADER_HEIGHT}px)`}
-                                width={"100%"}
-                            >
-                                <Routes>
-                                    <Route path="/">
+            <Center>
+                <Box
+                    maxWidth={(VIEWPORT_WIDTH + 200) + "px"}
+                    width={"100%"}
+                    bgGradient={useColorModeValue(
+                        "linear(to-r, white 5%, gray.800, white 95%)",
+                        "linear(to-r, gray.800 5%, white, gray.800 95%)",
+                    )}
+                >
+                    <Center>
+                        <Box
+                            textAlign="center"
+                            padding={3}
+                            bg={useColorModeValue(BG_LIGHT, BG_DARK)}
+                            maxWidth={VIEWPORT_WIDTH_PX}
+                            marginTop={`${HEADER_HEIGHT}px`}
+                            minHeight={`calc(100vh - ${FOOTER_HEIGHT}px - ${HEADER_HEIGHT}px)`}
+                            width={"100%"}
+                        >
+                            <Routes>
+                                <Route path="/">
+                                    <Route
+                                        path="wallet"
+                                        element={<Wallet walletInfo={walletInfo} />}
+                                    />
+                                    <Route
+                                        element={
+                                            // @ts-ignore: ts-lint thinks that {children} is missing but react router is taking care of this for us
+
+
+                                                <PageLayout
+                                                    cfds={cfds}
+                                                    connectedToMaker={connectedToMaker}
+                                                    showPromoBanner={isWithinPromoPeriod}
+                                                />
+
+                                        }
+                                    >
                                         <Route
-                                            path="wallet"
-                                            element={<Wallet walletInfo={walletInfo} />}
+                                            path="long"
+                                            element={
+                                                <Trade
+                                                    offer={longOffer}
+                                                    connectedToMaker={connectedToMaker}
+                                                    walletBalance={walletInfo ? walletInfo.balance : 0}
+                                                    isLong={true}
+                                                />
+                                            }
                                         />
                                         <Route
+                                            path="short"
                                             element={
-                                                // @ts-ignore: ts-lint thinks that {children} is missing but react router is taking care of this for us
-
-
-                                                    <PageLayout
-                                                        cfds={cfds}
-                                                        connectedToMaker={connectedToMaker}
-                                                        showPromoBanner={isWithinPromoPeriod}
-                                                    />
-
+                                                <Trade
+                                                    offer={shortOffer}
+                                                    connectedToMaker={connectedToMaker}
+                                                    walletBalance={walletInfo ? walletInfo.balance : 0}
+                                                    isLong={false}
+                                                />
                                             }
-                                        >
-                                            <Route
-                                                path="long"
-                                                element={
-                                                    <Trade
-                                                        offer={longOffer}
-                                                        connectedToMaker={connectedToMaker}
-                                                        walletBalance={walletInfo ? walletInfo.balance : 0}
-                                                        isLong={true}
-                                                    />
-                                                }
-                                            />
-                                            <Route
-                                                path="short"
-                                                element={
-                                                    <Trade
-                                                        offer={shortOffer}
-                                                        connectedToMaker={connectedToMaker}
-                                                        walletBalance={walletInfo ? walletInfo.balance : 0}
-                                                        isLong={false}
-                                                    />
-                                                }
-                                            />
-                                        </Route>
-                                        <Route index element={<Navigate to="long" />} />
+                                        />
                                     </Route>
-                                    <Route
-                                        path="/*"
-                                        element={<Navigate to="long" />}
-                                    />
-                                </Routes>
-                            </Box>
-                        </Center>
-                    </Box>
-                </Center>
-            </Box>
+                                    <Route index element={<Navigate to="long" />} />
+                                </Route>
+                                <Route
+                                    path="/*"
+                                    element={<Navigate to="long" />}
+                                />
+                            </Routes>
+                        </Box>
+                    </Center>
+                </Box>
+            </Center>
             <Footer />
         </>
     );

--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -53,6 +53,8 @@ export interface Offer {
 
 // TODO: Evaluate moving these globals into the theme to make them accessible through that
 export const VIEWPORT_WIDTH = 1000;
+export const FOOTER_HEIGHT = 50;
+export const HEADER_HEIGHT = 100;
 export const VIEWPORT_WIDTH_PX = VIEWPORT_WIDTH + "px";
 export const BG_LIGHT = "gray.50";
 export const BG_DARK = "gray.800";
@@ -175,12 +177,11 @@ export const App = () => {
                 nextFundingEvent={nextFundingEvent}
                 referencePrice={referencePrice}
             />
-            <Box>
+            <Box height={"100%"}>
                 <Center>
                     <Box
                         maxWidth={(VIEWPORT_WIDTH + 200) + "px"}
                         width={"100%"}
-                        height={"100%"}
                         bgGradient={useColorModeValue(
                             "linear(to-r, white 5%, gray.800, white 95%)",
                             "linear(to-r, gray.800 5%, white, gray.800 95%)",
@@ -192,8 +193,9 @@ export const App = () => {
                                 padding={3}
                                 bg={useColorModeValue(BG_LIGHT, BG_DARK)}
                                 maxWidth={VIEWPORT_WIDTH_PX}
+                                marginTop={`${HEADER_HEIGHT}px`}
+                                minHeight={`calc(100vh - ${FOOTER_HEIGHT}px - ${HEADER_HEIGHT}px)`}
                                 width={"100%"}
-                                marginTop={"100px"}
                             >
                                 <Routes>
                                     <Route path="/">

--- a/taker-frontend/src/components/Footer.tsx
+++ b/taker-frontend/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import { ExternalLinkIcon } from "@chakra-ui/icons";
 import { Box, Center, Divider, HStack, Link, Text, useColorModeValue } from "@chakra-ui/react";
 import * as React from "react";
+import { FOOTER_HEIGHT } from "../App";
 import { SocialLinks } from "./SocialLinks";
 
 function TextDivider() {
@@ -14,7 +15,7 @@ export default function Footer() {
             color={useColorModeValue("gray.700", "gray.200")}
         >
             <Center>
-                <HStack h={16} alignItems={"center"}>
+                <HStack h={`${FOOTER_HEIGHT}px`} alignItems={"center"}>
                     <Link
                         href="http://faq.itchysats.network"
                         isExternal

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -21,7 +21,7 @@ import {
 import * as React from "react";
 import { FaHome, FaWallet } from "react-icons/all";
 import { Link as ReachLink, useLocation, useNavigate } from "react-router-dom";
-import { BG_DARK, BG_LIGHT, VIEWPORT_WIDTH_PX } from "../App";
+import { BG_DARK, BG_LIGHT, HEADER_HEIGHT, VIEWPORT_WIDTH_PX } from "../App";
 import logoBlack from "../images/logo_nav_bar_black.svg";
 import logoWhite from "../images/logo_nav_bar_white.svg";
 import { ConnectionCloseReason, ConnectionStatus, WalletInfo } from "../types";
@@ -98,7 +98,7 @@ export default function Nav({ walletInfo, connectedToMaker, nextFundingEvent, re
 
     return (
         <>
-            <VStack spacing={0} position={"fixed"} width={"100%"} zIndex={"100"} height={"100px"}>
+            <VStack spacing={0} position={"fixed"} width={"100%"} zIndex={"100"} height={`${HEADER_HEIGHT}px`}>
                 <Box bg={useColorModeValue("gray.100", "gray.900")} width={"100%"}>
                     <Center>
                         <Box


### PR DESCRIPTION
The initially (or when switching to the wallet) "floating" footer has annoyed me for too long :)

There are several different ways to achieve the footer being always at the bottom, but at the same time not being fixed. I played with flexes for a while but could not get it done without weird side effects. I think it would be nice to have flex height for header and footer, but at this point I just want it to be done. 
Solution:

If the body is less than the viewport height (in our case height of the browser window) then we set a minimum of `body-height = viewport-height - header-height - footer-height`.
If the body becomes larger than the viewport height the footer will be pushed down (no fixed footer, only fixed header).

![image](https://user-images.githubusercontent.com/5557790/166616326-5c08e516-6299-423b-a089-1b430621927d.png)

When body is higher than viewport the footer is pushed down and we scroll to get to it:

![image](https://user-images.githubusercontent.com/5557790/166616388-c6ebcf2f-8b94-4f90-b173-c907b502e771.png)


