### PR TITLE
Revert "Taker checks balance before taking an offer"

### DIFF
--- a/daemon-tests/src/mocks/mod.rs
+++ b/daemon-tests/src/mocks/mod.rs
@@ -3,7 +3,6 @@ use crate::mocks::monitor::MockMonitor;
 use crate::mocks::oracle::MockOracle;
 use crate::mocks::price_feed::MockPriceFeed;
 use crate::mocks::wallet::MockWallet;
-use crate::Amount;
 use model::olivia;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -59,17 +58,6 @@ impl Mocks {
             .await
             .expect_sign()
             .returning(|sign_msg| Ok(sign_msg.psbt));
-    }
-
-    pub async fn mock_balance(&mut self) {
-        self.mock_balance_with(Amount::from_sat(100000000)).await;
-    }
-
-    pub async fn mock_balance_with(&mut self, balance: Amount) {
-        self.wallet()
-            .await
-            .expect_get_balance()
-            .returning(move |_| Ok(balance));
     }
 
     pub async fn mock_oracle_announcement(&mut self) {

--- a/daemon-tests/src/mocks/wallet.rs
+++ b/daemon-tests/src/mocks/wallet.rs
@@ -54,9 +54,6 @@ impl WalletActor {
     async fn handle(&mut self, msg: wallet::Withdraw) -> Result<Txid> {
         self.mock.lock().await.withdraw(msg)
     }
-    async fn handle(&mut self, msg: wallet::GetBalance) -> Result<Amount> {
-        self.mock.lock().await.get_balance(msg)
-    }
 }
 
 #[automock]
@@ -70,10 +67,6 @@ pub trait Wallet {
     }
 
     fn withdraw(&mut self, _msg: wallet::Withdraw) -> Result<Txid> {
-        unreachable!("mockall will reimplement this method")
-    }
-
-    fn get_balance(&mut self, _msg: wallet::GetBalance) -> Result<Amount> {
         unreachable!("mockall will reimplement this method")
     }
 }

