### PR TITLE
Trace time left in CFD when calculating hours to extend in rollover

### DIFF
--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1425,6 +1425,8 @@ impl Cfd {
 
         let hours_left = settlement_time - OffsetDateTime::now_utc();
 
+        tracing::trace!(target = "cfd", time_left_in_cfd = %hours_left, "Calculating hours to extend in rollover");
+
         if !hours_left.is_positive() {
             tracing::warn!("Rolling over a contract that can be settled non-collaboratively");
 


### PR DESCRIPTION
This can give us extra context when trying to figure out if a CFD is being rolled over for the correct number of hours.

---

Motivated by https://github.com/itchysats/itchysats/issues/1974.

It's important to highlight that if a rollover extends the lifetime of a CFD by 1 hour and 59 minutes, we are currently charging for only 1 hour. We may want to be less generous given that quite a lot of CFDs are not getting rolled over consistently every hour.