### PR TITLE
Taker sends `environment` as part of `Hello` message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM gcr.io/distroless/cc
 
+ENV ITCHYSATS_ENV=docker
+
 USER 1000
 
 LABEL "org.opencontainers.image.source"="https://github.com/itchysats/itchysats"

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -16,6 +16,7 @@ use daemon::projection::Feeds;
 use daemon::projection::MakerOffers;
 use daemon::seed::RandomSeed;
 use daemon::seed::Seed;
+use daemon::Environment;
 use daemon::HEARTBEAT_INTERVAL;
 use daemon::N_PAYOUTS;
 use model::libp2p::PeerId;
@@ -371,6 +372,7 @@ impl Taker {
             projection_actor,
             maker_identity,
             maker_multiaddr.clone(),
+            Environment::Test,
         )
         .unwrap();
 

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -19,6 +19,7 @@ use model::OrderId;
 use model::Price;
 use model::Role;
 use model::Usd;
+use parse_display::Display;
 use seed::Identities;
 use std::time::Duration;
 use time::ext::NumericalDuration;
@@ -116,6 +117,7 @@ where
         projection_actor: Address<projection::Actor>,
         maker_identity: Identity,
         maker_multiaddr: Multiaddr,
+        environment: Environment,
     ) -> Result<Self>
     where
         M: Handler<monitor::StartMonitoring>
@@ -201,6 +203,7 @@ where
                     identity.peer_id(),
                     maker_heartbeat_interval,
                     connect_timeout,
+                    environment,
                 )),
         );
 
@@ -335,5 +338,27 @@ where
                 fee: Some(fee_rate),
             })
             .await?
+    }
+}
+
+#[derive(Debug, Copy, Clone, Display)]
+pub enum Environment {
+    Umbrel,
+    RaspiBlitz,
+    Docker,
+    Binary,
+    Test,
+    Legacy,
+    Unknown,
+}
+
+impl Environment {
+    pub fn from_str_or_unknown(s: &str) -> Environment {
+        match s {
+            "umbrel" => Environment::Umbrel,
+            "raspiblitz" => Environment::RaspiBlitz,
+            "docker" => Environment::Docker,
+            _ => Environment::Unknown,
+        }
     }
 }

--- a/maker/src/cfd.rs
+++ b/maker/src/cfd.rs
@@ -795,6 +795,7 @@ where
             | wire::TakerToMaker::Hello(_)
             | wire::TakerToMaker::HelloV2 { .. }
             | wire::TakerToMaker::HelloV3 { .. }
+            | wire::TakerToMaker::HelloV4 { .. }
             | wire::TakerToMaker::Unknown => {
                 if cfg!(debug_assertions) {
                     unreachable!("Message {} is not dispatched to this actor", msg.name())

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -19,6 +19,7 @@ use daemon::seed::RandomSeed;
 use daemon::seed::Seed;
 use daemon::seed::UmbrelSeed;
 use daemon::wallet;
+use daemon::Environment;
 use daemon::TakerActorSystem;
 use daemon::HEARTBEAT_INTERVAL;
 use daemon::N_PAYOUTS;
@@ -340,6 +341,11 @@ async fn main() -> Result<()> {
         taker_peer_id: identities.libp2p.public().to_peer_id().to_string(),
     };
 
+    let environment = match option_env!("ITCHYSATS_ENV") {
+        Some(environment) => Environment::from_str_or_unknown(environment),
+        None => Environment::Binary,
+    };
+
     let taker = TakerActorSystem::new(
         db.clone(),
         wallet.clone(),
@@ -359,6 +365,7 @@ async fn main() -> Result<()> {
         projection_actor.clone(),
         Identity::new(maker_id),
         maker_multiaddr,
+        environment,
     )?;
 
     let (proj_actor, projection_feeds) =


### PR DESCRIPTION
- Introduce `HelloV4` that contains the environment

Set environment according to:

If `ITCHYSATS_ENVIRONMENT` envvar present: parse the value of the envvar.
    - If value is `umbrel` set to `UMBREL`
    - If value is `raspiblitz` set to `RASPIBLITZ`
    - If value is `docker` set to `DOCKER`
    - Else: set to `UNKNOWN`
Else
    - Set to `BINARY`

For previous `Hello` messages when logging we default environment to `LEGACY`.
For the tests we set the environment to `TEST`.

---

TODO (separate PRs / updates):

- Set `ITCHYSATS_ENY` on raspiblitz to `raspiblitz`
- set `ITCHYSATS_ENV` on umbrel to `umbrel`