### PR TITLE
Enable metric endpoint for taker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - network: an additional field `leverage` was added to `wire::MakerToTaker::TakeOffer`.
   - network: an additional field `leverage_choices` was added to `Order` which is sent from maker to taker when he created a new offer.
     The field `leverage` was deprecated.
+- Additional API for the taker: `api/metrics` will return prometheus-based metrics about your positions and about general behavior of the application
 
 ## [0.4.12] - 2022-04-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4201,6 +4201,7 @@ dependencies = [
  "itertools",
  "libp2p-core",
  "model",
+ "prometheus",
  "rocket",
  "rocket-basicauth",
  "rust-embed",

--- a/taker/Cargo.toml
+++ b/taker/Cargo.toml
@@ -15,6 +15,7 @@ http-api-problem = { version = "0.51.0", features = ["rocket"] }
 itertools = "0.10"
 libp2p-core = { version = "0.32", default-features = false }
 model = { path = "../model" }
+prometheus = { version = "0.13", default-features = false }
 rocket = { version = "0.5.0-rc.1", features = ["json", "uuid"] }
 rocket-basicauth = { path = "../rocket-basicauth" }
 rust-embed = "6.4"

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -382,6 +382,7 @@ async fn main() -> Result<()> {
                 routes::get_health_check,
                 routes::post_cfd_action,
                 routes::post_withdraw_request,
+                routes::get_metrics,
             ],
         )
         .register("/api", default_catchers())

--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -271,6 +271,19 @@ pub async fn post_withdraw_request(
     Ok(projection::to_mempool_url(txid, *network.inner()))
 }
 
+#[rocket::get("/metrics")]
+pub async fn get_metrics<'r>(_auth: Authenticated) -> Result<String, HttpApiProblem> {
+    let metrics = prometheus::TextEncoder::new()
+        .encode_to_string(&prometheus::gather())
+        .map_err(|e| {
+            HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .title("Failed to encode metrics")
+                .detail(e.to_string())
+        })?;
+
+    Ok(metrics)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Fixes #1980 

This allows us to collect metrics for the taker as well.

In a discussion with Thomas we thought about having a feature flag for this but I opted against it because that would mean we need to release 2 versions: one with and one without this feature. 

What do you think? Shall I add a feature flag or maybe a new cli arg which allows to enable the metric endpoint?