### PR TITLE
Supervise the maker's ping actor 

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -82,7 +82,6 @@ pub struct TakerActorSystem<O, W, P> {
     /// Keep this one around to avoid the supervisor being dropped due to ref-count changes on the
     /// address.
     _price_feed_supervisor: Address<supervisor::Actor<P, xtra_bitmex_price_feed::Error>>,
-    _dialer_actor: Address<dialer::Actor>,
     _dialer_supervisor: Address<supervisor::Actor<dialer::Actor, dialer::Error>>,
     _close_cfds_actor: Address<archive_closed_cfds::Actor>,
     _archive_failed_cfds_actor: Address<archive_failed_cfds::Actor>,
@@ -227,7 +226,7 @@ where
         let dialer_constructor =
             { move || dialer::Actor::new(endpoint_addr.clone(), maker_multiaddr.clone()) };
 
-        let (supervisor, dialer_actor) = supervisor::Actor::with_policy(
+        let (supervisor, _dialer_actor) = supervisor::Actor::with_policy(
             dialer_constructor,
             |_: &dialer::Error| true, // always restart dialer actor
         );
@@ -259,7 +258,6 @@ where
             price_feed_actor,
             executor,
             _price_feed_supervisor: price_feed_supervisor,
-            _dialer_actor: dialer_actor,
             _dialer_supervisor: dialer_supervisor,
             _close_cfds_actor: close_cfds_actor,
             _archive_failed_cfds_actor: archive_failed_cfds_actor,

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -160,11 +160,7 @@ where
         tasks.add(endpoint_context.run(endpoint));
 
         let (supervisor, _listener_actor) = supervisor::Actor::with_policy(
-            move || {
-                let endpoint_addr = endpoint_addr.clone();
-                let endpoint_listen = listen_multiaddr.clone();
-                listener::Actor::new(endpoint_addr, endpoint_listen)
-            },
+            move || listener::Actor::new(endpoint_addr.clone(), listen_multiaddr.clone()),
             |_: &listener::Error| true, // always restart listener actor
         );
         let listener_supervisor = supervisor.create(None).spawn(&mut tasks);

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -55,7 +55,6 @@ pub struct ActorSystem<O, W> {
     _listener_supervisor: Address<supervisor::Actor<listener::Actor, listener::Error>>,
     _position_metrics_actor: Address<position_metrics::Actor>,
     _cull_old_dlcs_actor: Address<cull_old_dlcs::Actor>,
-    _listener_actor: Address<listener::Actor>,
 }
 
 impl<O, W> ActorSystem<O, W>
@@ -160,7 +159,7 @@ where
 
         tasks.add(endpoint_context.run(endpoint));
 
-        let (supervisor, listener_actor) = supervisor::Actor::with_policy(
+        let (supervisor, _listener_actor) = supervisor::Actor::with_policy(
             move || {
                 let endpoint_addr = endpoint_addr.clone();
                 let endpoint_listen = listen_multiaddr.clone();
@@ -211,7 +210,6 @@ where
             _listener_supervisor: listener_supervisor,
             _position_metrics_actor: position_metrics_actor,
             _cull_old_dlcs_actor,
-            _listener_actor: listener_actor,
         })
     }
 

--- a/xtras/src/supervisor.rs
+++ b/xtras/src/supervisor.rs
@@ -18,6 +18,7 @@ pub struct Actor<T, R> {
     ctor: Box<dyn Fn() -> T + Send + 'static>,
     tasks: Tasks,
     restart_policy: Box<dyn FnMut(&R) -> bool + Send + 'static>,
+    _actor: Address<T>, // kept around to ensure that the supervised actor stays alive
     metrics: Metrics,
 }
 
@@ -64,6 +65,7 @@ where
             ctor: Box::new(ctor),
             tasks: Tasks::default(),
             restart_policy: Box::new(|UnitReason {}| true),
+            _actor: address.clone(),
             metrics: Metrics::default(),
         };
 
@@ -93,6 +95,7 @@ where
             ctor: Box::new(ctor),
             tasks: Tasks::default(),
             restart_policy: Box::new(restart_policy),
+            _actor: address.clone(),
             metrics: Metrics::default(),
         };
 

--- a/xtras/src/supervisor.rs
+++ b/xtras/src/supervisor.rs
@@ -30,8 +30,8 @@ struct Metrics {
     pub num_panics: u64,
 }
 
-#[derive(Debug)]
-struct UnitReason {}
+#[derive(Debug, Clone, Copy)]
+pub struct UnitReason {}
 
 impl fmt::Display for UnitReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
This serves two overlapping purposes:

1. Keep the `ping::Actor` alive by not dropping its only strong `xtra::Address`.
2. Restart the `ping::Actor` if it is ever stopped or panics.

Point 1 therefore means that this PR:

Fixes https://github.com/itchysats/itchysats/issues/2103.