### PR TITLE
Fix payout / P/L of closed CFDs

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -556,8 +556,9 @@ impl Cfd {
     }
 
     pub fn with_current_quote(self, latest_quote: Option<xtra_bitmex_price_feed::Quote>) -> Self {
-        // Closed CFDs should not be modified by the current quote
-        if self.aggregated.state == CfdState::Closed {
+        // If the payout was already set we don't care about the current quote, this applies to
+        // closed CFDs
+        if self.payout.is_some() {
             return self;
         }
 


### PR DESCRIPTION
Use the `payout` field for decision making. If it was set prior to `with_current_quote` we just exit because the `payout` is already set.
Like this we are independent of the state; which is necessary to make sure that `CfdAggregate` is still handled correctly when being closed.

Note that this is a somewhat hacky fix. We will run into trouble with this logic in the projection again once we make changes. 
The `Aggregate` within three `xyzCfdAggregate`s is error prone, we should refactor and simplfy this.