### PR TITLE
Legacy connection establishment logs `peer_id` if available

### DIFF
--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -495,7 +495,11 @@ impl Actor {
             ]))
             .inc();
 
-        tracing::debug!(taker_id = %identity, taker_addres = %address, %wire_version, %daemon_version, "Connection is ready");
+        if let Some(peer_id) = peer_id {
+            tracing::debug!(taker_id = %identity, taker_addres = %address, %wire_version, %daemon_version, %peer_id, "Connection is ready");
+        } else {
+            tracing::debug!(taker_id = %identity, taker_addres = %address, %wire_version, %daemon_version, "Connection is ready");
+        }
     }
 
     async fn handle_listener_failed(&mut self, msg: ListenerFailed, ctx: &mut xtra::Context<Self>) {


### PR DESCRIPTION
This is important to see if peers that run into errors over the libp2p connection are able to establish a legacy connection.
If a peer only tries to connect over libp2p it is likely a peer outside our application realm.