### PR TITLE
Allow updating maia in a backwards-compatible fashion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,6 +1873,7 @@ dependencies = [
  "rocket-basicauth",
  "rust-embed",
  "rust-embed-rocket",
+ "semver 1.0.9",
  "serde",
  "shared-bin",
  "thiserror",

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -22,6 +22,7 @@ rocket = { version = "0.5.0-rc.1", features = ["json", "uuid"] }
 rocket-basicauth = { path = "../rocket-basicauth" }
 rust-embed = "6.4"
 rust-embed-rocket = { path = "../rust-embed-rocket" }
+semver = { version = "1.0.9" }
 serde = { version = "1", features = ["derive"] }
 shared-bin = { path = "../shared-bin" }
 thiserror = "1"

--- a/maker/src/collab_settlement.rs
+++ b/maker/src/collab_settlement.rs
@@ -1,3 +1,4 @@
+use crate::cfd::MaiaProtocolVariant;
 use crate::connection;
 use anyhow::anyhow;
 use anyhow::Context;
@@ -35,6 +36,7 @@ pub struct Actor {
     executor: command::Executor,
     db: db::Connection,
     tasks: Tasks,
+    protocol_variant: MaiaProtocolVariant,
 }
 
 #[derive(Clone, Copy)]
@@ -154,6 +156,7 @@ impl Actor {
         process_manager: xtra::Address<process_manager::Actor>,
         db: db::Connection,
         n_payouts: usize,
+        protocol_variant: MaiaProtocolVariant,
     ) -> Self {
         Self {
             proposal,
@@ -165,6 +168,7 @@ impl Actor {
             db,
             tasks: Tasks::default(),
             is_initiated: false,
+            protocol_variant,
         }
     }
 

--- a/maker/src/contract_setup.rs
+++ b/maker/src/contract_setup.rs
@@ -1,3 +1,4 @@
+use crate::cfd::MaiaProtocolVariant;
 use crate::connection;
 use crate::metrics::time_to_first_position;
 use anyhow::Context;
@@ -43,6 +44,7 @@ pub struct Actor {
     tasks: Tasks,
     executor: command::Executor,
     time_to_first_position: xtra::Address<time_to_first_position::Actor>,
+    protocol_variant: MaiaProtocolVariant,
 }
 
 impl Actor {
@@ -60,6 +62,7 @@ impl Actor {
             Identity,
         ),
         time_to_first_position: xtra::Address<time_to_first_position::Actor>,
+        protocol_variant: MaiaProtocolVariant,
     ) -> Self {
         Self {
             executor: command::Executor::new(db, process_manager),
@@ -76,6 +79,7 @@ impl Actor {
             setup_msg_sender: None,
             tasks: Tasks::default(),
             time_to_first_position,
+            protocol_variant,
         }
     }
 

--- a/maker/src/rollover.rs
+++ b/maker/src/rollover.rs
@@ -1,3 +1,4 @@
+use crate::cfd::MaiaProtocolVariant;
 use crate::connection;
 use anyhow::Context as _;
 use anyhow::Result;
@@ -66,6 +67,7 @@ pub struct Actor {
     tasks: Tasks,
     executor: command::Executor,
     version: RolloverVersion,
+    protocol_variant: MaiaProtocolVariant,
 }
 
 impl Actor {
@@ -81,6 +83,7 @@ impl Actor {
         register: &(impl MessageChannel<connection::RegisterRollover> + 'static),
         db: db::Connection,
         version: RolloverVersion,
+        protocol_variant: MaiaProtocolVariant,
     ) -> Self {
         Self {
             order_id,
@@ -94,6 +97,7 @@ impl Actor {
             executor: command::Executor::new(db, process_manager),
             tasks: Tasks::default(),
             version,
+            protocol_variant,
         }
     }
 


### PR DESCRIPTION
Build a map of taker daemon versions when they connect to the maker. This allows
us to determine a policy in regards to which maia version to use during payout curve
calculation.

In this case, if the taker version is below 0.4.15 or unknown, use legacy maia version.