### PR TITLE
Revert changes to `prepare_db.sh`

### DIFF
--- a/daemon/prepare_db.sh
+++ b/daemon/prepare_db.sh
@@ -15,4 +15,4 @@ trap 'rm -f $TEMPDB' EXIT
 DATABASE_URL=sqlite:$TEMPDB cargo sqlx migrate run
 
 # prepare the sqlx-data.json rust mappings
-DATABASE_URL=sqlite:./$DAEMON_DIR/$TEMPDB SQLX_OFFLINE=true cargo sqlx prepare --merged -- --all-targets
+DATABASE_URL=sqlite:./$DAEMON_DIR/$TEMPDB SQLX_OFFLINE=true cargo sqlx prepare


### PR DESCRIPTION
With patch b89983111b2e074169e0d4c25df3a9be352cc8a8 we modified the `prepare_db.sh` script in order to be able to define `sqlx` queries under `cfg(test)`.

This was convenient, but it turns out that the changes cause the script to trigger _complete_ recompilation of the project every time we run it.

There may be an alternative, but for the time being we revert this change. The effect is very minor: we move some test queries to a
`sqlx_test_utils` annotated with `#[allow(dead_code)]`.