### PR TITLE
Send over fee account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.12.1] - 2022-05-06
+
 ## [0.4.12] - 2022-04-26
 
 ### Changed
@@ -118,7 +120,8 @@ Backport <https://github.com/itchysats/itchysats/pull/924> in an attempt to fix 
 
 Initial release for mainnet.
 
-[Unreleased]: https://github.com/itchysats/itchysats/compare/0.4.12...HEAD
+[Unreleased]: https://github.com/itchysats/itchysats/compare/0.4.12.1...HEAD
+[0.4.12.1]: https://github.com/itchysats/itchysats/compare/0.4.12...0.4.12.1
 [0.4.12]: https://github.com/itchysats/itchysats/compare/0.4.11...0.4.12
 [0.4.11]: https://github.com/itchysats/itchysats/compare/0.4.10...0.4.11
 [0.4.10]: https://github.com/itchysats/itchysats/compare/0.4.9...0.4.10

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -481,6 +481,7 @@ impl Actor {
                 oracle_event_id,
                 tx_fee_rate,
                 funding_rate,
+                complete_fee,
             } => {
                 if let Err(NotConnected(_)) = self
                     .rollover_actors
@@ -490,6 +491,7 @@ impl Actor {
                             oracle_event_id,
                             tx_fee_rate,
                             funding_rate,
+                            complete_fee: complete_fee.into(),
                         },
                     )
                     .await

--- a/daemon/src/rollover_taker.rs
+++ b/daemon/src/rollover_taker.rs
@@ -16,6 +16,7 @@ use futures::SinkExt;
 use maia::secp256k1_zkp::schnorrsig;
 use model::olivia::BitMexPriceEventId;
 use model::Dlc;
+use model::FeeFlow;
 use model::FundingFee;
 use model::FundingRate;
 use model::OrderId;
@@ -95,6 +96,7 @@ impl Actor {
             oracle_event_id,
             tx_fee_rate,
             funding_rate,
+            complete_fee,
         }: RolloverAccepted = msg;
         let order_id = self.id;
 
@@ -132,6 +134,7 @@ impl Actor {
             position,
             dlc,
             self.n_payouts,
+            complete_fee,
         );
 
         let this = ctx.address().expect("self to be alive");
@@ -320,6 +323,7 @@ pub struct RolloverAccepted {
     pub oracle_event_id: BitMexPriceEventId,
     pub tx_fee_rate: TxFeeRate,
     pub funding_rate: FundingRate,
+    pub complete_fee: FeeFlow,
 }
 
 /// Message sent from the `connection::Actor` to the

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -43,11 +43,11 @@ use model::calculate_payouts;
 use model::olivia;
 use model::Cet;
 use model::Dlc;
+use model::FeeFlow;
 use model::Position;
 use model::RevokedCommit;
 use model::Role;
 use model::RolloverParams;
-use model::RolloverVersion;
 use model::SetupParams;
 use model::CET_TIMELOCK;
 use std::collections::HashMap;
@@ -353,6 +353,7 @@ pub async fn roll_over(
     our_position: Position,
     dlc: Dlc,
     n_payouts: usize,
+    complete_fee: FeeFlow,
 ) -> Result<Dlc> {
     let sk = dlc.identity;
     let pk = PublicKey::new(secp256k1_zkp::PublicKey::from_secret_key(SECP256K1, &sk));
@@ -378,24 +379,6 @@ pub async fn roll_over(
         .with_context(|| format_expect_msg_within("Msg0"))?
         .try_into_msg0()
         .context("Failed to read Msg0")?;
-
-    let complete_fee = match rollover_params.version {
-        RolloverVersion::V1 => {
-            // Note there is actually a bug here, but we have to keep this as is to reach agreement
-            // on the fee for the protocol V1 version.
-            //
-            // The current fee is supposed to be added here, but we never noticed because in V1 the
-            // fee is always charged for one hour using a static rate. This results in applying the
-            // fee in the DLC only for the next rollover (because we do apply the fee in the Cfd
-            // when loading the rollover event). Effectively this means, that we always charged one
-            // rollover too little.
-            rollover_params.fee_account.settle()
-        }
-        RolloverVersion::V2 => rollover_params
-            .fee_account
-            .add_funding_fee(rollover_params.current_fee)
-            .settle(),
-    };
 
     let maker_lock_amount = dlc.maker_lock_amount;
     let taker_lock_amount = dlc.taker_lock_amount;

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -16,6 +16,7 @@ use maia::secp256k1_zkp::SecretKey;
 use maia::CfdTransactions;
 use maia::PartyParams;
 use maia::PunishParams;
+use model::FeeFlow;
 use model::FundingRate;
 use model::Leverage;
 use model::MakerOffers;
@@ -174,6 +175,7 @@ pub enum MakerToTaker {
         oracle_event_id: BitMexPriceEventId,
         tx_fee_rate: TxFeeRate,
         funding_rate: FundingRate,
+        complete_fee: CompleteFee,
     },
     RejectRollover(OrderId),
     Settlement {
@@ -182,6 +184,38 @@ pub enum MakerToTaker {
     },
     #[serde(other, deserialize_with = "deserialize_ignore_any")]
     Unknown,
+}
+
+/// Fee to be paid for the rollover.
+///
+/// The maker comes up with this amount so that both parties are on the same page
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum CompleteFee {
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    LongPaysShort(Amount),
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    ShortPaysLong(Amount),
+    Nein,
+}
+
+impl From<FeeFlow> for CompleteFee {
+    fn from(fee_flow: FeeFlow) -> Self {
+        match fee_flow {
+            FeeFlow::LongPaysShort(a) => CompleteFee::LongPaysShort(a),
+            FeeFlow::ShortPaysLong(a) => CompleteFee::ShortPaysLong(a),
+            FeeFlow::Nein => CompleteFee::Nein,
+        }
+    }
+}
+
+impl From<CompleteFee> for FeeFlow {
+    fn from(fee_flow: CompleteFee) -> Self {
+        match fee_flow {
+            CompleteFee::LongPaysShort(a) => FeeFlow::LongPaysShort(a),
+            CompleteFee::ShortPaysLong(a) => FeeFlow::ShortPaysLong(a),
+            CompleteFee::Nein => FeeFlow::Nein,
+        }
+    }
 }
 
 /// Legacy wire struct to retain backwards compatibility on the wire with version 0.4.7


### PR DESCRIPTION
This is more a band aid than a proper fix but should fix our ever failing rollovers, as now both parties are talking about the same rollover fees. 

The downside of this is that the `maker` could _trick_ the `taker` into paying a higher fee. 
For the time being, where we are the only maker, this should be good enough.

Ideally, we should ensure that a rollover guarantees to succeed for both parties. And hence, both parties always talk about the same rollover. 
Imho his is not easily achievable with the current implementation. 

Do Not Merge! If we want this, we will have to release from this branch!