### PR TITLE
Omit 0-amount outputs when reconstructing CETs

### DIFF
--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -274,7 +274,7 @@ impl Actor {
                 .execute(id, |cfd| cfd.decrypt_cet(&attestation.0))
                 .await
             {
-                tracing::warn!(order_id = %id, "Failed to decrypt CET using attestation: {}", err)
+                tracing::warn!(order_id = %id, "Failed to decrypt CET using attestation: {err:#}")
             }
         }
 


### PR DESCRIPTION
This fixes a bug where we were naively adding 0-amount outputs for the party that was getting liquidated when reconstructing "liquidation" CETs.

The network would not accept these transactions, but we were failing as soon as we were checking against the original CET TXID. In `maia` we were already constructing this kind of transaction correctly, by omitting the 0-amount output.