### PR TITLE
Move taker id to modal and some resposiveness

### DIFF
--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -262,9 +262,6 @@ export const App = () => {
                     </Center>
                 </Box>
             </Center>
-            <Center>
-                <Text fontSize={"12"}>Taker Id: {identity.taker_id}</Text>
-            </Center>
             <Footer taker_id={identity.taker_id} />
         </>
     );

--- a/taker-frontend/src/components/Footer.tsx
+++ b/taker-frontend/src/components/Footer.tsx
@@ -1,8 +1,26 @@
 import { ExternalLinkIcon } from "@chakra-ui/icons";
-import { Box, Button, Center, Divider, HStack, Link, Text, useColorModeValue } from "@chakra-ui/react";
+import {
+    Box,
+    Button,
+    Center,
+    Divider,
+    HStack,
+    IconButton,
+    Link,
+    Modal,
+    ModalBody,
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalOverlay,
+    Text,
+    useColorModeValue,
+    useDisclosure,
+} from "@chakra-ui/react";
 import { FeedbackFish } from "@feedback-fish/react";
 import * as React from "react";
-import { FaRegCommentDots } from "react-icons/all";
+import { FaInfo, FaRegCommentDots } from "react-icons/all";
 import { FAQ_URL, FOOTER_HEIGHT } from "../App";
 import { SocialLinks } from "./SocialLinks";
 
@@ -15,6 +33,8 @@ interface FooterProps {
 }
 
 export default function Footer({ taker_id }: FooterProps) {
+    const { isOpen, onOpen, onClose } = useDisclosure();
+
     return (
         <Box
             bg={useColorModeValue("gray.100", "gray.900")}
@@ -34,6 +54,29 @@ export default function Footer({ taker_id }: FooterProps) {
                     <TextDivider />
                     <Text fontSize={"20"} fontWeight={"bold"} display={["none", "none", "inherit"]}>Contact us:</Text>
                     <SocialLinks />
+                    <TextDivider />
+                    <IconButton
+                        aria-label={"itchysats-about"}
+                        icon={<FaInfo />}
+                        fontSize="20px"
+                        color={"gray.600"}
+                        onClick={onOpen}
+                    />
+                    <Modal isOpen={isOpen} onClose={onClose}>
+                        <ModalOverlay />
+                        <ModalContent>
+                            <ModalHeader>ItchySats Info</ModalHeader>
+                            <ModalCloseButton />
+                            <ModalBody>
+                                <Text>Your Taker ID: {taker_id}</Text>
+                            </ModalBody>
+                            <ModalFooter>
+                                <Button colorScheme="blue" mr={3} onClick={onClose}>
+                                    Close
+                                </Button>
+                            </ModalFooter>
+                        </ModalContent>
+                    </Modal>
                     <TextDivider />
                     <FeedbackFish
                         projectId="c1260a96cdb3d8"

--- a/taker-frontend/src/components/Footer.tsx
+++ b/taker-frontend/src/components/Footer.tsx
@@ -2,6 +2,7 @@ import { ExternalLinkIcon } from "@chakra-ui/icons";
 import { Box, Button, Center, Divider, HStack, Link, Text, useColorModeValue } from "@chakra-ui/react";
 import { FeedbackFish } from "@feedback-fish/react";
 import * as React from "react";
+import { FaRegCommentDots } from "react-icons/all";
 import { FAQ_URL, FOOTER_HEIGHT } from "../App";
 import { SocialLinks } from "./SocialLinks";
 
@@ -31,14 +32,21 @@ export default function Footer({ taker_id }: FooterProps) {
                         </HStack>
                     </Link>
                     <TextDivider />
-                    <Text fontSize={"20"} fontWeight={"bold"}>Contact us:</Text>
+                    <Text fontSize={"20"} fontWeight={"bold"} display={["none", "none", "inherit"]}>Contact us:</Text>
                     <SocialLinks />
                     <TextDivider />
                     <FeedbackFish
                         projectId="c1260a96cdb3d8"
                         metadata={{ position: "footer", customerId: taker_id }}
                     >
-                        <Button fontSize={"20"} color={useColorModeValue("black", "white")}>Send feedback</Button>
+                        <Button
+                            fontSize={"20"}
+                            color={useColorModeValue("black", "white")}
+                            leftIcon={<FaRegCommentDots />}
+                            variant={"ghost"}
+                        >
+                            <Text display={["none", "none", "inherit"]}>Send Feedback</Text>
+                        </Button>
                     </FeedbackFish>
                 </HStack>
             </Center>

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -139,7 +139,7 @@ export default function Nav({ walletInfo, connectedToMaker, nextFundingEvent, re
                         <HStack>
                             <Tooltip label={connectionStatusDisplay.tooltip}>
                                 <HStack>
-                                    <Text>{"Maker: "}</Text>
+                                    <Text>{"Maker "}</Text>
                                     {connectionStatusDisplay.warn
                                         ? (
                                             <WarningIcon
@@ -160,7 +160,7 @@ export default function Nav({ walletInfo, connectedToMaker, nextFundingEvent, re
                                 </HStack>
                             </Tooltip>
                             <TextDivider />
-                            <Text>{"Funding: "}</Text>
+                            <Text>{"Funding "}</Text>
                             <Skeleton
                                 isLoaded={nextFundingEvent != null}
                                 height={"20px"}
@@ -171,13 +171,21 @@ export default function Nav({ walletInfo, connectedToMaker, nextFundingEvent, re
                                     label={"The next time your CFDs will be extended and the funding fee will be collected based on the hourly rate."}
                                     hasArrow
                                 >
-                                    <HStack minWidth={"80px"}>
-                                        <Heading size={"sm"}>{nextFundingEvent}</Heading>
+                                    <HStack minWidth={"80px"} maxWidth={["90px", "90px", "inherit"]}>
+                                        <Heading
+                                            size={"sm"}
+                                            textOverflow={"ellipsis"}
+                                            overflow={"hidden"}
+                                            whiteSpace={"nowrap"}
+                                        >
+                                            {nextFundingEvent}
+                                        </Heading>
                                     </HStack>
                                 </Tooltip>
                             </Skeleton>
                             <TextDivider />
-                            <Text>{"Ref price: "}</Text>
+                            <Text display={["inherit", "inherit", "none"]}>Ref</Text>
+                            <Text display={["none", "none", "inherit"]}>Reference Price</Text>
                             <Skeleton
                                 isLoaded={referencePrice !== undefined}
                                 height={"20px"}


### PR DESCRIPTION
Scales better:

Wide screen:

![image](https://user-images.githubusercontent.com/5557790/167788575-cd05b85b-a74e-4b20-a33d-bb4409b2d561.png)

Narrow screen:

![image](https://user-images.githubusercontent.com/5557790/167789253-4f9ddff7-c94a-494b-90ca-0d6996ee889c.png)


Mobile (not perfect, but at least all header and footer items are all there):

![image](https://user-images.githubusercontent.com/5557790/167788693-e482b19c-16c6-4187-939a-7de15ea60d61.png)

--- 

Taker ID is not important enough to always display it, I added an `info` model where one can find it. We can store some other meta info (e.g. version, links to code, ...) there and layout nicer (did not invest time for now):

![image](https://user-images.githubusercontent.com/5557790/167789138-c46c40ae-9c9c-40df-ba22-9b4b0d5309fa.png)
