### PR TITLE
Reduce time to sync wallet and sync less often

### DIFF
--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -32,7 +32,7 @@ use tokio_tasks::Tasks;
 use xtra_productivity::xtra_productivity;
 use xtras::SendInterval;
 
-const SYNC_INTERVAL: Duration = Duration::from_secs(10);
+const SYNC_INTERVAL: Duration = Duration::from_secs(60);
 
 static BALANCE_GAUGE: conquer_once::Lazy<prometheus::Gauge> = conquer_once::Lazy::new(|| {
     prometheus::register_gauge!(

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -135,6 +135,7 @@ impl Actor<ElectrumBlockchain> {
 
 impl Actor<ElectrumBlockchain> {
     fn sync_internal(&mut self) -> Result<WalletInfo> {
+        let now = Instant::now();
         self.wallet
             .sync(&self.blockchain_client, SyncOptions::default())
             .context("Failed to sync wallet")?;
@@ -165,6 +166,7 @@ impl Actor<ElectrumBlockchain> {
             last_updated_at: Timestamp::now(),
         };
 
+        tracing::trace!(target : "wallet", sync_time_sec = %now.elapsed().as_secs(), "Wallet sync done");
         Ok(wallet_info)
     }
 }


### PR DESCRIPTION
We only want to sync for 1000 addresses during the first sync. This is because we might have generated over 1000 addresses in the past and if we would not sync that far ahead we would miss some balance.
For repeatedly sync it is enough to sync for the default 100 addresses because everytime we generate a change address it is automatically included.

This is a minor improvement because generating 1000 addresses and syncing for it takes some time.

The last commit might be *a* reason for our ever growing ram usage.