### PR TITLE
Libp2p rollover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,8 @@ dependencies = [
  "futures-util",
  "memchr",
  "pin-project-lite",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -800,6 +802,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
+ "asynchronous-codec",
  "bdk",
  "bdk-ext",
  "btsieve",

--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -605,7 +605,7 @@ async fn taker_notices_lack_of_maker() {
         &taker_config,
         maker.listen_addr,
         maker.identity,
-        maker.peer_id,
+        maker.connect_addr.clone(),
     )
     .await;
 
@@ -665,7 +665,7 @@ async fn start_from_open_cfd_state(
         &TakerConfig::default(),
         maker.listen_addr,
         maker.identity,
-        maker.peer_id,
+        maker.connect_addr.clone(),
     )
     .await;
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 anyhow = "1"
 async-stream = "0.3"
 async-trait = "0.1.53"
+asynchronous-codec = { version = "0.6.0", features = ["json"] }
 bdk = { version = "0.18", default-features = false, features = ["electrum"] }
 bdk-ext = { path = "../bdk-ext" }
 btsieve = { path = "../btsieve" }

--- a/daemon/src/libp2p_utils.rs
+++ b/daemon/src/libp2p_utils.rs
@@ -38,3 +38,11 @@ pub fn create_listen_tcp_multiaddr(socket_addr: &SocketAddr) -> Result<Multiaddr
 pub fn libp2p_socket_from_legacy_networking(legacy_addr: &SocketAddr) -> SocketAddr {
     SocketAddr::new(legacy_addr.ip(), legacy_addr.port() + 1)
 }
+
+/// Determine whether to use libp2p or fallback to a legacy protocol
+pub fn can_use_libp2p(cfd: &model::Cfd) -> bool {
+    // Our abitily to kick-off a libp2p version of protocol is constrained by
+    // having previously stored the PeerId of the counterparty. Otherwise we
+    // can't dial in to them using libp2p.
+    cfd.counterparty_peer_id().is_some()
+}

--- a/daemon/src/libp2p_utils.rs
+++ b/daemon/src/libp2p_utils.rs
@@ -1,6 +1,7 @@
 use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
+use std::net::IpAddr;
 use std::net::SocketAddr;
 
 use libp2p_core::Multiaddr;
@@ -20,11 +21,20 @@ pub fn create_connect_tcp_multiaddr(
         .with_context(|| "failed to construct multiaddr")
 }
 
+/// Construct a Multiaddr that can dial in to other party given their MultiAddr
+/// and PeerId
+pub fn create_connect_multiaddr(
+    listener_multiaddr: &Multiaddr,
+    listener_peer_id: &PeerId,
+) -> Result<Multiaddr> {
+    format!("{listener_multiaddr}/p2p/{listener_peer_id}")
+        .parse::<Multiaddr>()
+        .with_context(|| "failed to construct multiaddr")
+}
+
 /// Creates MultiAddr from SocketAddr
-pub fn create_listen_tcp_multiaddr(socket_addr: &SocketAddr) -> Result<Multiaddr> {
-    let ip = socket_addr.ip();
-    let port = socket_addr.port();
-    ensure!(socket_addr.is_ipv4(), "only ipv4 is supported");
+pub fn create_listen_tcp_multiaddr(ip: &IpAddr, port: u16) -> Result<Multiaddr> {
+    ensure!(ip.is_ipv4(), "only ipv4 is supported");
 
     format!("/ip4/{ip}/tcp/{port}")
         .parse::<Multiaddr>()

--- a/daemon/src/rollover.rs
+++ b/daemon/src/rollover.rs
@@ -1,0 +1,5 @@
+pub mod maker;
+pub mod protocol;
+pub mod taker;
+
+pub const PROTOCOL: &str = "/itchysats/rollover/1.0.0";

--- a/daemon/src/rollover/maker.rs
+++ b/daemon/src/rollover/maker.rs
@@ -1,0 +1,288 @@
+use anyhow::Context;
+use anyhow::Result;
+use async_trait::async_trait;
+use asynchronous_codec::Framed;
+use asynchronous_codec::JsonCodec;
+use futures::future;
+use futures::SinkExt;
+use futures::StreamExt;
+use libp2p_core::PeerId;
+use maia_core::secp256k1_zkp::schnorrsig;
+use model::FundingRate;
+use model::OrderId;
+use model::Position;
+use model::Role;
+use model::RolloverVersion;
+use model::TxFeeRate;
+use std::collections::HashMap;
+use tokio_tasks::Tasks;
+use xtra::message_channel::MessageChannel;
+use xtra_libp2p::NewInboundSubstream;
+use xtra_libp2p::Substream;
+use xtra_productivity::xtra_productivity;
+
+use crate::command;
+use crate::oracle;
+use crate::rollover::protocol::*;
+use crate::setup_contract;
+
+use super::protocol;
+
+type ListenerConnection = (
+    Framed<Substream, JsonCodec<ListenerMessage, DialerMessage>>,
+    PeerId,
+);
+
+/// Permanent actor to handle incoming substreams for the `/itchysats/rollover/1.0.0`
+/// protocol.
+///
+/// There is only one instance of this actor for all connections, meaning we must always spawn a
+/// task whenever we interact with a substream to not block the execution of other connections.
+pub struct Actor {
+    tasks: Tasks,
+    oracle_pk: schnorrsig::PublicKey,
+    get_announcement: Box<dyn MessageChannel<oracle::GetAnnouncement>>,
+    n_payouts: usize,
+    pending_protocols: HashMap<OrderId, ListenerConnection>,
+    executor: command::Executor,
+}
+
+impl Actor {
+    pub fn new(
+        executor: command::Executor,
+        oracle_pk: schnorrsig::PublicKey,
+        get_announcement: Box<dyn MessageChannel<oracle::GetAnnouncement>>,
+        n_payouts: usize,
+    ) -> Self {
+        Self {
+            tasks: Tasks::default(),
+            oracle_pk,
+            get_announcement,
+            n_payouts,
+            pending_protocols: HashMap::default(),
+            executor,
+        }
+    }
+}
+
+#[async_trait]
+impl xtra::Actor for Actor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+#[xtra_productivity(message_impl = false)]
+impl Actor {
+    async fn handle(&mut self, msg: NewInboundSubstream, ctx: &mut xtra::Context<Self>) {
+        let NewInboundSubstream { peer, stream } = msg;
+        let address = ctx.address().expect("we are alive");
+
+        self.tasks.add_fallible(
+            async move {
+                let mut framed =
+                    Framed::new(stream, JsonCodec::<ListenerMessage, DialerMessage>::new());
+
+                let propose = framed
+                    .next()
+                    .await
+                    .context("End of stream while receiving Propose")?
+                    .context("Failed to decode Propose")?
+                    .into_propose()?;
+
+                address
+                    .send(ProposeReceived {
+                        propose,
+                        framed,
+                        peer,
+                    })
+                    .await?;
+
+                anyhow::Ok(())
+            },
+            |e| async move { tracing::warn!("Failed to handle incoming rollover protocol: {e:#}") },
+        );
+    }
+}
+
+#[xtra_productivity]
+impl Actor {
+    async fn handle(&mut self, msg: ProposeReceived) {
+        let ProposeReceived {
+            propose,
+            framed,
+            peer,
+        } = msg;
+        let order_id = propose.order_id;
+
+        if let Err(e) = self
+            .executor
+            .execute(order_id, |cfd| {
+                // TODO: Validate that the correct peer is invoking this?
+                cfd.start_rollover()
+            })
+            .await
+        {
+            tracing::warn!(%order_id, "Rollover failed after handling taker proposal: {e:#}");
+
+            // We have to append failed to ensure that we can rollover in the future
+            // The cfd logic might otherwise prevent us from starting a rollover if there is still
+            // one ongoing that was not properly ended.
+            emit_failed(order_id, e, &self.executor).await;
+
+            return;
+        }
+
+        // In case we fail to accept/reject some proposals might never get cleaned up. Given that
+        // the taker will retry this should not do much harm because we will replace the proposal
+        // with a new one. This is acceptable for now.
+        self.pending_protocols.insert(order_id, (framed, peer));
+    }
+
+    async fn handle(&mut self, msg: Accept) -> Result<()> {
+        let Accept {
+            order_id,
+            tx_fee_rate,
+            long_funding_rate,
+            short_funding_rate,
+        } = msg;
+
+        let (mut framed, _) = self.pending_protocols.remove(&order_id).with_context(|| {
+            format!("No active protocol for {order_id} when accepting rollover")
+        })?;
+
+        self.tasks.add_fallible(
+            {
+                let executor = self.executor.clone();
+                let get_announcement = self.get_announcement.clone_channel();
+                let oracle_pk = self.oracle_pk;
+                let n_payouts = self.n_payouts;
+                async move {
+                    let (rollover_params, dlc, position, oracle_event_id, funding_rate) = executor
+                        .execute(order_id, |cfd| {
+                            let funding_rate = match cfd.position() {
+                                Position::Long => long_funding_rate,
+                                Position::Short => short_funding_rate,
+                            };
+
+                            let (event, params, dlc, position, oracle_event_id) = cfd
+                                .accept_rollover_proposal(
+                                    tx_fee_rate,
+                                    funding_rate,
+                                    RolloverVersion::V3,
+                                )?;
+
+                            Ok((event, params, dlc, position, oracle_event_id, funding_rate))
+                        })
+                        .await?;
+
+                    let complete_fee = rollover_params
+                        .fee_account
+                        .add_funding_fee(rollover_params.current_fee)
+                        .settle();
+
+                    framed
+                        .send(ListenerMessage::Decision(Decision::Confirm(Confirm {
+                            order_id,
+                            oracle_event_id,
+                            tx_fee_rate,
+                            funding_rate,
+                            complete_fee: complete_fee.into(),
+                        })))
+                        .await
+                        .context("Failed to send rollover confirmation message")?;
+
+                    let announcement = get_announcement
+                        .send(oracle::GetAnnouncement(oracle_event_id))
+                        .await
+                        .context("Oracle actor disconnected")?
+                        .context("Failed to get announcement")?;
+
+                    let funding_fee = *rollover_params.funding_fee();
+
+                    let (sink, stream) = framed.split();
+
+                    let dlc = setup_contract::roll_over(
+                        sink.with(|msg| future::ok(ListenerMessage::RolloverMsg(Box::new(msg)))),
+                        Box::pin(stream.filter_map(|msg| async move {
+                            match msg {
+                                Ok(msg) => msg.into_rollover_msg().ok(),
+                                Err(e) => {
+                                    tracing::error!("Failed to convert rollover message: {e:#}");
+                                    None
+                                }
+                            }
+                        }))
+                        .fuse(),
+                        (oracle_pk, announcement),
+                        rollover_params,
+                        Role::Maker,
+                        position,
+                        dlc,
+                        n_payouts,
+                        complete_fee,
+                    )
+                    .await?;
+
+                    emit_completed(order_id, dlc, funding_fee, &executor).await;
+
+                    Ok(())
+                }
+            },
+            {
+                let executor = self.executor.clone();
+                move |e| async move {
+                    emit_failed(order_id, e, &executor).await;
+                }
+            },
+        );
+
+        Ok(())
+    }
+
+    async fn handle(&mut self, msg: Reject) -> Result<()> {
+        let Reject { order_id } = msg;
+
+        let (mut framed, ..) = self.pending_protocols.remove(&order_id).with_context(|| {
+            format!("No active protocol for {order_id} when rejecting rollover")
+        })?;
+
+        emit_rejected(order_id, &self.executor).await;
+
+        self.tasks.add_fallible(
+            async move {
+                framed
+                    .send(ListenerMessage::Decision(Decision::Reject(
+                        protocol::Reject { order_id },
+                    )))
+                    .await
+            },
+            move |e| async move {
+                tracing::debug!(%order_id, "Failed to send reject rollover to the taker: {e:#}")
+            },
+        );
+
+        Ok(())
+    }
+}
+
+struct ProposeReceived {
+    propose: Propose,
+    framed: Framed<Substream, JsonCodec<ListenerMessage, DialerMessage>>,
+    peer: PeerId,
+}
+
+/// Upon accepting Rollover maker sends the current estimated transaction fee and
+/// funding rate
+#[derive(Clone, Copy, Debug)]
+pub struct Accept {
+    pub order_id: OrderId,
+    pub tx_fee_rate: TxFeeRate,
+    pub long_funding_rate: FundingRate,
+    pub short_funding_rate: FundingRate,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Reject {
+    pub order_id: OrderId,
+}

--- a/daemon/src/rollover/protocol.rs
+++ b/daemon/src/rollover/protocol.rs
@@ -1,0 +1,143 @@
+use crate::command;
+use crate::wire::CompleteFee;
+use crate::wire::RolloverMsg;
+use anyhow::anyhow;
+use anyhow::bail;
+use anyhow::Result;
+use model::olivia::BitMexPriceEventId;
+use model::Dlc;
+use model::FundingFee;
+use model::FundingRate;
+use model::OrderId;
+use model::Timestamp;
+use model::TxFeeRate;
+use serde::Deserialize;
+use serde::Serialize;
+
+pub struct RolloverCompletedParams {
+    pub dlc: Dlc,
+    pub funding_fee: FundingFee,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum DialerError {
+    #[error("Rollover got rejected")]
+    Rejected,
+    #[error("Rollover failed")]
+    Failed {
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum DialerMessage {
+    Propose(Propose),
+    RolloverMsg(Box<RolloverMsg>),
+}
+
+impl DialerMessage {
+    pub fn into_propose(self) -> Result<Propose> {
+        match self {
+            DialerMessage::Propose(propose) => Ok(propose),
+            DialerMessage::RolloverMsg(_) => bail!("Expected Propose but got RolloverMsg"),
+        }
+    }
+
+    pub fn into_rollover_msg(self) -> Result<RolloverMsg> {
+        match self {
+            DialerMessage::RolloverMsg(rollover_msg) => Ok(*rollover_msg),
+            DialerMessage::Propose(_) => bail!("Expected RolloverMsg but got Propose"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Serialize, Deserialize)]
+pub enum Decision {
+    Confirm(Confirm),
+    Reject(Reject),
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum ListenerMessage {
+    Decision(Decision),
+    RolloverMsg(Box<RolloverMsg>),
+}
+
+impl ListenerMessage {
+    pub fn into_decision(self) -> Result<Decision> {
+        match self {
+            ListenerMessage::Decision(decision) => Ok(decision),
+            ListenerMessage::RolloverMsg(_) => {
+                Err(anyhow!("Expected Decision but got RolloverMsg"))
+            }
+        }
+    }
+
+    pub fn into_rollover_msg(self) -> Result<RolloverMsg> {
+        match self {
+            ListenerMessage::RolloverMsg(rollover_msg) => Ok(*rollover_msg),
+            ListenerMessage::Decision(_) => Err(anyhow!("Expected RolloverMsg but got Decision")),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Serialize, Deserialize)]
+pub struct Propose {
+    pub order_id: OrderId,
+    pub timestamp: Timestamp,
+}
+
+#[derive(Copy, Clone, Serialize, Deserialize)]
+pub struct Confirm {
+    pub order_id: OrderId,
+    pub oracle_event_id: BitMexPriceEventId,
+    pub tx_fee_rate: TxFeeRate,
+    pub funding_rate: FundingRate,
+    pub complete_fee: CompleteFee,
+}
+
+#[derive(Copy, Clone, Serialize, Deserialize)]
+pub struct Reject {
+    pub order_id: OrderId,
+}
+
+pub(crate) async fn emit_completed(
+    order_id: OrderId,
+    dlc: Dlc,
+    funding_fee: FundingFee,
+    executor: &command::Executor,
+) {
+    if let Err(e) = executor
+        .execute(order_id, |cfd| Ok(cfd.complete_rollover(dlc, funding_fee)))
+        .await
+    {
+        tracing::error!(%order_id, "Failed to execute rollover completed: {e:#}")
+    }
+
+    tracing::info!(%order_id, "Rollover completed");
+}
+
+pub(crate) async fn emit_rejected(order_id: OrderId, executor: &command::Executor) {
+    if let Err(e) = executor
+        .execute(order_id, |cfd| {
+            Ok(cfd.reject_rollover(anyhow!("maker decision")))
+        })
+        .await
+    {
+        tracing::error!(%order_id, "Failed to execute rollover rejected: {e:#}")
+    }
+
+    tracing::info!(%order_id, "Rollover rejected");
+}
+
+pub(crate) async fn emit_failed(order_id: OrderId, e: anyhow::Error, executor: &command::Executor) {
+    tracing::error!(%order_id, "Rollover failed: {e:#}");
+
+    if let Err(e) = executor
+        .execute(order_id, |cfd| Ok(cfd.fail_rollover(e)))
+        .await
+    {
+        tracing::error!(%order_id, "Failed to execute rollover failed: {e:#}")
+    }
+}

--- a/daemon/src/rollover/taker.rs
+++ b/daemon/src/rollover/taker.rs
@@ -1,0 +1,218 @@
+use crate::command;
+use crate::future_ext::FutureExt;
+use crate::oracle;
+use crate::rollover;
+use crate::rollover::protocol::emit_completed;
+use crate::rollover::protocol::emit_failed;
+use crate::rollover::protocol::emit_rejected;
+use crate::rollover::protocol::Confirm;
+use crate::rollover::protocol::Decision;
+use crate::rollover::protocol::DialerMessage;
+use crate::rollover::protocol::ListenerMessage;
+use crate::rollover::protocol::Propose;
+use crate::setup_contract;
+use anyhow::Context;
+use async_trait::async_trait;
+use futures::future;
+use futures::SinkExt;
+use futures::StreamExt;
+use maia_core::secp256k1_zkp::schnorrsig;
+use model::libp2p::PeerId;
+use model::OrderId;
+use model::Role;
+use model::Timestamp;
+use std::time::Duration;
+use tokio_tasks::Tasks;
+use xtra::message_channel::MessageChannel;
+use xtra::Address;
+use xtra_libp2p::Endpoint;
+use xtra_libp2p::OpenSubstream;
+use xtra_libp2p::Substream;
+use xtra_productivity::xtra_productivity;
+
+/// The duration that the taker waits until a decision (accept/reject) is expected from the maker
+///
+/// If the maker does not respond within `DECISION_TIMEOUT` seconds then the taker will fail the
+/// rollover.
+const DECISION_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// One actor to rule all the rollovers
+pub struct Actor {
+    endpoint: Address<Endpoint>,
+    oracle_pk: schnorrsig::PublicKey,
+    get_announcement: Box<dyn MessageChannel<oracle::GetAnnouncement>>,
+    n_payouts: usize,
+    tasks: Tasks,
+    executor: command::Executor,
+}
+
+#[async_trait]
+impl xtra::Actor for Actor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+#[derive(Copy, Clone)]
+pub struct ProposeRollover {
+    pub order_id: OrderId,
+    pub maker_peer_id: PeerId,
+}
+
+impl Actor {
+    pub fn new(
+        endpoint: Address<Endpoint>,
+        executor: command::Executor,
+        oracle_pk: schnorrsig::PublicKey,
+        get_announcement: Box<dyn MessageChannel<oracle::GetAnnouncement>>,
+        n_payouts: usize,
+    ) -> Self {
+        Self {
+            endpoint,
+            tasks: Tasks::default(),
+            executor,
+            get_announcement,
+            oracle_pk,
+            n_payouts,
+        }
+    }
+}
+
+impl Actor {
+    async fn open_substream(&self, peer_id: PeerId) -> anyhow::Result<Substream> {
+        Ok(self
+            .endpoint
+            .send(OpenSubstream::single_protocol(
+                peer_id.inner(),
+                rollover::PROTOCOL,
+            ))
+            .await
+            .context("Endpoint is disconnected")
+            .context("Failed to open substream")??)
+    }
+}
+
+#[xtra_productivity]
+impl Actor {
+    pub async fn handle(&mut self, msg: ProposeRollover) {
+        let ProposeRollover {
+            order_id,
+            maker_peer_id,
+        } = msg;
+
+        let substream = match self.open_substream(maker_peer_id).await {
+            Ok(substream) => substream,
+            Err(e) => {
+                tracing::error!(%order_id, "Failed to start rollover: {e:#}");
+                emit_failed(order_id, e, &self.executor).await;
+                return;
+            }
+        };
+
+        self.tasks.add_fallible(
+            {
+                let executor = self.executor.clone();
+                let get_announcement = self.get_announcement.clone_channel();
+                let oracle_pk = self.oracle_pk;
+                let n_payouts = self.n_payouts;
+                async move {
+                    let mut framed = asynchronous_codec::Framed::new(
+                        substream,
+                        asynchronous_codec::JsonCodec::<DialerMessage, ListenerMessage>::new(),
+                    );
+
+                    executor
+                        .execute(order_id, |cfd| cfd.start_rollover())
+                        .await?;
+
+                    framed
+                        .send(DialerMessage::Propose(Propose {
+                            order_id,
+                            timestamp: Timestamp::now(),
+                        }))
+                        .await
+                        .context("Failed to send Msg0")?;
+
+                    match framed
+                        .next()
+                        .timeout(DECISION_TIMEOUT)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "Maker did not accept/reject within {} seconds.",
+                                DECISION_TIMEOUT.as_secs()
+                            )
+                        })?
+                        .context("End of stream while receiving rollover decision from maker")?
+                        .context("Failed to decode rollover decision from maker")?
+                        .into_decision()?
+                    {
+                        Decision::Confirm(Confirm {
+                            order_id,
+                            oracle_event_id,
+                            tx_fee_rate,
+                            funding_rate,
+                            complete_fee,
+                        }) => {
+                            let (rollover_params, dlc, position) = executor
+                                .execute(order_id, |cfd| {
+                                    cfd.handle_rollover_accepted_taker(tx_fee_rate, funding_rate)
+                                })
+                                .await?;
+
+                            let announcement = get_announcement
+                                .send(oracle::GetAnnouncement(oracle_event_id))
+                                .await
+                                .context("Oracle actor disconnected")?
+                                .context("Failed to get announcement")?;
+
+                            tracing::info!(%order_id, "Rollover proposal got accepted");
+
+                            let funding_fee = *rollover_params.funding_fee();
+
+                            let (sink, stream) = framed.split();
+
+                            let dlc = setup_contract::roll_over(
+                                sink.with(|msg| {
+                                    future::ok(DialerMessage::RolloverMsg(Box::new(msg)))
+                                }),
+                                Box::pin(stream.filter_map(|msg| async move {
+                                    match msg {
+                                        Ok(msg) => msg.into_rollover_msg().ok(),
+                                        Err(e) => {
+                                            tracing::error!(
+                                                "Failed to convert rollover message: {e:#}"
+                                            );
+                                            None
+                                        }
+                                    }
+                                }))
+                                .fuse(),
+                                (oracle_pk, announcement),
+                                rollover_params,
+                                Role::Taker,
+                                position,
+                                dlc,
+                                n_payouts,
+                                complete_fee.into(),
+                            )
+                            .await?;
+
+                            emit_completed(order_id, dlc, funding_fee, &executor).await;
+                        }
+                        Decision::Reject(_) => {
+                            emit_rejected(order_id, &executor).await;
+                        }
+                    }
+                    Ok(())
+                }
+            },
+            {
+                let executor = self.executor.clone();
+                move |e| async move {
+                    emit_failed(order_id, e, &executor).await;
+                }
+            },
+        );
+    }
+}

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -52,6 +52,7 @@ pub struct ActorSystem<O, W> {
     _listener_supervisor: Address<supervisor::Actor<listener::Actor, listener::Error>>,
     _position_metrics_actor: Address<position_metrics::Actor>,
     _cull_old_dlcs_actor: Address<cull_old_dlcs::Actor>,
+    _listener_actor: Address<listener::Actor>,
 }
 
 impl<O, W> ActorSystem<O, W>
@@ -146,7 +147,7 @@ where
         let endpoint_listen = daemon::libp2p_utils::create_listen_tcp_multiaddr(&libp2p_socket)
             .expect("to parse properly");
 
-        let (supervisor, _listener_actor) = supervisor::Actor::with_policy(
+        let (supervisor, listener_actor) = supervisor::Actor::with_policy(
             move || {
                 let endpoint_addr = endpoint_addr.clone();
                 let endpoint_listen = endpoint_listen.clone();
@@ -197,6 +198,7 @@ where
             _listener_supervisor: listener_supervisor,
             _position_metrics_actor: position_metrics_actor,
             _cull_old_dlcs_actor,
+            _listener_actor: listener_actor,
         })
     }
 

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -100,6 +100,13 @@ async fn main() -> Result<()> {
 
     let (projection_actor, projection_context) = xtra::Context::new(None);
 
+    let libp2p_socket = daemon::libp2p_utils::libp2p_socket_from_legacy_networking(&p2p_socket);
+    let endpoint_listen = daemon::libp2p_utils::create_listen_tcp_multiaddr(
+        &libp2p_socket.ip(),
+        libp2p_socket.port(),
+    )
+    .expect("to parse properly");
+
     let maker = ActorSystem::new(
         db.clone(),
         wallet.clone(),
@@ -117,6 +124,7 @@ async fn main() -> Result<()> {
         identities,
         HEARTBEAT_INTERVAL,
         p2p_socket,
+        endpoint_listen,
     )?;
 
     let (supervisor, price_feed) =

--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -84,6 +84,8 @@ impl OpenSubstream<Single> {
     /// We will only attempt to negotiate the given protocol. If the endpoint does not speak this
     /// protocol, negotiation will fail.
     pub fn single_protocol(peer: PeerId, protocol: &'static str) -> Self {
+        tracing::trace!("Open substream with peer {peer} on protocol {protocol}");
+
         Self {
             peer,
             protocols: vec![protocol],
@@ -100,6 +102,9 @@ impl OpenSubstream<Multiple> {
     /// can attempt to first establish a substream with a new protocol and falling back to older
     /// versions in case the new version is not supported.
     pub fn multiple_protocols(peer: PeerId, protocols: Vec<&'static str>) -> Self {
+        tracing::trace!(
+            "Open substream (multi protocol) with peer {peer} on protocol {protocols:?}"
+        );
         Self {
             peer,
             protocols,


### PR DESCRIPTION
Introduces protocol for rollover over libp2p connection.

Open TODO:

- [ ] Ensure to incorporate the changes of https://github.com/itchysats/itchysats/pull/2066 once it merges

---

On top of this PR we need a clearer picture how we see this evolve. Would be good to write an ADR about this
	
- [ ] Discussion about evolving protocol versions
		- Separation of protocol (messaging) and actor (decision making, processing external decisions e.g. accept/reject)
		- Multiple actors for one protocol version?
		- Decision making on the maker side?

- [ ] Discuss about scaling - congestion issues (bottleneck of actors being flooded with messages)
		- Potentially have one actor per protocol *per taker*
		Challanges: Ephemeral actors per connection
		- Potentially introduce bounded inboxes
		Challanges: Bounded inboxes is somewhat of an unknown

Note on congestion: We tried to avoid the pattern of "coming back to the actor from a task within the actor" because it likely leads to more congestion. We dispatch into a task early (on both the maker and taker side) and then finishing up is just done within the task using the executor (i.e. finish in the database) without involving the rollover actor. I think this is a good pattern but open to discussion :)