--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -201,13 +201,7 @@ async fn taker_takes_order_and_maker_rejects() {
     let order_id = received.short.unwrap().id;
 
     taker.mocks.mock_oracle_announcement().await;
-    taker.mocks.mock_balance().await;
-    taker.mocks.mock_party_params().await;
-
     maker.mocks.mock_oracle_announcement().await;
-    maker.mocks.mock_balance().await;
-    maker.mocks.mock_party_params().await;
-
     taker
         .system
         .take_offer(order_id, Usd::new(dec!(10)), Leverage::TWO)
@@ -239,13 +233,7 @@ async fn another_offer_is_automatically_created_after_taker_takes_order() {
     let order_id_take = received.short.unwrap().id;
 
     taker.mocks.mock_oracle_announcement().await;
-    taker.mocks.mock_balance().await;
-    taker.mocks.mock_party_params().await;
-
     maker.mocks.mock_oracle_announcement().await;
-    maker.mocks.mock_balance().await;
-    maker.mocks.mock_party_params().await;
-
     taker
         .system
         .take_offer(order_id_take, Usd::new(dec!(10)), Leverage::TWO)
@@ -296,12 +284,7 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
     let order_id = received.short.unwrap().id;
 
     taker.mocks.mock_oracle_announcement().await;
-    taker.mocks.mock_balance().await;
-    taker.mocks.mock_party_params().await;
-
     maker.mocks.mock_oracle_announcement().await;
-    maker.mocks.mock_balance().await;
-    maker.mocks.mock_party_params().await;
 
     taker
         .system
@@ -309,6 +292,9 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
         .await
         .unwrap();
     wait_next_state!(order_id, maker, taker, CfdState::PendingSetup);
+
+    maker.mocks.mock_party_params().await;
+    taker.mocks.mock_party_params().await;
 
     maker.mocks.mock_wallet_sign_and_broadcast().await;
     taker.mocks.mock_wallet_sign_and_broadcast().await;
@@ -704,15 +690,10 @@ async fn start_from_open_cfd_state(
         .mocks
         .mock_oracle_announcement_with(announcement.clone())
         .await;
-    taker.mocks.mock_balance().await;
-    taker.mocks.mock_party_params().await;
-
     maker
         .mocks
         .mock_oracle_announcement_with(announcement)
         .await;
-    maker.mocks.mock_balance().await;
-    maker.mocks.mock_party_params().await;
 
     let order_to_take = match position_maker {
         Position::Short => received.short,
@@ -727,6 +708,9 @@ async fn start_from_open_cfd_state(
         .await
         .unwrap();
     wait_next_state!(order_to_take.id, maker, taker, CfdState::PendingSetup);
+
+    maker.mocks.mock_party_params().await;
+    taker.mocks.mock_party_params().await;
 
     maker.mocks.mock_wallet_sign_and_broadcast().await;
     taker.mocks.mock_wallet_sign_and_broadcast().await;

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 use crate::bitcoin::Txid;
-use anyhow::bail;
 use anyhow::Context as _;
 use anyhow::Result;
 use bdk::bitcoin;
@@ -19,7 +18,6 @@ use model::Order;
 use model::OrderId;
 use model::Price;
 use model::Role;
-use model::TxFeeRate;
 use model::Usd;
 use parse_display::Display;
 use seed::Identities;
@@ -101,7 +99,6 @@ where
     W: Handler<wallet::BuildPartyParams>
         + Handler<wallet::Sign>
         + Handler<wallet::Withdraw>
-        + Handler<wallet::GetBalance>
         + Actor<Stop = ()>,
     P: Handler<xtra_bitmex_price_feed::LatestQuote> + Actor<Stop = xtra_bitmex_price_feed::Error>,
 {
@@ -363,39 +360,4 @@ impl Environment {
             _ => Environment::Unknown,
         }
     }
-}
-
-pub async fn balance_check(
-    margin: Amount,
-    tx_fee_rate: TxFeeRate,
-    build_party_params: &(impl MessageChannel<wallet::BuildPartyParams> + 'static),
-    get_balance: &(impl MessageChannel<wallet::GetBalance> + 'static),
-) -> Result<()> {
-    let dummy_pk = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af"
-        .parse()
-        .expect("static pk to parse");
-    let build_params = build_party_params
-        .send(wallet::BuildPartyParams {
-            amount: margin,
-            identity_pk: dummy_pk,
-            fee_rate: tx_fee_rate,
-        })
-        .await
-        .context("Wallet actor unavailable")??;
-
-    let lock_amount = build_params.lock_amount;
-    let balance = get_balance
-        .send(wallet::GetBalance)
-        .await
-        .context("Wallet actor unavailable")??;
-
-    if balance < lock_amount {
-        bail!(
-            "Wallet balance {} insufficient to open cfd with lock amount {}",
-            balance,
-            lock_amount
-        )
-    }
-
-    Ok(())
 }

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -1,4 +1,3 @@
-use crate::balance_check;
 use crate::collab_settlement_taker;
 use crate::connection;
 use crate::oracle;
@@ -168,9 +167,7 @@ impl<O, W> Actor<O, W> {
 impl<O, W> Actor<O, W>
 where
     O: xtra::Handler<oracle::GetAnnouncement> + xtra::Handler<oracle::MonitorAttestation>,
-    W: xtra::Handler<wallet::BuildPartyParams>
-        + xtra::Handler<wallet::Sign>
-        + xtra::Handler<wallet::GetBalance>,
+    W: xtra::Handler<wallet::BuildPartyParams> + xtra::Handler<wallet::Sign>,
 {
     async fn handle_take_offer(&mut self, msg: TakeOffer) -> Result<()> {
         let TakeOffer {
@@ -194,23 +191,6 @@ where
 
         let order_to_take = order_to_take.context("Order to take could not be found in current maker offers, you might have an outdated offer")?;
 
-        let cfd = Cfd::from_order(
-            &order_to_take,
-            quantity,
-            self.maker_identity,
-            Some(self.maker_peer_id),
-            Role::Taker,
-            leverage,
-        );
-
-        balance_check(
-            cfd.margin(),
-            order_to_take.tx_fee_rate,
-            &self.wallet,
-            &self.wallet,
-        )
-        .await?;
-
         // The offer we are instructed to take is removed from the
         // set of available offers immediately so that we don't attempt
         // to take it more than once
@@ -227,9 +207,18 @@ where
 
         tracing::info!("Taking current order: {:?}", &order_to_take);
 
-        // We insert the cfd here without any events yet, only static data
-        // Once the contract setup with the other party is started the first event will be
+        // We create the cfd here without any events yet, only static data
+        // Once the contract setup completes (rejected / accepted / failed) the first event will be
         // recorded
+        let cfd = Cfd::from_order(
+            &order_to_take,
+            quantity,
+            self.maker_identity,
+            Some(self.maker_peer_id),
+            Role::Taker,
+            leverage,
+        );
+
         self.db.insert_cfd(&cfd).await?;
         self.projection_actor
             .send(projection::CfdChanged(cfd.id()))

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -276,14 +276,6 @@ where
             address: self.wallet.get_address(AddressIndex::New)?.address,
         })
     }
-
-    pub fn handle_get_balance(&mut self, _msg: GetBalance) -> Result<Amount> {
-        let balance = self
-            .wallet
-            .get_balance()
-            .context("Failed to retrieve wallet balance")?;
-        Ok(Amount::from_sat(balance))
-    }
 }
 
 #[async_trait]
@@ -326,9 +318,6 @@ pub struct Withdraw {
     pub fee: Option<FeeRate>,
     pub address: Address,
 }
-
-#[derive(Clone, Copy)]
-pub struct GetBalance;
 
 /// Bitcoin error codes: <https://github.com/bitcoin/bitcoin/blob/97d3500601c1d28642347d014a6de1e38f53ae4e/src/rpc/protocol.h#L23>
 #[derive(Clone, Copy)]
@@ -444,7 +433,6 @@ mod tests {
     use itertools::Itertools;
     use rand::thread_rng;
     use std::collections::HashSet;
-    use xtra::spawn::TokioGlobalSpawnExt;
     use xtra::Actor as _;
 
     impl Actor<()> {
@@ -618,52 +606,5 @@ mod tests {
             .await
             .unwrap()
             .expect("single UTXO to be available after unlocking it");
-    }
-
-    #[tokio::test]
-    async fn given_margin_less_balance_then_insufficient_funds_error_when_building_party_params() {
-        let balance = Amount::from_btc(0.1).unwrap();
-        let margin = Amount::from_btc(0.2).unwrap();
-
-        let actor = Actor::new_offline(balance, 1, Duration::from_secs(120))
-            .unwrap()
-            .create(None)
-            .spawn_global();
-
-        let (_, identity_pk) = keypair::new(&mut thread_rng());
-
-        actor
-            .send(BuildPartyParams {
-                amount: margin,
-                identity_pk,
-                fee_rate: TxFeeRate::default(),
-            })
-            .await
-            .unwrap()
-            .expect_err("insufficient funds");
-    }
-
-    #[tokio::test]
-    async fn given_margin_equals_balance_and_fee_rate_then_insufficient_funds_error_when_building_party_params(
-    ) {
-        let balance = Amount::from_btc(0.1).unwrap();
-        let margin = Amount::from_btc(0.1).unwrap();
-
-        let actor = Actor::new_offline(balance, 1, Duration::from_secs(120))
-            .unwrap()
-            .create(None)
-            .spawn_global();
-
-        let (_, identity_pk) = keypair::new(&mut thread_rng());
-
-        actor
-            .send(BuildPartyParams {
-                amount: margin,
-                identity_pk,
-                fee_rate: TxFeeRate::default(),
-            })
-            .await
-            .unwrap()
-            .expect_err("insufficient funds");
     }
 }

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -63,7 +63,6 @@ where
     W: Handler<wallet::BuildPartyParams>
         + Handler<wallet::Sign>
         + Handler<wallet::Withdraw>
-        + Handler<wallet::GetBalance>
         + Actor<Stop = ()>,
 {
     #[allow(clippy::too_many_arguments)]

--- a/maker/src/cfd.rs
+++ b/maker/src/cfd.rs
@@ -9,7 +9,6 @@ use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use async_trait::async_trait;
-use daemon::balance_check;
 use daemon::command;
 use daemon::libp2p_utils::can_use_libp2p;
 use daemon::oracle;
@@ -315,9 +314,7 @@ where
     T: xtra::Handler<connection::ConfirmOrder>
         + xtra::Handler<connection::TakerMessage>
         + xtra::Handler<connection::BroadcastOffers>,
-    W: xtra::Handler<wallet::Sign>
-        + xtra::Handler<wallet::BuildPartyParams>
-        + xtra::Handler<wallet::GetBalance>,
+    W: xtra::Handler<wallet::Sign> + xtra::Handler<wallet::BuildPartyParams>,
 {
     async fn handle_take_order(
         &mut self,
@@ -369,25 +366,6 @@ where
             Role::Maker,
             leverage,
         );
-
-        if let Err(e) = balance_check(
-            cfd.margin(),
-            order_to_take.tx_fee_rate,
-            &self.wallet,
-            &self.wallet,
-        )
-        .await
-        {
-            tracing::warn!(%order_id, %taker_id, "Rejecting taker's order: {e}");
-
-            self.takers
-                .send(connection::TakerMessage {
-                    taker_id,
-                    msg: wire::MakerToTaker::RejectOrder(order_id),
-                })
-                .await??;
-            return Ok(());
-        }
 
         // 2. Replicate the orders in the offers with new ones to allow other takers to use
         // the same offer
@@ -712,9 +690,7 @@ where
         + xtra::Handler<connection::BroadcastOffers>
         + xtra::Handler<connection::settlement::Response>
         + xtra::Handler<connection::RegisterRollover>,
-    W: xtra::Handler<wallet::Sign>
-        + xtra::Handler<wallet::BuildPartyParams>
-        + xtra::Handler<wallet::GetBalance>,
+    W: xtra::Handler<wallet::Sign> + xtra::Handler<wallet::BuildPartyParams>,
 {
     async fn handle_new_order(&mut self, msg: OfferParams) -> Result<()> {
         // 1. Update actor state to current order

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -743,7 +743,7 @@ impl Cfd {
             .map(|dlc| dlc.settlement_event_id.timestamp())
     }
 
-    pub fn margin(&self) -> Amount {
+    fn margin(&self) -> Amount {
         match self.position {
             Position::Long => {
                 calculate_margin(self.initial_price, self.quantity, self.long_leverage)


### PR DESCRIPTION
Reverts itchysats/itchysats#2129

---

Unfortunately this can have very weird side effects on the `taker` side.
I am not totally sure why we run into the problems, but it seems that the way `GetBalance` is implemented does not pick up the balance from mempool. (This is my guess based on the behaviour we saw...)
This can result to a balance being displayed in the UI, but when opening a position we get an `Insufficient funds` error in the UI. 
This can likely be solved, but for now it's easier to revert this to have more stable master.
