### PR TITLE
Log `OrderId` next to message whenever possible

### DIFF
--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -70,7 +70,12 @@ impl State {
             }
         };
 
-        tracing::trace!(target: "wire", msg_name = msg_str, "Sending");
+        match msg.order_id() {
+            Some(order_id) => {
+                tracing::trace!(target: "wire", msg_name = msg_str, %order_id, "Sending")
+            }
+            None => tracing::trace!(target: "wire", msg_name = msg_str, "Sending"),
+        };
 
         write
             .send(msg)
@@ -432,7 +437,10 @@ impl Actor {
 
         let msg_name = msg.name();
 
-        tracing::trace!(target: "wire", msg_name, "Received");
+        match msg.order_id() {
+            Some(order_id) => tracing::trace!(target: "wire", msg_name, %order_id, "Received"),
+            None => tracing::trace!(target: "wire", msg_name, "Received"),
+        }
 
         match msg {
             wire::MakerToTaker::Heartbeat => {

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -159,6 +159,20 @@ impl TakerToMaker {
             TakerToMaker::Unknown => "TakerToMaker::Unknown",
         }
     }
+
+    pub fn order_id(&self) -> Option<OrderId> {
+        use TakerToMaker::*;
+        match self {
+            DeprecatedTakeOrder { order_id, .. }
+            | TakeOrder { order_id, .. }
+            | ProposeRollover { order_id, .. }
+            | ProposeRolloverV2 { order_id, .. }
+            | Protocol { order_id, .. }
+            | RolloverProtocol { order_id, .. }
+            | Settlement { order_id, .. } => Some(*order_id),
+            Hello(_) | HelloV2 { .. } | Unknown => None,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -280,6 +294,22 @@ impl MakerToTaker {
                 maker_to_taker::Settlement::Reject => "MakerToTaker::Settlement::Reject",
             },
             MakerToTaker::Unknown => "MakerToTaker::Unknown",
+        }
+    }
+
+    pub fn order_id(&self) -> Option<OrderId> {
+        use MakerToTaker::*;
+        match self {
+            CurrentOrder(Some(DeprecatedOrder047 { id: order_id, .. }))
+            | ConfirmOrder(order_id)
+            | RejectOrder(order_id)
+            | InvalidOrderId(order_id)
+            | Protocol { order_id, .. }
+            | RolloverProtocol { order_id, .. }
+            | ConfirmRollover { order_id, .. }
+            | RejectRollover(order_id)
+            | Settlement { order_id, .. } => Some(*order_id),
+            Hello(_) | Heartbeat | CurrentOffers(_) | CurrentOrder(_) | Unknown => None,
         }
     }
 }

--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -118,7 +118,14 @@ impl Connection {
             .with(&HashMap::from([(MESSAGE_LABEL, msg_str)]))
             .inc();
 
-        tracing::trace!(target: "wire", %taker_id, msg_name = msg_str, "Sending");
+        match msg.order_id() {
+            Some(order_id) => {
+                tracing::trace!(target: "wire", %taker_id, msg_name = msg_str, %order_id, "Sending")
+            }
+            None => {
+                tracing::trace!(target: "wire", %taker_id, msg_name = msg_str, "Sending")
+            }
+        }
 
         let taker_version = self.wire_version.clone();
 
@@ -500,7 +507,14 @@ impl Actor {
     async fn handle_msg_from_taker(&mut self, msg: cfd::FromTaker) {
         let msg_str = msg.msg.name();
 
-        tracing::trace!(target: "wire", taker_id = %msg.taker_id, msg_name = msg_str, "Received");
+        match msg.msg.order_id() {
+            Some(order_id) => {
+                tracing::trace!(target: "wire", taker_id = %msg.taker_id, msg_name = msg_str, %order_id, "Received")
+            }
+            None => {
+                tracing::trace!(target: "wire", taker_id = %msg.taker_id, msg_name = msg_str, "Received")
+            }
+        }
 
         use wire::TakerToMaker::*;
         match msg.msg {


### PR DESCRIPTION
It's not always available (not all messages are associated with and `OrderId`), which is why we have to use the `tracing` syntax
`?order_id`.

The context of when a message was sent or received, associated with an `OrderId`, should be useful for debugging.