### PR TITLE
Steal connection

### DIFF
--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -106,6 +106,7 @@ struct Connection {
     write: wire::Write<wire::TakerToMaker, wire::MakerToTaker>,
     wire_version: wire::Version,
     daemon_version: String,
+    address: SocketAddr,
     _tasks: Tasks,
 }
 
@@ -419,12 +420,13 @@ impl Actor {
     ) {
         let this = ctx.address().expect("we are alive");
 
-        if self.connections.contains_key(&identity) {
+        if let Some(connection) = self.connections.get(&identity) {
             tracing::debug!(
                 taker_id = %identity,
-                "Refusing to accept 2nd connection from already connected taker!"
+                new_address = %address,
+                old_address = %connection.address,
+                "Received second connection from taker: overwriting existing connection with new!"
             );
-            return;
         }
 
         let _: Result<(), xtra::Error> = self
@@ -475,6 +477,7 @@ impl Actor {
             identity,
             Connection {
                 taker: identity,
+                address,
                 write,
                 wire_version: wire_version.clone(),
                 daemon_version: daemon_version.clone(),


### PR DESCRIPTION

Resolves #2007

If the same taker tries to connect twice we prioritize the second connection. This can be useful if the taker thinks he is disconnected from the maker but the maker does not
