### PR TITLE
Depend on two versions of maia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,7 +816,8 @@ dependencies = [
  "libp2p-core",
  "libp2p-noise",
  "libp2p-tcp",
- "maia",
+ "maia 0.1.0",
+ "maia 0.2.0",
  "maia-core",
  "model",
  "parse-display",
@@ -1845,7 +1846,21 @@ dependencies = [
 [[package]]
 name = "maia"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/maia#e419cb2cf19bed6ec53eaa3672408a6205a9b705"
+source = "git+https://github.com/comit-network/maia?rev=e419cb2cf19bed6ec53eaa3672408a6205a9b705#e419cb2cf19bed6ec53eaa3672408a6205a9b705"
+dependencies = [
+ "anyhow",
+ "bdk",
+ "itertools",
+ "maia-core",
+ "rand 0.6.5",
+ "secp256k1-zkp",
+ "thiserror",
+]
+
+[[package]]
+name = "maia"
+version = "0.2.0"
+source = "git+https://github.com/comit-network/maia?rev=a963084189e1598ca622abe206a78015ab6b8466#a963084189e1598ca622abe206a78015ab6b8466"
 dependencies = [
  "anyhow",
  "bdk",
@@ -1859,7 +1874,7 @@ dependencies = [
 [[package]]
 name = "maia-core"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/maia#e419cb2cf19bed6ec53eaa3672408a6205a9b705"
+source = "git+https://github.com/comit-network/maia?rev=e419cb2cf19bed6ec53eaa3672408a6205a9b705#e419cb2cf19bed6ec53eaa3672408a6205a9b705"
 dependencies = [
  "anyhow",
  "bdk",
@@ -1882,7 +1897,7 @@ dependencies = [
  "hex",
  "http-api-problem",
  "libp2p-tcp",
- "maia",
+ "maia 0.2.0",
  "maia-core",
  "model",
  "prometheus",
@@ -2030,7 +2045,7 @@ dependencies = [
  "hex",
  "itertools",
  "libp2p-core",
- "maia",
+ "maia 0.2.0",
  "maia-core",
  "nalgebra 0.31.0",
  "ndarray",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,6 +2045,7 @@ dependencies = [
  "hex",
  "itertools",
  "libp2p-core",
+ "maia 0.1.0",
  "maia 0.2.0",
  "maia-core",
  "nalgebra 0.31.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ resolver = "2"
 
 [patch.crates-io]
 xtra = { git = "https://github.com/comit-network/xtra" } # We need to use unreleased patches.
-maia = { git = "https://github.com/comit-network/maia" } # Unreleased
-maia-core = { git = "https://github.com/comit-network/maia" } # Unreleased
+maia = { git = "https://github.com/comit-network/maia", rev = "a963084189e1598ca622abe206a78015ab6b8466" } # Unreleased
+maia-core = { git = "https://github.com/comit-network/maia", rev = "e419cb2cf19bed6ec53eaa3672408a6205a9b705", package = "maia-core" } # Unreleased version, pinned before maia's breaking change
 xtra_productivity = { git = "https://github.com/comit-network/xtra-productivity" } # Unreleased

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -22,8 +22,9 @@ itertools = "0.10"
 libp2p-core = { version = "0.32", default-features = false }
 libp2p-noise = "0.35"
 libp2p-tcp = { version = "0.32", default-features = false, features = ["tokio"] }
-maia = "0.1.0"
+maia = "0.2.0"
 maia-core = "0.1.0"
+maia-deprecated = { git = "https://github.com/comit-network/maia", rev = "e419cb2cf19bed6ec53eaa3672408a6205a9b705", package = "maia" } # includes subtract-fee bug, needed for protocols over legacy networking
 model = { path = "../model" }
 parse-display = "0.5.5"
 prometheus = { version = "0.13", default-features = false }

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -56,6 +56,8 @@ pub mod projection;
 pub mod rollover;
 pub mod seed;
 pub mod setup_contract;
+// TODO: Remove setup_contract_deprecated module after phasing out legacy networking
+pub mod setup_contract_deprecated;
 pub mod setup_taker;
 pub mod taker_cfd;
 mod transaction_ext;

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -82,7 +82,6 @@ pub struct TakerActorSystem<O, W, P> {
     /// Keep this one around to avoid the supervisor being dropped due to ref-count changes on the
     /// address.
     _price_feed_supervisor: Address<supervisor::Actor<P, xtra_bitmex_price_feed::Error>>,
-    _dialer_actor: Address<dialer::Actor>,
     _dialer_supervisor: Address<supervisor::Actor<dialer::Actor, dialer::Error>>,
     _close_cfds_actor: Address<archive_closed_cfds::Actor>,
     _archive_failed_cfds_actor: Address<archive_failed_cfds::Actor>,
@@ -227,7 +226,7 @@ where
         let dialer_constructor =
             { move || dialer::Actor::new(endpoint_addr.clone(), maker_multiaddr.clone()) };
 
-        let (supervisor, dialer_actor) = supervisor::Actor::with_policy(
+        let (supervisor, _dialer_actor) = supervisor::Actor::with_policy(
             dialer_constructor,
             |_: &dialer::Error| true, // always restart dialer actor
         );
@@ -259,7 +258,6 @@ where
             price_feed_actor,
             executor,
             _price_feed_supervisor: price_feed_supervisor,
-            _dialer_actor: dialer_actor,
             _dialer_supervisor: dialer_supervisor,
             _close_cfds_actor: close_cfds_actor,
             _archive_failed_cfds_actor: archive_failed_cfds_actor,

--- a/daemon/src/setup_contract_deprecated.rs
+++ b/daemon/src/setup_contract_deprecated.rs
@@ -1,0 +1,830 @@
+use crate::future_ext::FutureExt;
+use crate::transaction_ext::TransactionExt;
+use crate::wallet;
+use crate::wire::Msg0;
+use crate::wire::Msg1;
+use crate::wire::Msg2;
+use crate::wire::Msg3;
+use crate::wire::RolloverMsg;
+use crate::wire::RolloverMsg0;
+use crate::wire::RolloverMsg1;
+use crate::wire::RolloverMsg2;
+use crate::wire::RolloverMsg3;
+use crate::wire::SetupMsg;
+use anyhow::Context;
+use anyhow::Result;
+use bdk::bitcoin::secp256k1::schnorrsig;
+use bdk::bitcoin::secp256k1::Signature;
+use bdk::bitcoin::secp256k1::SECP256K1;
+use bdk::bitcoin::util::psbt::PartiallySignedTransaction;
+use bdk::bitcoin::Amount;
+use bdk::bitcoin::PublicKey;
+use bdk::bitcoin::Transaction;
+use bdk::descriptor::Descriptor;
+use bdk::miniscript::DescriptorTrait;
+use bdk_ext::keypair;
+use futures::stream::FusedStream;
+use futures::Sink;
+use futures::SinkExt;
+use futures::StreamExt;
+use maia_core::interval;
+use maia_core::secp256k1_zkp;
+use maia_core::secp256k1_zkp::EcdsaAdaptorSignature;
+use maia_core::Announcement;
+use maia_core::PartyParams;
+use maia_core::PunishParams;
+use maia_deprecated::commit_descriptor;
+use maia_deprecated::compute_adaptor_pk;
+use maia_deprecated::create_cfd_transactions;
+use maia_deprecated::lock_descriptor;
+use maia_deprecated::renew_cfd_transactions;
+use maia_deprecated::spending_tx_sighash;
+use model::calculate_payouts;
+use model::olivia;
+use model::Cet;
+use model::Dlc;
+use model::FeeFlow;
+use model::Position;
+use model::RevokedCommit;
+use model::Role;
+use model::RolloverParams;
+use model::SetupParams;
+use model::CET_TIMELOCK;
+use std::collections::HashMap;
+use std::iter::FromIterator;
+use std::ops::RangeInclusive;
+use std::time::Duration;
+use xtra::prelude::MessageChannel;
+
+/// How long contract setup protocol waits for the next message before giving up
+///
+/// 120s are currently needed to ensure that we can outlive times when the maker/taker are under
+/// heavy message load. Failed contract setups are annoying compared to failed rollovers so we allow
+/// more time to see them less often.
+const CONTRACT_SETUP_MSG_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// How long rollover protocol waits for the next message before giving up
+///
+/// 60s timeout are acceptable here because rollovers are automatically retried; a few failed
+/// rollovers are not a big deal.
+const ROLLOVER_MSG_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Given an initial set of parameters, sets up the CFD contract with
+/// the other party.
+#[allow(clippy::too_many_arguments)]
+pub async fn new(
+    mut sink: impl Sink<SetupMsg, Error = anyhow::Error> + Unpin,
+    mut stream: impl FusedStream<Item = SetupMsg> + Unpin,
+    (oracle_pk, announcement): (schnorrsig::PublicKey, olivia::Announcement),
+    setup_params: SetupParams,
+    build_party_params_channel: Box<dyn MessageChannel<wallet::BuildPartyParams>>,
+    sign_channel: Box<dyn MessageChannel<wallet::Sign>>,
+    role: Role,
+    position: Position,
+    n_payouts: usize,
+) -> Result<Dlc> {
+    let (sk, pk) = keypair::new(&mut rand::thread_rng());
+    let (rev_sk, rev_pk) = keypair::new(&mut rand::thread_rng());
+    let (publish_sk, publish_pk) = keypair::new(&mut rand::thread_rng());
+
+    let own_params = build_party_params_channel
+        .send(wallet::BuildPartyParams {
+            amount: setup_params.margin,
+            identity_pk: pk,
+            fee_rate: setup_params.tx_fee_rate,
+        })
+        .await
+        .context("Failed to send message to wallet actor")?
+        .context("Failed to build party params")?;
+
+    let own_punish = PunishParams {
+        revocation_pk: rev_pk,
+        publish_pk,
+    };
+
+    sink.send(SetupMsg::Msg0(Msg0::from((own_params.clone(), own_punish))))
+        .await
+        .context("Failed to send Msg0")?;
+    let msg0 = stream
+        .select_next_some()
+        .timeout(CONTRACT_SETUP_MSG_TIMEOUT)
+        .await
+        .with_context(|| format_expect_msg_within("Msg0", CONTRACT_SETUP_MSG_TIMEOUT))?
+        .try_into_msg0()?;
+
+    tracing::info!("Exchanged setup parameters");
+
+    let (other, other_punish) = msg0.into();
+
+    let params = AllParams::new(own_params, own_punish, other, other_punish, role);
+
+    let expected_margin = setup_params.counterparty_margin;
+    let actual_margin = params.other.lock_amount;
+
+    if actual_margin != expected_margin {
+        anyhow::bail!(
+            "Amounts sent by counterparty don't add up, expected margin {expected_margin} but got {actual_margin}"
+        )
+    }
+
+    let settlement_event_id = announcement.id;
+    let payouts = HashMap::from_iter([(
+        announcement.into(),
+        calculate_payouts(
+            position,
+            role,
+            setup_params.price,
+            setup_params.quantity,
+            setup_params.long_leverage,
+            setup_params.short_leverage,
+            n_payouts,
+            setup_params.fee_account.settle(),
+        )?,
+    )]);
+
+    let own_cfd_txs = tokio::task::spawn_blocking({
+        let maker_params = params.maker().clone();
+        let taker_params = params.taker().clone();
+        let maker_punish = *params.maker_punish();
+        let taker_punish = *params.taker_punish();
+
+        move || {
+            create_cfd_transactions(
+                (maker_params, maker_punish),
+                (taker_params, taker_punish),
+                oracle_pk,
+                (CET_TIMELOCK, setup_params.refund_timelock),
+                payouts,
+                sk,
+                setup_params.tx_fee_rate.to_u32(),
+            )
+        }
+    })
+    .await?
+    .context("Failed to create CFD transactions")?;
+
+    tracing::info!("Created CFD transactions");
+
+    sink.send(SetupMsg::Msg1(Msg1::from(own_cfd_txs.clone())))
+        .await
+        .context("Failed to send Msg1")?;
+
+    let msg1 = stream
+        .select_next_some()
+        .timeout(CONTRACT_SETUP_MSG_TIMEOUT)
+        .await
+        .with_context(|| format_expect_msg_within("Msg1", CONTRACT_SETUP_MSG_TIMEOUT))?
+        .try_into_msg1()?;
+
+    tracing::info!("Exchanged CFD transactions");
+
+    let lock_desc = lock_descriptor(params.maker().identity_pk, params.taker().identity_pk);
+
+    let lock_amount = params.maker().lock_amount + params.taker().lock_amount;
+
+    let commit_desc = commit_descriptor(
+        (
+            params.maker().identity_pk,
+            params.maker_punish().revocation_pk,
+            params.maker_punish().publish_pk,
+        ),
+        (
+            params.taker().identity_pk,
+            params.taker_punish().revocation_pk,
+            params.taker_punish().publish_pk,
+        ),
+    );
+
+    let own_cets = own_cfd_txs.cets;
+    let commit_tx = own_cfd_txs.commit.0.clone();
+
+    let commit_amount = Amount::from_sat(commit_tx.output[0].value);
+
+    verify_adaptor_signature(
+        &commit_tx,
+        &lock_desc,
+        lock_amount,
+        &msg1.commit,
+        &params.own_punish.publish_pk,
+        &params.other.identity_pk,
+    )
+    .context("Commit adaptor signature does not verify")?;
+
+    for own_grouped_cets in own_cets.clone() {
+        let other_cets = msg1
+            .cets
+            .get(&own_grouped_cets.event.id)
+            .cloned()
+            .context("Expect event to exist in msg")?;
+
+        verify_cets(
+            (oracle_pk, own_grouped_cets.event.nonce_pks.clone()),
+            params.other.clone(),
+            own_grouped_cets.cets,
+            other_cets,
+            commit_desc.clone(),
+            commit_amount,
+        )
+        .await
+        .context("CET signatures don't verify")?;
+    }
+
+    let lock_tx = own_cfd_txs.lock;
+    let refund_tx = own_cfd_txs.refund.0;
+
+    verify_signature(
+        &refund_tx,
+        &commit_desc,
+        commit_amount,
+        &msg1.refund,
+        &params.other.identity_pk,
+    )
+    .context("Refund signature does not verify")?;
+
+    tracing::info!("Verified all signatures");
+
+    let mut signed_lock_tx = sign_channel
+        .send(wallet::Sign { psbt: lock_tx })
+        .await
+        .context("Failed to send message to wallet actor")?
+        .context("Failed to sign transaction")?;
+    sink.send(SetupMsg::Msg2(Msg2 {
+        signed_lock: signed_lock_tx.clone(),
+    }))
+    .await
+    .context("Failed to send Msg2")?;
+    let msg2 = stream
+        .select_next_some()
+        .timeout(CONTRACT_SETUP_MSG_TIMEOUT)
+        .await
+        .with_context(|| format_expect_msg_within("Msg2", CONTRACT_SETUP_MSG_TIMEOUT))?
+        .try_into_msg2()?;
+    signed_lock_tx
+        .merge(msg2.signed_lock)
+        .context("Failed to merge lock PSBTs")?;
+
+    tracing::info!("Exchanged signed lock transaction");
+
+    // TODO: In case we sign+send but never receive (the signed lock_tx from the other party) we
+    // need some fallback handling (after x time) to spend the outputs in a different way so the
+    // other party cannot hold us hostage
+
+    let cets = tokio::task::spawn_blocking({
+        let maker_address = params.maker().address.clone();
+        let taker_address = params.taker().address.clone();
+        let commit_tx = commit_tx.clone();
+        let commit_desc = commit_desc.clone();
+        move || {
+        own_cets
+            .into_iter()
+            .map(|grouped_cets| {
+                let event_id = grouped_cets.event.id;
+                let other_cets = msg1
+                    .cets
+                    .get(&event_id)
+                    .with_context(|| format!("Counterparty CETs for event {event_id} missing"))?;
+                let cets = grouped_cets
+                    .cets
+                    .into_iter()
+                    .map(|(tx, _, digits)| {
+                        let other_encsig = other_cets
+                            .iter()
+                            .find_map(|(other_range, other_encsig)| {
+                                (other_range == &digits.range()).then(|| other_encsig)
+                            })
+                            .with_context(|| {
+                                let range = digits.range();
+
+                                format!(
+                                    "Missing counterparty adaptor signature for CET corresponding to price range {range:?}",
+                                )
+                            })?;
+
+                        let maker_amount = tx.find_output_amount(&maker_address.script_pubkey()).unwrap_or_default();
+                        let taker_amount = tx.find_output_amount(&taker_address.script_pubkey()).unwrap_or_default();
+
+                        let cet = Cet {
+                            maker_amount,
+                            taker_amount,
+                            adaptor_sig: *other_encsig,
+                            range: digits.range(),
+                            n_bits: digits.len(),
+                            txid: tx.txid(),
+                        };
+
+                        debug_assert_eq!(
+                            cet.to_tx((&commit_tx, &commit_desc), &maker_address, &taker_address)
+                                .expect("can reconstruct CET")
+                                .txid(),
+                            tx.txid()
+                        );
+
+                        Ok(cet)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                Ok((event_id.parse()?, cets))
+            })
+            .collect::<Result<HashMap<_, _>>>()
+    }})
+    .await??;
+
+    // TODO: Remove send- and receiving ACK messages once we are able to handle incomplete DLC
+    // monitoring
+    sink.send(SetupMsg::Msg3(Msg3))
+        .await
+        .context("Failed to send Msg3")?;
+    let _ = stream
+        .select_next_some()
+        .timeout(CONTRACT_SETUP_MSG_TIMEOUT)
+        .await
+        .with_context(|| format_expect_msg_within("Msg3", CONTRACT_SETUP_MSG_TIMEOUT))?
+        .try_into_msg3()?;
+
+    Ok(Dlc {
+        identity: sk,
+        identity_counterparty: params.other.identity_pk,
+        revocation: rev_sk,
+        revocation_pk_counterparty: other_punish.revocation_pk,
+        publish: publish_sk,
+        publish_pk_counterparty: other_punish.publish_pk,
+        maker_address: params.maker().address.clone(),
+        taker_address: params.taker().address.clone(),
+        lock: (signed_lock_tx.extract_tx(), lock_desc),
+        commit: (commit_tx, msg1.commit, commit_desc),
+        cets,
+        refund: (refund_tx, msg1.refund),
+        maker_lock_amount: params.maker().lock_amount,
+        taker_lock_amount: params.taker().lock_amount,
+        revoked_commit: Vec::new(),
+        settlement_event_id,
+        refund_timelock: setup_params.refund_timelock,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn roll_over(
+    mut sink: impl Sink<RolloverMsg, Error = anyhow::Error> + Unpin,
+    mut stream: impl FusedStream<Item = RolloverMsg> + Unpin,
+    (oracle_pk, announcement): (schnorrsig::PublicKey, olivia::Announcement),
+    rollover_params: RolloverParams,
+    our_role: Role,
+    our_position: Position,
+    dlc: Dlc,
+    n_payouts: usize,
+    complete_fee: FeeFlow,
+) -> Result<Dlc> {
+    let sk = dlc.identity;
+    let pk = PublicKey::new(secp256k1_zkp::PublicKey::from_secret_key(SECP256K1, &sk));
+
+    let (rev_sk, rev_pk) = keypair::new(&mut rand::thread_rng());
+    let (publish_sk, publish_pk) = keypair::new(&mut rand::thread_rng());
+
+    let own_punish = PunishParams {
+        revocation_pk: rev_pk,
+        publish_pk,
+    };
+
+    sink.send(RolloverMsg::Msg0(RolloverMsg0 {
+        revocation_pk: rev_pk,
+        publish_pk,
+    }))
+    .await
+    .context("Failed to send Msg0")?;
+    let msg0 = stream
+        .select_next_some()
+        .timeout(ROLLOVER_MSG_TIMEOUT)
+        .await
+        .with_context(|| format_expect_msg_within("Msg0", ROLLOVER_MSG_TIMEOUT))?
+        .try_into_msg0()?;
+
+    let maker_lock_amount = dlc.maker_lock_amount;
+    let taker_lock_amount = dlc.taker_lock_amount;
+    let payouts = HashMap::from_iter([(
+        Announcement {
+            id: announcement.id.to_string(),
+            nonce_pks: announcement.nonce_pks.clone(),
+        },
+        calculate_payouts(
+            our_position,
+            our_role,
+            rollover_params.price,
+            rollover_params.quantity,
+            rollover_params.long_leverage,
+            rollover_params.short_leverage,
+            n_payouts,
+            complete_fee,
+        )?,
+    )]);
+
+    // unsign lock tx because PartiallySignedTransaction needs an unsigned tx
+    let mut unsigned_lock_tx = dlc.lock.0.clone();
+    unsigned_lock_tx
+        .input
+        .iter_mut()
+        .for_each(|input| input.witness.clear());
+
+    let lock_tx = PartiallySignedTransaction::from_unsigned_tx(unsigned_lock_tx)?;
+    let other_punish_params = PunishParams {
+        revocation_pk: msg0.revocation_pk,
+        publish_pk: msg0.publish_pk,
+    };
+    let ((maker_identity, maker_punish_params), (taker_identity, taker_punish_params)) =
+        match our_role {
+            Role::Maker => (
+                (pk, own_punish),
+                (dlc.identity_counterparty, other_punish_params),
+            ),
+            Role::Taker => (
+                (dlc.identity_counterparty, other_punish_params),
+                (pk, own_punish),
+            ),
+        };
+    let own_cfd_txs = tokio::task::spawn_blocking({
+        let maker_address = dlc.maker_address.clone();
+        let taker_address = dlc.taker_address.clone();
+        let lock_tx = lock_tx.clone();
+
+        move || {
+            renew_cfd_transactions(
+                lock_tx,
+                (
+                    maker_identity,
+                    maker_lock_amount,
+                    maker_address,
+                    maker_punish_params,
+                ),
+                (
+                    taker_identity,
+                    taker_lock_amount,
+                    taker_address,
+                    taker_punish_params,
+                ),
+                oracle_pk,
+                (CET_TIMELOCK, rollover_params.refund_timelock),
+                payouts,
+                sk,
+                rollover_params.fee_rate.to_u32(),
+            )
+        }
+    })
+    .await?
+    .context("Failed to create new CFD transactions")?;
+
+    sink.send(RolloverMsg::Msg1(RolloverMsg1::from(own_cfd_txs.clone())))
+        .await
+        .context("Failed to send Msg1")?;
+
+    let msg1 = stream
+        .select_next_some()
+        .timeout(ROLLOVER_MSG_TIMEOUT)
+        .await
+        .with_context(|| format_expect_msg_within("Msg1", ROLLOVER_MSG_TIMEOUT))?
+        .try_into_msg1()?;
+
+    let lock_amount = taker_lock_amount + maker_lock_amount;
+
+    let commit_desc = commit_descriptor(
+        (
+            maker_identity,
+            maker_punish_params.revocation_pk,
+            maker_punish_params.publish_pk,
+        ),
+        (
+            taker_identity,
+            taker_punish_params.revocation_pk,
+            taker_punish_params.publish_pk,
+        ),
+    );
+
+    let own_cets = own_cfd_txs.cets;
+    let commit_tx = own_cfd_txs.commit.0.clone();
+
+    let commit_amount = Amount::from_sat(commit_tx.output[0].value);
+
+    verify_adaptor_signature(
+        &commit_tx,
+        &dlc.lock.1,
+        lock_amount,
+        &msg1.commit,
+        &publish_pk,
+        &dlc.identity_counterparty,
+    )
+    .context("Commit adaptor signature does not verify")?;
+
+    let other_address = match our_role {
+        Role::Maker => dlc.taker_address.clone(),
+        Role::Taker => dlc.maker_address.clone(),
+    };
+
+    for own_grouped_cets in own_cets.clone() {
+        let other_cets = msg1
+            .cets
+            .get(&own_grouped_cets.event.id)
+            .cloned()
+            .context("Expect event to exist in msg")?;
+
+        verify_cets(
+            (oracle_pk, announcement.nonce_pks.clone()),
+            PartyParams {
+                lock_psbt: lock_tx.clone(),
+                identity_pk: dlc.identity_counterparty,
+                lock_amount,
+                address: other_address.clone(),
+            },
+            own_grouped_cets.cets,
+            other_cets,
+            commit_desc.clone(),
+            commit_amount,
+        )
+        .await
+        .context("CET signatures don't verify")?;
+    }
+
+    let refund_tx = own_cfd_txs.refund.0;
+
+    verify_signature(
+        &refund_tx,
+        &commit_desc,
+        commit_amount,
+        &msg1.refund,
+        &dlc.identity_counterparty,
+    )
+    .context("Refund signature does not verify")?;
+
+    let maker_address = &dlc.maker_address;
+    let taker_address = &dlc.taker_address;
+    let cets = own_cets
+        .into_iter()
+        .map(|grouped_cets| {
+            let event_id = grouped_cets.event.id;
+            let other_cets = msg1
+                .cets
+                .get(&event_id)
+                .with_context(|| format!("Counterparty CETs for event {event_id} missing"))?;
+            let cets = grouped_cets
+                .cets
+                .into_iter()
+                .map(|(tx, _, digits)| {
+                    let other_encsig = other_cets
+                        .iter()
+                        .find_map(|(other_range, other_encsig)| {
+                            (other_range == &digits.range()).then(|| other_encsig)
+                        })
+                        .with_context(|| {
+                            let range = digits.range();
+
+                            format!(
+                                "Missing counterparty adaptor signature for CET corresponding to
+                                 price range {range:?}"
+                            )
+                        })?;
+
+                    let maker_amount = tx
+                        .find_output_amount(&maker_address.script_pubkey())
+                        .unwrap_or_default();
+                    let taker_amount = tx
+                        .find_output_amount(&taker_address.script_pubkey())
+                        .unwrap_or_default();
+                    let cet = Cet {
+                        maker_amount,
+                        taker_amount,
+                        adaptor_sig: *other_encsig,
+                        range: digits.range(),
+                        n_bits: digits.len(),
+                        txid: tx.txid(),
+                    };
+
+                    debug_assert_eq!(
+                        cet.to_tx((&commit_tx, &commit_desc), maker_address, taker_address)
+                            .expect("can reconstruct CET")
+                            .txid(),
+                        tx.txid()
+                    );
+
+                    Ok(cet)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok((event_id.parse()?, cets))
+        })
+        .collect::<Result<HashMap<_, _>>>()?;
+
+    // reveal revocation secrets to the other party
+    sink.send(RolloverMsg::Msg2(RolloverMsg2 {
+        revocation_sk: dlc.revocation,
+    }))
+    .await
+    .context("Failed to send Msg2")?;
+
+    let msg2 = stream
+        .select_next_some()
+        .timeout(ROLLOVER_MSG_TIMEOUT)
+        .await
+        .with_context(|| format_expect_msg_within("Msg2", ROLLOVER_MSG_TIMEOUT))?
+        .try_into_msg2()?;
+    let revocation_sk_theirs = msg2.revocation_sk;
+
+    {
+        let derived_rev_pk = PublicKey::new(secp256k1_zkp::PublicKey::from_secret_key(
+            SECP256K1,
+            &revocation_sk_theirs,
+        ));
+
+        if derived_rev_pk != dlc.revocation_pk_counterparty {
+            anyhow::bail!("Counterparty sent invalid revocation sk");
+        }
+    }
+
+    let mut revoked_commit = dlc.revoked_commit;
+    revoked_commit.push(RevokedCommit {
+        encsig_ours: own_cfd_txs.commit.1,
+        revocation_sk_theirs,
+        publication_pk_theirs: dlc.publish_pk_counterparty,
+        txid: dlc.commit.0.txid(),
+        script_pubkey: dlc.commit.2.script_pubkey(),
+    });
+
+    // TODO: Remove send- and receiving ACK messages once we are able to handle incomplete DLC
+    // monitoring
+    sink.send(RolloverMsg::Msg3(RolloverMsg3))
+        .await
+        .context("Failed to send Msg3")?;
+    let _ = stream
+        .select_next_some()
+        .timeout(ROLLOVER_MSG_TIMEOUT)
+        .await
+        .with_context(|| format_expect_msg_within("Msg3", ROLLOVER_MSG_TIMEOUT))?
+        .try_into_msg3()?;
+
+    Ok(Dlc {
+        identity: sk,
+        identity_counterparty: dlc.identity_counterparty,
+        revocation: rev_sk,
+        revocation_pk_counterparty: other_punish_params.revocation_pk,
+        publish: publish_sk,
+        publish_pk_counterparty: other_punish_params.publish_pk,
+        maker_address: dlc.maker_address,
+        taker_address: dlc.taker_address,
+        lock: dlc.lock.clone(),
+        commit: (commit_tx, msg1.commit, commit_desc),
+        cets,
+        refund: (refund_tx, msg1.refund),
+        maker_lock_amount,
+        taker_lock_amount,
+        revoked_commit,
+        settlement_event_id: announcement.id,
+        refund_timelock: rollover_params.refund_timelock,
+    })
+}
+
+/// A convenience struct for storing PartyParams and PunishParams of both
+/// parties and the role of the caller.
+struct AllParams {
+    pub own: PartyParams,
+    pub own_punish: PunishParams,
+    pub other: PartyParams,
+    pub other_punish: PunishParams,
+    pub own_role: Role,
+}
+
+impl AllParams {
+    fn new(
+        own: PartyParams,
+        own_punish: PunishParams,
+        other: PartyParams,
+        other_punish: PunishParams,
+        own_role: Role,
+    ) -> Self {
+        Self {
+            own,
+            own_punish,
+            other,
+            other_punish,
+            own_role,
+        }
+    }
+
+    fn maker(&self) -> &PartyParams {
+        match self.own_role {
+            Role::Maker => &self.own,
+            Role::Taker => &self.other,
+        }
+    }
+
+    fn taker(&self) -> &PartyParams {
+        match self.own_role {
+            Role::Maker => &self.other,
+            Role::Taker => &self.own,
+        }
+    }
+
+    fn maker_punish(&self) -> &PunishParams {
+        match self.own_role {
+            Role::Maker => &self.own_punish,
+            Role::Taker => &self.other_punish,
+        }
+    }
+    fn taker_punish(&self) -> &PunishParams {
+        match self.own_role {
+            Role::Maker => &self.other_punish,
+            Role::Taker => &self.own_punish,
+        }
+    }
+}
+
+async fn verify_cets(
+    (oracle_pk, nonce_pks): (schnorrsig::PublicKey, Vec<schnorrsig::PublicKey>),
+    other: PartyParams,
+    own_cets: Vec<(Transaction, EcdsaAdaptorSignature, interval::Digits)>,
+    cets: Vec<(RangeInclusive<u64>, EcdsaAdaptorSignature)>,
+    commit_desc: Descriptor<PublicKey>,
+    commit_amount: Amount,
+) -> Result<()> {
+    tokio::task::spawn_blocking(move || {
+        for (tx, _, digits) in own_cets.iter() {
+            let other_encsig = cets
+                .iter()
+                .find_map(|(range, encsig)| (range == &digits.range()).then(|| encsig))
+                .with_context(|| {
+                    let range = digits.range();
+
+                    format!("no enc sig from other party for price range {range:?}",)
+                })?;
+
+            verify_cet_encsig(
+                tx,
+                other_encsig,
+                digits,
+                &other.identity_pk,
+                (&oracle_pk, &nonce_pks),
+                &commit_desc,
+                commit_amount,
+            )
+            .context("enc sig on CET does not verify")?;
+        }
+
+        anyhow::Ok(())
+    })
+    .await??;
+
+    Ok(())
+}
+
+fn verify_adaptor_signature(
+    tx: &Transaction,
+    spent_descriptor: &Descriptor<PublicKey>,
+    spent_amount: Amount,
+    encsig: &EcdsaAdaptorSignature,
+    encryption_point: &PublicKey,
+    pk: &PublicKey,
+) -> Result<()> {
+    let sighash = spending_tx_sighash(tx, spent_descriptor, spent_amount);
+
+    encsig
+        .verify(SECP256K1, &sighash, &pk.key, &encryption_point.key)
+        .context("failed to verify encsig spend tx")
+}
+
+fn verify_signature(
+    tx: &Transaction,
+    spent_descriptor: &Descriptor<PublicKey>,
+    spent_amount: Amount,
+    sig: &Signature,
+    pk: &PublicKey,
+) -> Result<()> {
+    let sighash = spending_tx_sighash(tx, spent_descriptor, spent_amount);
+    SECP256K1.verify(&sighash, sig, &pk.key)?;
+    Ok(())
+}
+
+fn verify_cet_encsig(
+    tx: &Transaction,
+    encsig: &EcdsaAdaptorSignature,
+    digits: &interval::Digits,
+    pk: &PublicKey,
+    (oracle_pk, nonce_pks): (&schnorrsig::PublicKey, &[schnorrsig::PublicKey]),
+    spent_descriptor: &Descriptor<PublicKey>,
+    spent_amount: Amount,
+) -> Result<()> {
+    let index_nonce_pairs = &digits
+        .to_indices()
+        .into_iter()
+        .zip(nonce_pks.iter().cloned())
+        .collect::<Vec<_>>();
+    let adaptor_point = compute_adaptor_pk(oracle_pk, index_nonce_pairs)
+        .context("could not calculate adaptor point")?;
+    verify_adaptor_signature(
+        tx,
+        spent_descriptor,
+        spent_amount,
+        encsig,
+        &PublicKey::new(adaptor_point),
+        pk,
+    )
+}
+
+/// Wrapper for the msg
+fn format_expect_msg_within(msg: &str, timeout: Duration) -> String {
+    let seconds = timeout.as_secs();
+
+    format!("Expected {msg} within {seconds} seconds")
+}

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -2,7 +2,7 @@ use crate::command;
 use crate::connection;
 use crate::db;
 use crate::process_manager;
-use crate::setup_contract;
+use crate::setup_contract_deprecated;
 use crate::wallet;
 use crate::wire;
 use anyhow::anyhow;
@@ -111,7 +111,7 @@ impl Actor {
         // the spawned contract setup task
         self.setup_msg_sender = Some(sender);
 
-        let contract_future = setup_contract::new(
+        let contract_future = setup_contract_deprecated::new(
             xtra::message_channel::MessageChannel::sink(&self.maker)
                 .with(move |msg| future::ok(wire::TakerToMaker::Protocol { order_id, msg })),
             receiver,

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -15,7 +15,7 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 hex = "0.4"
 http-api-problem = { version = "0.52.0", features = ["rocket"] }
 libp2p-tcp = { version = "0.32", default-features = false, features = ["tokio"] }
-maia = "0.1.0"
+maia = "0.2.0"
 maia-core = "0.1.0"
 model = { path = "../model" }
 prometheus = { version = "0.13", default-features = false }

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -160,11 +160,7 @@ where
         tasks.add(endpoint_context.run(endpoint));
 
         let (supervisor, _listener_actor) = supervisor::Actor::with_policy(
-            move || {
-                let endpoint_addr = endpoint_addr.clone();
-                let endpoint_listen = listen_multiaddr.clone();
-                listener::Actor::new(endpoint_addr, endpoint_listen)
-            },
+            move || listener::Actor::new(endpoint_addr.clone(), listen_multiaddr.clone()),
             |_: &listener::Error| true, // always restart listener actor
         );
         let listener_supervisor = supervisor.create(None).spawn(&mut tasks);

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -55,7 +55,6 @@ pub struct ActorSystem<O, W> {
     _listener_supervisor: Address<supervisor::Actor<listener::Actor, listener::Error>>,
     _position_metrics_actor: Address<position_metrics::Actor>,
     _cull_old_dlcs_actor: Address<cull_old_dlcs::Actor>,
-    _listener_actor: Address<listener::Actor>,
 }
 
 impl<O, W> ActorSystem<O, W>
@@ -160,7 +159,7 @@ where
 
         tasks.add(endpoint_context.run(endpoint));
 
-        let (supervisor, listener_actor) = supervisor::Actor::with_policy(
+        let (supervisor, _listener_actor) = supervisor::Actor::with_policy(
             move || {
                 let endpoint_addr = endpoint_addr.clone();
                 let endpoint_listen = listen_multiaddr.clone();
@@ -211,7 +210,6 @@ where
             _listener_supervisor: listener_supervisor,
             _position_metrics_actor: position_metrics_actor,
             _cull_old_dlcs_actor,
-            _listener_actor: listener_actor,
         })
     }
 

--- a/maker/src/contract_setup.rs
+++ b/maker/src/contract_setup.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use daemon::command;
 use daemon::db;
 use daemon::process_manager;
-use daemon::setup_contract;
+use daemon::setup_contract_deprecated;
 use daemon::wallet;
 use daemon::wire;
 use futures::channel::mpsc;
@@ -94,7 +94,7 @@ impl Actor {
 
         let taker_id = setup_params.counterparty_identity();
 
-        let contract_future = setup_contract::new(
+        let contract_future = setup_contract_deprecated::new(
             self.taker.sink().with(move |msg| {
                 future::ok(connection::TakerMessage {
                     taker_id,

--- a/maker/src/rollover.rs
+++ b/maker/src/rollover.rs
@@ -5,7 +5,7 @@ use daemon::command;
 use daemon::db;
 use daemon::oracle;
 use daemon::process_manager;
-use daemon::setup_contract;
+use daemon::setup_contract_deprecated;
 use daemon::wire;
 use futures::channel::mpsc;
 use futures::channel::mpsc::UnboundedSender;
@@ -218,7 +218,7 @@ impl Actor {
 
         let funding_fee = *rollover_params.funding_fee();
 
-        let rollover_fut = setup_contract::roll_over(
+        let rollover_fut = setup_contract_deprecated::roll_over(
             self.send_to_taker_actor.sink().with(move |msg| {
                 future::ok(connection::TakerMessage {
                     taker_id,

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -11,7 +11,7 @@ conquer-once = "0.3"
 hex = "0.4"
 itertools = "0.10"
 libp2p-core = { version = "0.32.1", default-features = false, features = ["serde"] }
-maia = "0.1.0"
+maia = "0.2.0"
 maia-core = "0.1.0"
 nalgebra = { version = "0.31", default-features = false, features = ["std"] }
 ndarray = "0.15.4"

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -13,6 +13,7 @@ itertools = "0.10"
 libp2p-core = { version = "0.32.1", default-features = false, features = ["serde"] }
 maia = "0.2.0"
 maia-core = "0.1.0"
+maia-deprecated = { git = "https://github.com/comit-network/maia", rev = "e419cb2cf19bed6ec53eaa3672408a6205a9b705", package = "maia" } # includes subtract-fee bug, needed for protocols over legacy networking
 nalgebra = { version = "0.31", default-features = false, features = ["std"] }
 ndarray = "0.15.4"
 ndarray_einsum_beta = "0.7.0"

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1866,7 +1866,10 @@ impl Dlc {
 
             (outpoint, amount)
         };
-        let (tx, sighash) = maia::close_transaction(
+        // In order to preserve backwards compatibility, we are using maia
+        // v0.1.0 always (this code is called from legacy collab settlement protocol)
+        // TODO: Use maia v0.2.0 with libp2p-based collab close
+        let (tx, sighash) = maia_deprecated::close_transaction(
             lock_desc,
             lock_outpoint,
             lock_amount,

--- a/xtras/src/supervisor.rs
+++ b/xtras/src/supervisor.rs
@@ -18,6 +18,7 @@ pub struct Actor<T, R> {
     ctor: Box<dyn Fn() -> T + Send + 'static>,
     tasks: Tasks,
     restart_policy: Box<dyn FnMut(&R) -> bool + Send + 'static>,
+    _actor: Address<T>, // kept around to ensure that the supervised actor stays alive
     metrics: Metrics,
 }
 
@@ -64,6 +65,7 @@ where
             ctor: Box::new(ctor),
             tasks: Tasks::default(),
             restart_policy: Box::new(|UnitReason {}| true),
+            _actor: address.clone(),
             metrics: Metrics::default(),
         };
 
@@ -93,6 +95,7 @@ where
             ctor: Box::new(ctor),
             tasks: Tasks::default(),
             restart_policy: Box::new(restart_policy),
+            _actor: address.clone(),
             metrics: Metrics::default(),
         };
 

--- a/xtras/src/supervisor.rs
+++ b/xtras/src/supervisor.rs
@@ -30,8 +30,8 @@ struct Metrics {
     pub num_panics: u64,
 }
 
-#[derive(Debug)]
-struct UnitReason {}
+#[derive(Debug, Clone, Copy)]
+pub struct UnitReason {}
 
 impl fmt::Display for UnitReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
With the advent of libp2p-based protocols, we have the opportunity to clearly
demarcate older and newer takers, making it possible to roll out recent maia bugfixes.

After this change:
- libp2p-based protocols will use maia v0.2.0
- legacy networking will use maia v0.1.0 (`maia_deprecated`), which matches maia
    version shipped with legacy takers

The contents of setup_contract.rs (protocol logic) has been copied wholesale to
`setup_contract_deprecated.rs` with the expectation that the whole file will be
deleted when we decide to drop support for takers using legacy networking layer.

Co-authored-by: Philipp Hoenisch <philipp@hoenisch.at>