### PR TITLE
Define separate `oracle::MonitorAttestations` for start-up

### DIFF
--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -247,16 +247,18 @@ impl Actor {
             )
         }
     }
+
+    fn add_pending_attestation(&mut self, event_id: BitMexPriceEventId) {
+        if !self.pending_attestations.insert(event_id) {
+            tracing::trace!("Attestation for {event_id} already being monitored");
+        }
+    }
 }
 
 #[xtra_productivity]
 impl Actor {
     fn handle_monitor_attestation(&mut self, msg: MonitorAttestation) {
-        let price_event_id = msg.event_id;
-
-        if !self.pending_attestations.insert(price_event_id) {
-            tracing::trace!("Attestation {price_event_id} already being monitored");
-        }
+        self.add_pending_attestation(msg.event_id)
     }
 
     fn handle_get_announcement(


### PR DESCRIPTION
It should be more efficient to send one message instructing the actor to monitor several attestations when initialising the `oracle::Actor`, rather than multiple smaller messages.

Inspired by looking at #2049.