### PR TITLE
Introduce rollover version 3

### DIFF
--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -313,7 +313,7 @@ impl Actor {
         } = msg;
 
         self.state
-            .send(wire::TakerToMaker::ProposeRolloverV2 {
+            .send(wire::TakerToMaker::ProposeRolloverV3 {
                 order_id,
                 timestamp,
             })

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -6,16 +6,14 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use maia_core::secp256k1_zkp::schnorrsig;
 use model::olivia;
+use model::olivia::next_announcement_after;
 use model::olivia::BitMexPriceEventId;
 use model::CfdEvent;
 use model::EventKind;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::ops::Add;
-use time::ext::NumericalDuration;
 use time::Duration;
 use time::OffsetDateTime;
-use time::Time;
 use tokio_tasks::Tasks;
 use xtra_productivity::xtra_productivity;
 use xtras::SendInterval;
@@ -309,20 +307,6 @@ impl Actor {
 #[error("Announcement {0} not found")]
 pub struct NoAnnouncement(pub BitMexPriceEventId);
 
-pub fn next_announcement_after(timestamp: OffsetDateTime) -> BitMexPriceEventId {
-    let adjusted = ceil_to_next_hour(timestamp);
-
-    BitMexPriceEventId::with_20_digits(adjusted)
-}
-
-fn ceil_to_next_hour(original: OffsetDateTime) -> OffsetDateTime {
-    let timestamp = original.add(1.hours());
-    let exact_hour = Time::from_hms(timestamp.hour(), 0, 0).expect(
-        "Exact hour from timestamp to be always within range, both docs and tests confirm it",
-    );
-    timestamp.replace_time(exact_hour)
-}
-
 #[async_trait]
 impl xtra::Actor for Actor {
     type Stop = ();
@@ -388,30 +372,4 @@ impl Attestation {
 
 impl xtra::Message for Attestation {
     type Result = ();
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use time::macros::datetime;
-
-    #[test]
-    fn next_event_id_after_timestamp() {
-        let event_id = next_announcement_after(datetime!(2021-09-23 10:40:00).assume_utc());
-
-        assert_eq!(
-            event_id.to_string(),
-            "/x/BitMEX/BXBT/2021-09-23T11:00:00.price?n=20"
-        );
-    }
-
-    #[test]
-    fn next_event_id_is_midnight_next_day() {
-        let event_id = next_announcement_after(datetime!(2021-09-23 23:40:00).assume_utc());
-
-        assert_eq!(
-            event_id.to_string(),
-            "/x/BitMEX/BXBT/2021-09-24T00:00:00.price?n=20"
-        );
-    }
 }

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -119,6 +119,10 @@ pub enum TakerToMaker {
         order_id: OrderId,
         timestamp: Timestamp,
     },
+    ProposeRolloverV3 {
+        order_id: OrderId,
+        timestamp: Timestamp,
+    },
     Protocol {
         order_id: OrderId,
         msg: SetupMsg,
@@ -150,6 +154,7 @@ impl TakerToMaker {
             },
             TakerToMaker::ProposeRollover { .. } => "TakerToMaker::ProposeRollover",
             TakerToMaker::ProposeRolloverV2 { .. } => "TakerToMaker::ProposeRolloverV2",
+            TakerToMaker::ProposeRolloverV3 { .. } => "TakerToMaker::ProposeRolloverV3",
             TakerToMaker::RolloverProtocol { msg, .. } => match msg {
                 RolloverMsg::Msg0(_) => "TakerToMaker::RolloverProtocol::Msg0",
                 RolloverMsg::Msg1(_) => "TakerToMaker::RolloverProtocol::Msg1",
@@ -174,6 +179,7 @@ impl TakerToMaker {
             | TakeOrder { order_id, .. }
             | ProposeRollover { order_id, .. }
             | ProposeRolloverV2 { order_id, .. }
+            | ProposeRolloverV3 { order_id, .. }
             | Protocol { order_id, .. }
             | RolloverProtocol { order_id, .. }
             | Settlement { order_id, .. } => Some(*order_id),

--- a/maker/src/cfd.rs
+++ b/maker/src/cfd.rs
@@ -741,6 +741,24 @@ where
                     tracing::warn!("Failed to handle rollover proposal V2: {:#}", e);
                 }
             }
+            wire::TakerToMaker::ProposeRolloverV3 {
+                order_id,
+                timestamp,
+            } => {
+                if let Err(e) = self
+                    .handle_propose_rollover(
+                        RolloverProposal {
+                            order_id,
+                            timestamp,
+                        },
+                        taker_id,
+                        RolloverVersion::V3,
+                    )
+                    .await
+                {
+                    tracing::warn!("Failed to handle rollover proposal V3: {:#}", e);
+                }
+            }
             wire::TakerToMaker::RolloverProtocol { .. }
             | wire::TakerToMaker::Protocol { .. }
             | wire::TakerToMaker::Hello(_)

--- a/maker/src/cfd.rs
+++ b/maker/src/cfd.rs
@@ -18,6 +18,7 @@ use daemon::wallet;
 use daemon::wire;
 use maia_core::secp256k1_zkp::schnorrsig;
 use model::libp2p::PeerId;
+use model::olivia;
 use model::olivia::BitMexPriceEventId;
 use model::Cfd;
 use model::FundingRate;
@@ -108,7 +109,7 @@ pub struct OfferParams {
 
 impl OfferParams {
     fn pick_oracle_event_id(settlement_interval: Duration) -> BitMexPriceEventId {
-        oracle::next_announcement_after(time::OffsetDateTime::now_utc() + settlement_interval)
+        olivia::next_announcement_after(time::OffsetDateTime::now_utc() + settlement_interval)
     }
 
     pub fn create_long_order(&self, settlement_interval: Duration) -> Option<Order> {

--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -547,7 +547,9 @@ impl Actor {
                     tracing::warn!(%order_id, "No active settlement actor");
                 }
             }
-            ProposeRollover { order_id, .. } | ProposeRolloverV2 { order_id, .. } => {
+            ProposeRollover { order_id, .. }
+            | ProposeRolloverV2 { order_id, .. }
+            | ProposeRolloverV3 { order_id, .. } => {
                 if self.rollover_actors.len() < 2 {
                     let _ = self.taker_msg_channel.send_async_safe(msg).await;
                 } else {

--- a/maker/src/rollover.rs
+++ b/maker/src/rollover.rs
@@ -12,6 +12,7 @@ use futures::channel::mpsc::UnboundedSender;
 use futures::future;
 use futures::SinkExt;
 use maia_core::secp256k1_zkp::schnorrsig;
+use model::olivia;
 use model::Dlc;
 use model::FundingFee;
 use model::FundingRate;
@@ -173,7 +174,7 @@ impl Actor {
             .await?;
 
         let oracle_event_id =
-            oracle::next_announcement_after(time::OffsetDateTime::now_utc() + interval);
+            olivia::next_announcement_after(time::OffsetDateTime::now_utc() + interval);
 
         let taker_id = self.taker_id;
 

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -909,7 +909,7 @@ impl Cfd {
         tx_fee_rate: TxFeeRate,
         funding_rate: FundingRate,
         version: rollover::Version,
-    ) -> Result<(CfdEvent, RolloverParams, Dlc, Position, Duration)> {
+    ) -> Result<(CfdEvent, RolloverParams, Dlc, Position, BitMexPriceEventId)> {
         if !self.during_rollover {
             bail!("The CFD is not rolling over");
         }
@@ -918,9 +918,14 @@ impl Cfd {
             bail!("Can only accept proposal as a maker");
         }
 
+        let candidate_event_id =
+            olivia::next_announcement_after(OffsetDateTime::now_utc() + self.settlement_interval);
         let hours_to_charge = match version {
             rollover::Version::V1 => 1,
             rollover::Version::V2 => self.hours_to_extend_in_rollover()?,
+            rollover::Version::V3 => {
+                self.hours_to_extend_in_rollover_based_on_event(candidate_event_id)?
+            }
         };
 
         let funding_fee = FundingFee::calculate(
@@ -955,7 +960,7 @@ impl Cfd {
             ),
             self.dlc.clone().context("No DLC present")?,
             self.position,
-            self.settlement_interval,
+            candidate_event_id,
         ))
     }
 
@@ -974,7 +979,10 @@ impl Cfd {
 
         self.can_rollover()?;
 
-        let hours_to_charge = self.hours_to_extend_in_rollover()?;
+        let candidate_event_id =
+            olivia::next_announcement_after(OffsetDateTime::now_utc() + self.settlement_interval);
+        let hours_to_charge =
+            self.hours_to_extend_in_rollover_based_on_event(candidate_event_id)?;
         let funding_fee = FundingFee::calculate(
             self.initial_price,
             self.quantity,
@@ -1468,6 +1476,38 @@ impl Cfd {
         } else {
             hours_to_extend as u64
         })
+    }
+
+    fn hours_to_extend_in_rollover_based_on_event(
+        &self,
+        candidate_event_id: BitMexPriceEventId,
+    ) -> Result<u64> {
+        let dlc = self.dlc.as_ref().context("Cannot roll over without DLC")?;
+        let current_settlement_time = dlc.settlement_event_id.timestamp();
+
+        let hours_left = current_settlement_time - OffsetDateTime::now_utc();
+
+        tracing::trace!(target = "cfd", time_left_in_cfd = %hours_left, "Calculating hours to extend in rollover");
+
+        if !hours_left.is_positive() {
+            tracing::warn!("Rolling over a contract that can be settled non-collaboratively");
+
+            return Ok(SETTLEMENT_INTERVAL.whole_hours() as u64);
+        }
+
+        let candidate_settlement_time = candidate_event_id.timestamp();
+        let time_to_extend = candidate_settlement_time - current_settlement_time;
+
+        let hours_to_extend = time_to_extend.whole_hours();
+
+        if !hours_to_extend.is_positive() {
+            bail!(
+                "Cannot rollover if candidate event ID is no later than current event ID:
+                 {candidate_settlement_time} <= {current_settlement_time}",
+            );
+        }
+
+        Ok(hours_to_extend as u64)
     }
 
     pub fn version(&self) -> u32 {
@@ -3098,6 +3138,111 @@ mod tests {
 
         let should_liquidation_price = Price::INFINITE;
         assert_eq!(is_liquidation_price, should_liquidation_price);
+    }
+
+    #[test]
+    fn given_current_settlement_in_12_hours_and_candidate_in_19_then_7_hour_extension() {
+        let current_event_id =
+            BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc() + 12.hours());
+        let candidate_event_id =
+            BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc() + 19.hours());
+
+        let taker = Cfd::dummy_taker_long().dummy_open(current_event_id);
+        let maker = Cfd::dummy_maker_short().dummy_open(current_event_id);
+
+        assert_eq!(
+            taker
+                .hours_to_extend_in_rollover_based_on_event(candidate_event_id)
+                .unwrap(),
+            7
+        );
+
+        assert_eq!(
+            maker
+                .hours_to_extend_in_rollover_based_on_event(candidate_event_id)
+                .unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn given_settlement_within_24_hours_when_calculating_hours_to_extend_based_on_event_then_return_expected_hours(
+    ) {
+        let settlement_interval = SETTLEMENT_INTERVAL.whole_hours();
+
+        let candidate_event_id = BitMexPriceEventId::with_20_digits(
+            OffsetDateTime::now_utc() + settlement_interval.hours(),
+        );
+
+        for hour in 0..settlement_interval {
+            let current_event_id =
+                BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc() + hour.hours());
+
+            let taker = Cfd::dummy_taker_long().dummy_open(current_event_id);
+            let maker = Cfd::dummy_maker_short().dummy_open(current_event_id);
+
+            assert_eq!(
+                taker
+                    .hours_to_extend_in_rollover_based_on_event(candidate_event_id)
+                    .unwrap(),
+                (candidate_event_id.timestamp() - current_event_id.timestamp()).whole_hours()
+                    as u64
+            );
+
+            assert_eq!(
+                maker
+                    .hours_to_extend_in_rollover_based_on_event(candidate_event_id)
+                    .unwrap(),
+                (candidate_event_id.timestamp() - current_event_id.timestamp()).whole_hours()
+                    as u64
+            );
+        }
+    }
+
+    #[test]
+    fn given_cfd_can_be_settled_when_calculating_hours_to_extend_based_on_event_then_return_settlement_interval(
+    ) {
+        let event_id_1_hour_ago =
+            BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc() - 1.hours());
+
+        let taker = Cfd::dummy_taker_long().dummy_open(event_id_1_hour_ago);
+        let maker = Cfd::dummy_maker_short().dummy_open(event_id_1_hour_ago);
+
+        let event_id_in_24_hours =
+            BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc() - 24.hours());
+
+        assert_eq!(
+            taker
+                .hours_to_extend_in_rollover_based_on_event(event_id_in_24_hours)
+                .unwrap(),
+            SETTLEMENT_INTERVAL.whole_hours() as u64
+        );
+
+        assert_eq!(
+            maker
+                .hours_to_extend_in_rollover_based_on_event(event_id_in_24_hours)
+                .unwrap(),
+            SETTLEMENT_INTERVAL.whole_hours() as u64
+        );
+    }
+
+    #[test]
+    fn given_candidate_settlement_before_current_settlement_then_fails_to_calculate_hours_to_extend_based_on_event(
+    ) {
+        let current_event_id =
+            BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc() + 2.hours());
+        let earlier_event_id =
+            BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc() + 1.hours());
+
+        let taker = Cfd::dummy_taker_long().dummy_open(current_event_id);
+        let maker = Cfd::dummy_maker_short().dummy_open(current_event_id);
+
+        taker
+            .hours_to_extend_in_rollover_based_on_event(earlier_event_id)
+            .unwrap_err();
+        maker
+            .hours_to_extend_in_rollover_based_on_event(earlier_event_id)
+            .unwrap_err();
     }
 
     #[test]

--- a/model/src/olivia.rs
+++ b/model/src/olivia.rs
@@ -8,6 +8,7 @@ use serde_with::DeserializeFromStr;
 use serde_with::SerializeDisplay;
 use std::fmt;
 use std::str;
+use time::ext::NumericalDuration;
 use time::format_description::FormatItem;
 use time::macros::format_description;
 use time::Duration;
@@ -134,6 +135,20 @@ impl From<Announcement> for maia_core::Announcement {
 }
 
 impl_sqlx_type_display_from_str!(BitMexPriceEventId);
+
+pub fn next_announcement_after(timestamp: OffsetDateTime) -> BitMexPriceEventId {
+    let adjusted = ceil_to_next_hour(timestamp);
+
+    BitMexPriceEventId::with_20_digits(adjusted)
+}
+
+fn ceil_to_next_hour(original: OffsetDateTime) -> OffsetDateTime {
+    let timestamp = original + 1.hours();
+    let exact_hour = Time::from_hms(timestamp.hour(), 0, 0).expect(
+        "Exact hour from timestamp to be always within range, both docs and tests confirm it",
+    );
+    timestamp.replace_time(exact_hour)
+}
 
 mod olivia_api {
     use super::*;
@@ -445,5 +460,25 @@ mod tests {
             BitMexPriceEventId::with_20_digits(datetime!(2021-09-23 10:00:00).assume_utc());
 
         assert!(past_event.has_likely_occurred());
+    }
+
+    #[test]
+    fn next_event_id_after_timestamp() {
+        let event_id = next_announcement_after(datetime!(2021-09-23 10:40:00).assume_utc());
+
+        assert_eq!(
+            event_id.to_string(),
+            "/x/BitMEX/BXBT/2021-09-23T11:00:00.price?n=20"
+        );
+    }
+
+    #[test]
+    fn next_event_id_is_midnight_next_day() {
+        let event_id = next_announcement_after(datetime!(2021-09-23 23:40:00).assume_utc());
+
+        assert_eq!(
+            event_id.to_string(),
+            "/x/BitMEX/BXBT/2021-09-24T00:00:00.price?n=20"
+        );
     }
 }

--- a/model/src/rollover.rs
+++ b/model/src/rollover.rs
@@ -18,6 +18,12 @@ pub enum Version {
     /// This version can handle charging for "missed" rollovers, i.e. we calculate the hours to
     /// charge based on the oracle event timestamp of the last successful rollover.
     V2,
+    /// Version two of the rollover protocol
+    ///
+    /// This version calculates the time to extend the settlement time
+    /// by using the `BitMexPriceEventId` of the settlement event
+    /// associated with the rollover.
+    V3,
 }
 
 impl std::fmt::Display for Version {
@@ -25,6 +31,7 @@ impl std::fmt::Display for Version {
         match *self {
             Version::V1 => write!(f, "V1"),
             Version::V2 => write!(f, "V2"),
+            Version::V3 => write!(f, "V3"),
         }
     }
 }


### PR DESCRIPTION
Fixes #1974 (we can still rollover every two hours, but we should charge/pay accordingly).

Taker now default to version 3. The maker supports all versions.

This new version calculates the hours to extend the settlement time by during rollover based on the event ID that will actually be proposed. The motivation is to charge for rollovers based on the actual extension to the settlement time of the CFD that they provide.