### PR TITLE
Peer-id in db cleanup

### DIFF
--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -167,7 +167,7 @@ impl Connection {
         .bind(&cfd.counterparty_peer_id().unwrap_or({
             tracing::debug!(
                 order_id=%cfd.id(),
-                taker_id=%cfd.counterparty_network_identity(),
+                counterparty_identity=%cfd.counterparty_network_identity(),
                 "Inserting deprecated CFD with placeholder peer-id"
             );
             PeerId::placeholder()

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -164,7 +164,7 @@ impl Connection {
         .bind(&cfd.settlement_time_interval_hours().whole_hours())
         .bind(&cfd.quantity())
         .bind(&cfd.counterparty_network_identity())
-        .bind(&cfd.counterparty_peer_id().unwrap_or({
+        .bind(&cfd.counterparty_peer_id().unwrap_or_else(|| {
             tracing::debug!(
                 order_id=%cfd.id(),
                 counterparty_identity=%cfd.counterparty_network_identity(),


### PR DESCRIPTION
When going through the test logs I noticed some weirdness. Might as well get this into master.