### PR TITLE
Weird cfd log metrics fixes

### DIFF
--- a/daemon/src/position_metrics.rs
+++ b/daemon/src/position_metrics.rs
@@ -376,6 +376,7 @@ mod metrics {
                         is_closed = cfd.is_closed,
                         is_refunded = cfd.is_refunded,
                         is_rejected = cfd.is_rejected,
+                        is_failed = cfd.is_failed,
                         order_id = %cfd.id,
                         "CFD is in weird state"
                     );

--- a/daemon/src/position_metrics.rs
+++ b/daemon/src/position_metrics.rs
@@ -168,10 +168,19 @@ impl Cfd {
                 is_open: true,
                 ..self
             },
-            ContractSetupFailed => Self {
-                is_failed: true,
-                ..self
-            },
+            ContractSetupFailed => {
+                // This is needed due to a bug that has since been fixed; `OfferRejected` and
+                // `ContractSetupFailed` are mutually exclusive.
+                // We give `OfferRejected` priority over `ContractSetupFailed`.
+                if self.is_rejected {
+                    Self { ..self }
+                } else {
+                    Self {
+                        is_failed: true,
+                        ..self
+                    }
+                }
+            }
             OfferRejected => Self {
                 is_rejected: true,
                 ..self

--- a/daemon/src/position_metrics.rs
+++ b/daemon/src/position_metrics.rs
@@ -164,7 +164,7 @@ impl Cfd {
                 is_refunded: false,
                 ..self
             },
-            ContractSetupCompleted { .. } | LockConfirmed | LockConfirmedAfterFinality => Self {
+            ContractSetupCompleted { .. } | LockConfirmed => Self {
                 is_open: true,
                 ..self
             },
@@ -218,6 +218,14 @@ impl Cfd {
                 ..self
             },
             CollaborativeSettlementConfirmed => Self {
+                is_open: false,
+                is_closed: true,
+                ..self
+            },
+            LockConfirmedAfterFinality => Self {
+                // This event is only appended if lock confirmation happens after we spent from lock
+                // on chain. This is for special case where collaborative settlement is triggered
+                // before lock is confirmed. In such a case the CFD is closed
                 is_open: false,
                 is_closed: true,
                 ..self


### PR DESCRIPTION
That fixes the logs.

@bonomat If you prefer to restrict the `rejected` and `failed` CFD by ID let me know. We could also clean with up in the database, but I am not sure it's worth it. I think the condition I added is good enough.