### PR TITLE
Downgrade upgrade error to warning

### DIFF
--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -434,7 +434,7 @@ impl Endpoint {
                                         Ok(())
                                     },
                                     move |e: anyhow::Error| async move {
-                                        tracing::error!("Cannot upgrade connection {e:#}");
+                                        tracing::warn!("Could not upgrade connection {e:#}");
                                     },
                                 );
                             }


### PR DESCRIPTION
All the instances where we see this log point to someone connecting to us, that is not able to connect.
This does not seem to lead to critical problems that would justify an `error` log.