### PR TITLE
Maker wallet address cache size configurable

### DIFF
--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -55,6 +55,10 @@ pub enum Network {
 
         #[clap(subcommand)]
         withdraw: Option<Withdraw>,
+
+        /// The wallet address cache size used for the initial scan.
+        #[clap(long, default_value = "500")]
+        address_cache_size: u32,
     },
     /// Run on testnet.
     Testnet {
@@ -64,6 +68,10 @@ pub enum Network {
 
         #[clap(subcommand)]
         withdraw: Option<Withdraw>,
+
+        /// The wallet address cache size used for the initial scan.
+        #[clap(long, default_value = "500")]
+        address_cache_size: u32,
     },
     /// Run on signet
     Signet {
@@ -73,6 +81,10 @@ pub enum Network {
 
         #[clap(subcommand)]
         withdraw: Option<Withdraw>,
+
+        /// The wallet address cache size used for the initial scan.
+        #[clap(long, default_value = "500")]
+        address_cache_size: u32,
     },
 }
 
@@ -123,6 +135,20 @@ impl Network {
             Network::Mainnet { withdraw, .. } => withdraw,
             Network::Testnet { withdraw, .. } => withdraw,
             Network::Signet { withdraw, .. } => withdraw,
+        }
+    }
+
+    pub fn address_cache_size(&self) -> &u32 {
+        match self {
+            Network::Mainnet {
+                address_cache_size, ..
+            } => address_cache_size,
+            Network::Testnet {
+                address_cache_size, ..
+            } => address_cache_size,
+            Network::Signet {
+                address_cache_size, ..
+            } => address_cache_size,
         }
     }
 }

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -54,7 +54,11 @@ async fn main() -> Result<()> {
 
     let mut tasks = Tasks::default();
 
-    let (wallet, wallet_feed_receiver) = wallet::Actor::new(opts.network.electrum(), ext_priv_key)?;
+    let (wallet, wallet_feed_receiver) = wallet::Actor::new(
+        opts.network.electrum(),
+        ext_priv_key,
+        *opts.network.address_cache_size(),
+    )?;
 
     let wallet = wallet.create(None).spawn(&mut tasks);
 


### PR DESCRIPTION
This allows us to experiment with different cache sizes and overcome problems if a hardcoded address cache is not sufficient anymore or causes problems with public nodes.
Default is set to `500`. This is a change to the previously hardcoded cache of `1000` addresses. We use `1000` to be "on the safe side" for longer, but given that it is configurable now we don't have to be this exhaustive.