### PR TITLE
Taker checks balance before taking an offer

### DIFF
--- a/daemon-tests/src/mocks/mod.rs
+++ b/daemon-tests/src/mocks/mod.rs
@@ -3,6 +3,7 @@ use crate::mocks::monitor::MockMonitor;
 use crate::mocks::oracle::MockOracle;
 use crate::mocks::price_feed::MockPriceFeed;
 use crate::mocks::wallet::MockWallet;
+use crate::Amount;
 use model::olivia;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -58,6 +59,17 @@ impl Mocks {
             .await
             .expect_sign()
             .returning(|sign_msg| Ok(sign_msg.psbt));
+    }
+
+    pub async fn mock_balance(&mut self) {
+        self.mock_balance_with(Amount::from_sat(100000000)).await;
+    }
+
+    pub async fn mock_balance_with(&mut self, balance: Amount) {
+        self.wallet()
+            .await
+            .expect_get_balance()
+            .returning(move |_| Ok(balance));
     }
 
     pub async fn mock_oracle_announcement(&mut self) {

--- a/daemon-tests/src/mocks/wallet.rs
+++ b/daemon-tests/src/mocks/wallet.rs
@@ -54,6 +54,9 @@ impl WalletActor {
     async fn handle(&mut self, msg: wallet::Withdraw) -> Result<Txid> {
         self.mock.lock().await.withdraw(msg)
     }
+    async fn handle(&mut self, msg: wallet::GetBalance) -> Result<Amount> {
+        self.mock.lock().await.get_balance(msg)
+    }
 }
 
 #[automock]
@@ -67,6 +70,10 @@ pub trait Wallet {
     }
 
     fn withdraw(&mut self, _msg: wallet::Withdraw) -> Result<Txid> {
+        unreachable!("mockall will reimplement this method")
+    }
+
+    fn get_balance(&mut self, _msg: wallet::GetBalance) -> Result<Amount> {
         unreachable!("mockall will reimplement this method")
     }
 }

--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -201,6 +201,9 @@ async fn taker_takes_order_and_maker_rejects() {
     let order_id = received.short.unwrap().id;
 
     taker.mocks.mock_oracle_announcement().await;
+    taker.mocks.mock_balance().await;
+    taker.mocks.mock_party_params().await;
+
     maker.mocks.mock_oracle_announcement().await;
     taker
         .system
@@ -233,6 +236,9 @@ async fn another_offer_is_automatically_created_after_taker_takes_order() {
     let order_id_take = received.short.unwrap().id;
 
     taker.mocks.mock_oracle_announcement().await;
+    taker.mocks.mock_balance().await;
+    taker.mocks.mock_party_params().await;
+
     maker.mocks.mock_oracle_announcement().await;
     taker
         .system
@@ -284,6 +290,9 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
     let order_id = received.short.unwrap().id;
 
     taker.mocks.mock_oracle_announcement().await;
+    taker.mocks.mock_balance().await;
+    taker.mocks.mock_party_params().await;
+
     maker.mocks.mock_oracle_announcement().await;
 
     taker
@@ -294,7 +303,6 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
     wait_next_state!(order_id, maker, taker, CfdState::PendingSetup);
 
     maker.mocks.mock_party_params().await;
-    taker.mocks.mock_party_params().await;
 
     maker.mocks.mock_wallet_sign_and_broadcast().await;
     taker.mocks.mock_wallet_sign_and_broadcast().await;
@@ -690,6 +698,9 @@ async fn start_from_open_cfd_state(
         .mocks
         .mock_oracle_announcement_with(announcement.clone())
         .await;
+    taker.mocks.mock_balance().await;
+    taker.mocks.mock_party_params().await;
+
     maker
         .mocks
         .mock_oracle_announcement_with(announcement)
@@ -710,7 +721,6 @@ async fn start_from_open_cfd_state(
     wait_next_state!(order_to_take.id, maker, taker, CfdState::PendingSetup);
 
     maker.mocks.mock_party_params().await;
-    taker.mocks.mock_party_params().await;
 
     maker.mocks.mock_wallet_sign_and_broadcast().await;
     taker.mocks.mock_wallet_sign_and_broadcast().await;

--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -205,6 +205,9 @@ async fn taker_takes_order_and_maker_rejects() {
     taker.mocks.mock_party_params().await;
 
     maker.mocks.mock_oracle_announcement().await;
+    maker.mocks.mock_balance().await;
+    maker.mocks.mock_party_params().await;
+
     taker
         .system
         .take_offer(order_id, Usd::new(dec!(10)), Leverage::TWO)
@@ -240,6 +243,9 @@ async fn another_offer_is_automatically_created_after_taker_takes_order() {
     taker.mocks.mock_party_params().await;
 
     maker.mocks.mock_oracle_announcement().await;
+    maker.mocks.mock_balance().await;
+    maker.mocks.mock_party_params().await;
+
     taker
         .system
         .take_offer(order_id_take, Usd::new(dec!(10)), Leverage::TWO)
@@ -294,6 +300,8 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
     taker.mocks.mock_party_params().await;
 
     maker.mocks.mock_oracle_announcement().await;
+    maker.mocks.mock_balance().await;
+    maker.mocks.mock_party_params().await;
 
     taker
         .system
@@ -301,8 +309,6 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
         .await
         .unwrap();
     wait_next_state!(order_id, maker, taker, CfdState::PendingSetup);
-
-    maker.mocks.mock_party_params().await;
 
     maker.mocks.mock_wallet_sign_and_broadcast().await;
     taker.mocks.mock_wallet_sign_and_broadcast().await;
@@ -705,6 +711,8 @@ async fn start_from_open_cfd_state(
         .mocks
         .mock_oracle_announcement_with(announcement)
         .await;
+    maker.mocks.mock_balance().await;
+    maker.mocks.mock_party_params().await;
 
     let order_to_take = match position_maker {
         Position::Short => received.short,
@@ -719,8 +727,6 @@ async fn start_from_open_cfd_state(
         .await
         .unwrap();
     wait_next_state!(order_to_take.id, maker, taker, CfdState::PendingSetup);
-
-    maker.mocks.mock_party_params().await;
 
     maker.mocks.mock_wallet_sign_and_broadcast().await;
     taker.mocks.mock_wallet_sign_and_broadcast().await;

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -63,6 +63,7 @@ where
     W: Handler<wallet::BuildPartyParams>
         + Handler<wallet::Sign>
         + Handler<wallet::Withdraw>
+        + Handler<wallet::GetBalance>
         + Actor<Stop = ()>,
 {
     #[allow(clippy::too_many_arguments)]

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -743,7 +743,7 @@ impl Cfd {
             .map(|dlc| dlc.settlement_event_id.timestamp())
     }
 
-    fn margin(&self) -> Amount {
+    pub fn margin(&self) -> Amount {
         match self.position {
             Position::Long => {
                 calculate_margin(self.initial_price, self.quantity, self.long_leverage)


### PR DESCRIPTION
I think it is more resilient to check this *before* we start. 

At the moment even if we know that we can't open the CFD we will create it in the database and then hope to add a failed event and eventually clean it up and move it to failed. Quite a lot of work if we already know it won't work out in the first place. 
This might impact usability, because we get feedback on the wallet having a problem early - which might be annoying at times, but I think in the long run this is better because we can react to the problem rather than pushing this out by "failing the setup".

The taker just checks before sending a request to the maker.
The maker checks upon receiving a request and rejects right away if the balance is insufficient.