### PR TITLE
Add small offset to timestamp before fetch

### DIFF
--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -182,7 +182,7 @@ impl Actor {
 
     fn update_pending_attestations(&mut self, ctx: &mut xtra::Context<Self>) {
         for event_id in self.pending_attestations.iter().copied() {
-            if !event_id.has_likely_occured() {
+            if !event_id.has_likely_occurred() {
                 tracing::trace!("Skipping {event_id} because it likely hasn't occurred yet");
 
                 continue;

--- a/model/src/olivia.rs
+++ b/model/src/olivia.rs
@@ -75,7 +75,7 @@ impl BitMexPriceEventId {
     /// Checks whether this event has likely already occurred.
     ///
     /// We can't be sure about it because our local clock might be off from the oracle's clock.
-    pub fn has_likely_occured(&self) -> bool {
+    pub fn has_likely_occurred(&self) -> bool {
         let now = OffsetDateTime::now_utc();
 
         now > self.timestamp + Duration::minutes(1)
@@ -444,6 +444,6 @@ mod tests {
         let past_event =
             BitMexPriceEventId::with_20_digits(datetime!(2021-09-23 10:00:00).assume_utc());
 
-        assert!(past_event.has_likely_occured());
+        assert!(past_event.has_likely_occurred());
     }
 }

--- a/model/src/olivia.rs
+++ b/model/src/olivia.rs
@@ -10,6 +10,7 @@ use std::fmt;
 use std::str;
 use time::format_description::FormatItem;
 use time::macros::format_description;
+use time::Duration;
 use time::OffsetDateTime;
 use time::PrimitiveDateTime;
 use time::Time;
@@ -77,7 +78,7 @@ impl BitMexPriceEventId {
     pub fn has_likely_occured(&self) -> bool {
         let now = OffsetDateTime::now_utc();
 
-        now > self.timestamp
+        now > self.timestamp + Duration::minutes(1)
     }
 
     pub fn to_olivia_url(self) -> Url {


### PR DESCRIPTION
We expect the oracle to attest to the price at `timestamp` but due to spacetime distortion we give it another minute before we fetch. This should reduce the error below because we will only fetch the attestation if it is _very_ likely to have occurred.

```json
{"timestamp":"2022-05-10T07:00:03.759931111Z","level":"DEBUG","fields":{"message":"Failed to fetch attestation: Failed to deserialize as Attestation: error decoding response body: attestation missing: attestation missing"},"target":"daemon::oracle"}
```

Resolves #1966 

What do you think @luckysori ?