### PR TITLE
Let `xtras::spawner::Actor` manage ping tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5238,6 +5238,7 @@ dependencies = [
  "tokio-tasks",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "xtra",
  "xtra_productivity",
 ]

--- a/tokio-tasks/src/lib.rs
+++ b/tokio-tasks/src/lib.rs
@@ -1,53 +1,6 @@
-use future_ext::FutureExt;
-use futures::future::RemoteHandle;
-use futures::Future;
+pub use task_map::*;
+pub use tasks::*;
 
 mod future_ext;
-
-/// Struct controlling the lifetime of the async tasks, such as
-/// running actors and periodic notifications. If it gets dropped, all
-/// tasks are cancelled.
-#[derive(Default)]
-pub struct Tasks(Vec<RemoteHandle<()>>);
-
-impl Tasks {
-    /// Spawn the task on the runtime and remember the handle.
-    ///
-    /// The task will be stopped if this instance of [`Tasks`] goes
-    /// out of scope.
-    pub fn add(&mut self, f: impl Future<Output = ()> + Send + 'static) {
-        let handle = f.spawn_with_handle();
-        self.0.push(handle);
-    }
-
-    /// Spawn a fallible task on the runtime and remember the handle.
-    ///
-    /// The task will be stopped if this instance of [`Tasks`] goes
-    /// out of scope. If the task fails, the `err_handler` will be
-    /// invoked.
-    pub fn add_fallible<E, EF>(
-        &mut self,
-        f: impl Future<Output = Result<(), E>> + Send + 'static,
-        err_handler: impl FnOnce(E) -> EF + Send + 'static,
-    ) where
-        E: Send + 'static,
-        EF: Future<Output = ()> + Send + 'static,
-    {
-        let fut = async move {
-            match f.await {
-                Ok(()) => {}
-                Err(err) => err_handler(err).await,
-            }
-        };
-
-        let handle = fut.spawn_with_handle();
-        self.0.push(handle);
-    }
-}
-
-#[cfg(feature = "xtra")]
-impl xtra::spawn::Spawner for Tasks {
-    fn spawn<F: Future<Output = ()> + Send + 'static>(&mut self, fut: F) {
-        self.add(fut);
-    }
-}
+mod task_map;
+mod tasks;

--- a/tokio-tasks/src/task_map.rs
+++ b/tokio-tasks/src/task_map.rs
@@ -1,0 +1,69 @@
+use crate::future_ext::FutureExt;
+use futures::future::RemoteHandle;
+use futures::Future;
+use std::collections::HashMap;
+use std::hash;
+
+/// Struct controlling the lifetime of the async tasks, such as
+/// running actors and periodic notifications. If it gets dropped, all
+/// tasks are cancelled.
+///
+/// Each task is associated with a key, so that it can be removed from
+/// the internal `HashMap` whenever consumers want to stop tracking
+/// the corresponding task. By removing it from the `HashMap` we free
+/// up space.
+pub struct TaskMap<K>(HashMap<K, RemoteHandle<()>>);
+
+impl<K> TaskMap<K>
+where
+    K: Eq + hash::Hash,
+{
+    /// Spawn the task on the runtime and remember the handle.
+    ///
+    /// The task will be stopped if this instance of [`TaskMap`] goes
+    /// out of scope.
+    pub fn add(&mut self, key: K, f: impl Future<Output = ()> + Send + 'static) {
+        let handle = f.spawn_with_handle();
+        self.0.insert(key, handle);
+    }
+
+    /// Spawn a fallible task on the runtime and remember the handle.
+    ///
+    /// The task will be stopped if this instance of [`TaskMap`] goes
+    /// out of scope. If the task fails, the `err_handler` will be
+    /// invoked.
+    pub fn add_fallible<E, EF>(
+        &mut self,
+        key: K,
+        f: impl Future<Output = Result<(), E>> + Send + 'static,
+        err_handler: impl FnOnce(E) -> EF + Send + 'static,
+    ) where
+        E: Send + 'static,
+        EF: Future<Output = ()> + Send + 'static,
+    {
+        let fut = async move {
+            match f.await {
+                Ok(()) => {}
+                Err(err) => err_handler(err).await,
+            }
+        };
+
+        let handle = fut.spawn_with_handle();
+        self.0.insert(key, handle);
+    }
+
+    /// Remove the handle of a task from the internal `HashMap`.
+    ///
+    /// After removing a task which is present in the `HashMap`, the
+    /// `RemoteHandle` will be dropped, effectively ending the task if
+    /// it was still ongoing.
+    pub fn remove(&mut self, key: &K) {
+        self.0.remove(key);
+    }
+}
+
+impl<K> Default for TaskMap<K> {
+    fn default() -> Self {
+        Self(HashMap::new())
+    }
+}

