### PR TITLE
Service not available instead of general HTTP error

### DIFF
--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -262,7 +262,7 @@ pub async fn get_cfds<'r>(
 
     match cfds {
         Some(cfds) => Ok(Json(cfds)),
-        None => Err(HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
+        None => Err(HttpApiProblem::new(StatusCode::SERVICE_UNAVAILABLE)
             .title("CFDs not yet available")
             .detail("CFDs are still being loaded from the database. Please retry later.")),
     }


### PR DESCRIPTION
Upon startup a `503` indicates in a better way that the service is just not available (yet).
This error can *only* happen on startup, because that is the only time the feed contains `None`.
We only initialize the feed with `None` but always send `Some`.

We could even go further and include a `Retry-After` header, but I did not implement that yet.