### PR TITLE
Only allow two rollover at a time

### DIFF
--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -531,19 +531,12 @@ impl Actor {
                 }
             }
             ProposeRollover { order_id, .. } | ProposeRolloverV2 { order_id, .. } => {
-                if self.rollover_actors.is_empty() {
+                if self.rollover_actors.len() < 2 {
                     let _ = self.taker_msg_channel.send_async_safe(msg).await;
                 } else {
-                    let ongoing = self.rollover_actors.first_key();
                     let ignored = order_id;
-
-                    match ongoing {
-                        None => {
-                            tracing::error!("Ignoring rollover request but it appears there is no rollover ongoing. This should really not happen.")
-                        }
-                        Some(ongoing) => {
-                            tracing::trace!(target:"wire", %ongoing, %ignored, "Ignoring rollover request because there is still a rollover ongoing.")
-                        }
+                    for ongoing in self.rollover_actors.keys() {
+                        tracing::trace!(target:"wire", %ongoing, %ignored, "Ignoring rollover request because there is still a rollover ongoing.")
                     }
                 }
             }

--- a/xtras/src/address_map.rs
+++ b/xtras/src/address_map.rs
@@ -2,6 +2,7 @@ use crate::ActorName;
 use crate::SendAsyncSafe;
 use anyhow::Result;
 use std::collections::hash_map::Entry;
+use std::collections::hash_map::Keys;
 use std::collections::HashMap;
 use std::hash::Hash;
 use xtra::Address;
@@ -61,8 +62,13 @@ where
         self.inner.is_empty()
     }
 
-    pub fn first_key(&self) -> Option<&K> {
-        self.inner.keys().next()
+    pub fn len(&mut self) -> usize {
+        self.gc();
+        self.inner.len()
+    }
+
+    pub fn keys(&self) -> Keys<'_, K, Address<A>> {
+        self.inner.keys()
     }
 
     pub fn insert(&mut self, key: K, address: Address<A>) {


### PR DESCRIPTION
With this change we only allow two rollover at the time to reduce the load on the maker.

The current amount of CFDs requires to allow more than 1, so we opt for 2 for now until we know if that helps with stability. 