--- a/tokio-tasks/src/tasks.rs
+++ b/tokio-tasks/src/tasks.rs
@@ -1,0 +1,51 @@
+use crate::future_ext::FutureExt;
+use futures::future::RemoteHandle;
+use futures::Future;
+
+/// Struct controlling the lifetime of the async tasks, such as
+/// running actors and periodic notifications. If it gets dropped, all
+/// tasks are cancelled.
+#[derive(Default)]
+pub struct Tasks(Vec<RemoteHandle<()>>);
+
+impl Tasks {
+    /// Spawn the task on the runtime and remember the handle.
+    ///
+    /// The task will be stopped if this instance of [`Tasks`] goes
+    /// out of scope.
+    pub fn add(&mut self, f: impl Future<Output = ()> + Send + 'static) {
+        let handle = f.spawn_with_handle();
+        self.0.push(handle);
+    }
+
+    /// Spawn a fallible task on the runtime and remember the handle.
+    ///
+    /// The task will be stopped if this instance of [`Tasks`] goes
+    /// out of scope. If the task fails, the `err_handler` will be
+    /// invoked.
+    pub fn add_fallible<E, EF>(
+        &mut self,
+        f: impl Future<Output = Result<(), E>> + Send + 'static,
+        err_handler: impl FnOnce(E) -> EF + Send + 'static,
+    ) where
+        E: Send + 'static,
+        EF: Future<Output = ()> + Send + 'static,
+    {
+        let fut = async move {
+            match f.await {
+                Ok(()) => {}
+                Err(err) => err_handler(err).await,
+            }
+        };
+
+        let handle = fut.spawn_with_handle();
+        self.0.push(handle);
+    }
+}
+
+#[cfg(feature = "xtra")]
+impl xtra::spawn::Spawner for Tasks {
+    fn spawn<F: Future<Output = ()> + Send + 'static>(&mut self, fut: F) {
+        self.add(fut);
+    }
+}

--- a/xtra-libp2p-ping/Cargo.toml
+++ b/xtra-libp2p-ping/Cargo.toml
@@ -13,7 +13,7 @@ conquer-once = "0.3"
 futures = "0.3"
 prometheus = { version = "0.13", default-features = false }
 rand = "0.8"
-tokio-tasks = { path = "../tokio-tasks" }
+tokio-tasks = { path = "../tokio-tasks", features = ["xtra"] }
 tracing = "0.1"
 xtra = "0.6"
 xtra-libp2p = { path = "../xtra-libp2p" }

--- a/xtras/Cargo.toml
+++ b/xtras/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 tokio-tasks = { path = "../tokio-tasks" }
 tracing = { version = "0.1" }
+uuid = { version = "0.8", features = ["v4"] }
 xtra = { version = "0.6" }
 xtra_productivity = { version = "0.1.0" }
 

--- a/xtras/src/lib.rs
+++ b/xtras/src/lib.rs
@@ -3,6 +3,7 @@ pub mod address_map;
 mod log_failure;
 mod send_async_safe;
 mod send_interval;
+pub mod spawner;
 pub mod supervisor;
 
 pub use actor_name::ActorName;

