### PR TITLE
Delete trivial CFDs on `maker`/`taker` startup

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -127,6 +127,7 @@ where
             + Handler<monitor::TryBroadcastTransaction>
             + Actor<Stop = ()>,
     {
+        futures::executor::block_on(db.delete_trivial_cfds())?;
         futures::executor::block_on(db.cull_old_dlcs())?;
 
         let (maker_online_status_feed_sender, maker_online_status_feed_receiver) =

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -88,6 +88,7 @@ where
             + Handler<monitor::MonitorCetFinality>
             + Actor<Stop = ()>,
     {
+        futures::executor::block_on(db.delete_trivial_cfds())?;
         futures::executor::block_on(db.cull_old_dlcs())?;
 
         let (monitor_addr, monitor_ctx) = Context::new(None);

--- a/sqlite-db/sqlx-data.json
+++ b/sqlite-db/sqlx-data.json
@@ -316,6 +316,16 @@
       ]
     }
   },
+  "a5dd38ead5160c1324ef31a0118cf77987e50fc01e3b9f06ad3df080dcbf48f5": {
+    "query": "\n            DELETE FROM\n                cfds\n            WHERE\n                id\n            NOT IN\n            (\n                SELECT\n                    events.cfd_id\n                FROM\n                    events\n            )\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 0
+      },
+      "nullable": []
+    }
+  },
   "a8124175098e096f61da0874f7cd9f1ebfadde95fd2fc2cc478982be04d1e150": {
     "query": "\n            UPDATE time_to_first_position\n            SET first_position_timestamp = $2\n            WHERE taker_id = $1 and first_position_timestamp is NULL\n            ",
     "describe": {

--- a/sqlite-db/src/delete_trivial_cfds.rs
+++ b/sqlite-db/src/delete_trivial_cfds.rs
@@ -1,0 +1,107 @@
+use crate::Connection;
+use anyhow::Result;
+
+impl Connection {
+    /// Delete all CFDs which have no events associated with them.
+    ///
+    /// It is recommended to call this method right after calling
+    /// `sqlite_db::connect`, before new CFDs are added to the
+    /// database. This is to ensure that no relevant data is deleted.
+    pub async fn delete_trivial_cfds(&self) -> Result<()> {
+        let mut conn = self.inner.acquire().await?;
+
+        // FIXME: I cannot run `cargo sqlx prepare` locally :(, so I
+        // can't add/modify any of the `sqlx` macros.
+        let affected_rows = sqlx::query(
+            r#"
+            DELETE FROM
+                cfds
+            WHERE
+                id
+            NOT IN
+            (
+                SELECT
+                    events.cfd_id
+                FROM
+                    events
+            )
+            "#,
+        )
+        .execute(&mut *conn)
+        .await?
+        .rows_affected();
+
+        if affected_rows > 0 {
+            tracing::info!(n = %affected_rows, "Deleted trivial CFDs");
+        } else {
+            tracing::info!("No trivial CFDs to delete");
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use model::CfdEvent;
+    use model::EventKind;
+
+    use crate::memory;
+    use crate::tests::dummy_cfd;
+
+    #[tokio::test]
+    async fn given_trivial_cfds_then_they_are_deleted_from_cfds() {
+        let db = memory().await.unwrap();
+
+        let cfd_0 = dummy_cfd();
+        db.insert_cfd(&cfd_0).await.unwrap();
+
+        let cfd_1 = dummy_cfd();
+        db.insert_cfd(&cfd_1).await.unwrap();
+
+        let ids_before = db.load_open_cfd_ids().await.unwrap();
+
+        db.delete_trivial_cfds().await.unwrap();
+
+        let ids_after = db.load_open_cfd_ids().await.unwrap();
+
+        assert!(ids_before.contains(&cfd_0.id()));
+        assert!(ids_before.contains(&cfd_1.id()));
+
+        assert!(ids_after.is_empty())
+    }
+
+    #[tokio::test]
+    async fn given_trivial_cfd_among_others_then_trivial_cfd_is_only_one_deleted() {
+        let db = memory().await.unwrap();
+
+        let trivial_cfd = dummy_cfd();
+        db.insert_cfd(&trivial_cfd).await.unwrap();
+
+        let cfd_0 = dummy_cfd();
+        db.insert_cfd(&cfd_0).await.unwrap();
+        db.append_event(CfdEvent::new(cfd_0.id(), EventKind::ContractSetupStarted))
+            .await
+            .unwrap();
+
+        let cfd_1 = dummy_cfd();
+        db.insert_cfd(&cfd_1).await.unwrap();
+        db.append_event(CfdEvent::new(cfd_1.id(), EventKind::ContractSetupStarted))
+            .await
+            .unwrap();
+
+        let ids_before = db.load_open_cfd_ids().await.unwrap();
+
+        db.delete_trivial_cfds().await.unwrap();
+
+        let ids_after = db.load_open_cfd_ids().await.unwrap();
+
+        assert!(ids_before.contains(&trivial_cfd.id()));
+        assert!(ids_before.contains(&cfd_0.id()));
+        assert!(ids_before.contains(&cfd_1.id()));
+
+        assert!(!ids_after.contains(&trivial_cfd.id()));
+        assert!(ids_after.contains(&cfd_0.id()));
+        assert!(ids_after.contains(&cfd_1.id()));
+    }
+}

--- a/sqlite-db/src/delete_trivial_cfds.rs
+++ b/sqlite-db/src/delete_trivial_cfds.rs
@@ -10,9 +10,7 @@ impl Connection {
     pub async fn delete_trivial_cfds(&self) -> Result<()> {
         let mut conn = self.inner.acquire().await?;
 
-        // FIXME: I cannot run `cargo sqlx prepare` locally :(, so I
-        // can't add/modify any of the `sqlx` macros.
-        let affected_rows = sqlx::query(
+        let affected_rows = sqlx::query!(
             r#"
             DELETE FROM
                 cfds

--- a/sqlite-db/src/lib.rs
+++ b/sqlite-db/src/lib.rs
@@ -38,6 +38,7 @@ pub use failed::*;
 
 mod closed;
 mod cull_old_dlcs;
+mod delete_trivial_cfds;
 mod event_log;
 mod failed;
 mod impls;

--- a/sqlite-db/src/lib.rs
+++ b/sqlite-db/src/lib.rs
@@ -36,12 +36,12 @@ pub use closed::*;
 pub use cull_old_dlcs::*;
 pub use failed::*;
 
-pub mod closed;
-pub mod cull_old_dlcs;
-pub mod event_log;
-pub mod failed;
+mod closed;
+mod cull_old_dlcs;
+mod event_log;
+mod failed;
 mod impls;
-pub mod time_to_first_position;
+mod time_to_first_position;
 
 #[derive(Clone)]
 pub struct Connection {


### PR DESCRIPTION
This work was started before #2128 superseded #1997.