### PR TITLE
Apply timeout to all message handlers of connection actors

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -47,7 +47,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 tracing = { version = "0.1" }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 x25519-dalek = { version = "1.1" }
-xtra = { version = "0.6", features = ["metrics"] }
+xtra = { version = "0.6", features = ["metrics", "timeout"] }
 xtra-bitmex-price-feed = { path = "../xtra-bitmex-price-feed" }
 xtra-libp2p = { path = "../xtra-libp2p" }
 xtra-libp2p-ping = { path = "../xtra-libp2p-ping" }

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -180,13 +180,17 @@ where
             .checked_mul(2)
             .expect("not to overflow");
 
-        tasks.add(connection_actor_ctx.run(connection::Actor::new(
-            maker_online_status_feed_sender,
-            &cfd_actor_addr,
-            identity.identity_sk,
-            taker_heartbeat_timeout,
-            connect_timeout,
-        )));
+        tasks.add(
+            connection_actor_ctx
+                .with_handler_timeout(Duration::from_secs(120))
+                .run(connection::Actor::new(
+                    maker_online_status_feed_sender,
+                    &cfd_actor_addr,
+                    identity.identity_sk,
+                    taker_heartbeat_timeout,
+                    connect_timeout,
+                )),
+        );
 
         tasks.add(monitor_ctx.run(monitor_constructor(executor.clone())?));
 

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -157,14 +157,18 @@ where
         );
         let listener_supervisor = supervisor.create(None).spawn(&mut tasks);
 
-        tasks.add(inc_conn_ctx.run(connection::Actor::new(
-            Box::new(cfd_actor_addr.clone()),
-            Box::new(cfd_actor_addr.clone()),
-            Box::new(cfd_actor_addr.clone()),
-            identity.identity_sk,
-            heartbeat_interval,
-            p2p_socket,
-        )));
+        tasks.add(
+            inc_conn_ctx
+                .with_handler_timeout(Duration::from_secs(120))
+                .run(connection::Actor::new(
+                    Box::new(cfd_actor_addr.clone()),
+                    Box::new(cfd_actor_addr.clone()),
+                    Box::new(cfd_actor_addr.clone()),
+                    identity.identity_sk,
+                    heartbeat_interval,
+                    p2p_socket,
+                )),
+        );
 
         tasks.add(monitor_ctx.run(monitor_constructor(executor.clone())?));
 


### PR DESCRIPTION
Fixes #2005.

This is so that we can ensure that no message can block the actor forever.

Things to consider:

- The original issue suggested that we may want to remove some internal timeouts. I have not dared to touch that, but maybe someone else with more context can make a call.
- The value of 120 seconds is completely arbitrary. The way this new `xtra` feature works, the timeout applies to _all_ handlers for a given `Actor`. This suggests to me that we want to be cautious with this value. But 120 seconds might be too much time for it to be useful.