--- a/xtras/src/spawner.rs
+++ b/xtras/src/spawner.rs
@@ -1,0 +1,128 @@
+use crate::SendAsyncSafe;
+use async_trait::async_trait;
+use futures::Future;
+use tokio_tasks::TaskMap;
+use uuid::Uuid;
+use xtra::Context;
+use xtra_productivity::xtra_productivity;
+
+/// A spawner actor controls the lifetime of tasks it is instructed to
+/// spawn. If all (strong) `Address`es to this `xtra::Actor` are
+/// dropped, all the tasks it is tracking will be cancelled.
+///
+/// Furthermore, a spawner actor will learn about any spawned task
+/// that has finished, dropping the corresponding task handle and
+/// freeing up memory.
+pub struct Actor {
+    tasks: TaskMap<Uuid>,
+}
+
+impl Actor {
+    pub fn new() -> Self {
+        Self {
+            tasks: TaskMap::default(),
+        }
+    }
+}
+
+#[xtra_productivity]
+impl<T> Actor
+where
+    T: Future<Output = ()> + Send + 'static,
+{
+    fn handle<T>(&mut self, msg: Spawn<T>, ctx: &mut Context<Self>)
+    where
+        T: Future<Output = ()> + Send + 'static,
+    {
+        let this = ctx.address().expect("we are alive");
+        let id = Uuid::new_v4();
+
+        self.tasks.add(id, async move {
+            msg.task.await;
+            if let Err(e) = this.send_async_safe(Finished(id)).await {
+                tracing::warn!("Failed to tell spawner about finished task: {e:#}");
+            };
+        })
+    }
+}
+
+#[async_trait]
+impl<T, EH, EF, E> xtra::Handler<SpawnFallible<T, EH>> for Actor
+where
+    T: Future<Output = Result<(), E>> + Send + 'static,
+    EH: FnOnce(E) -> EF + Send + 'static,
+    EF: Future<Output = ()> + Send + 'static,
+    E: Send + 'static,
+{
+    async fn handle(&mut self, msg: SpawnFallible<T, EH>, ctx: &mut Context<Self>) {
+        let this = ctx.address().expect("we are alive");
+        let id = Uuid::new_v4();
+
+        self.tasks.add_fallible(
+            id,
+            async move {
+                msg.task.await?;
+                if let Err(e) = this.send_async_safe(Finished(id)).await {
+                    tracing::warn!("Failed to tell spawner about finished task: {e:#}",);
+                };
+
+                Ok(())
+            },
+            msg.err_handler,
+        )
+    }
+}
+
+#[xtra_productivity]
+impl Actor {
+    fn handle(&mut self, Finished(id): Finished) {
+        self.tasks.remove(&id);
+    }
+}
+
+/// Spawn a `task` on the runtime, remembering the handle.
+pub struct Spawn<T> {
+    task: T,
+}
+
+/// Spawn a fallible task `T` on the runtime, remembering the handle.
+///
+/// If the tasks fails, the `err_handler` will be invoked.
+pub struct SpawnFallible<T, EH> {
+    task: T,
+    err_handler: EH,
+}
+
+impl<T, EH> SpawnFallible<T, EH> {
+    pub fn new(task: T, err_handler: EH) -> Self {
+        Self { task, err_handler }
+    }
+}
+
+/// Module private message to notify ourselves that a task has
+/// finished.
+///
+/// The provided key of type `Uuid` will be used to remove the
+/// corresponding task handle from the internal `TaskMap`.
+struct Finished(Uuid);
+
+#[async_trait]
+impl xtra::Actor for Actor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+impl Default for Actor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T, EH> xtra::Message for SpawnFallible<T, EH>
+where
+    T: Send + 'static,
+    EH: Send + 'static,
+{
+    type Result = ();
+}


### PR DESCRIPTION
Fixes https://github.com/itchysats/itchysats/issues/2051.

It does so by spawning the ephemeral ping tasks via the `xtras::spawner::Actor` (as opposed to using `Tasks` directly). This
actor will clean up the task handles internally when they are no longer needed.

We are still able to tie the lifetime of theses tasks to the lifetime of the `ping::Actor` because:

1. Actors are dropped when all their (strong) `xtra::Address`es are dropped.
2. We store the only (strong) `xtra::Address` to the `spawner::Actor` inside of `ping::Actor`.

This means that whenever `ping::Actor` is dropped, the last `xtra::Address<spawner::Actor, Strong>` is dropped, stopping all the ongoing tasks that were spawned through it.