### PR TITLE
Add notification capabilities to Endpoint

### DIFF
--- a/xtra-libp2p-ping/src/lib.rs
+++ b/xtra-libp2p-ping/src/lib.rs
@@ -18,6 +18,7 @@ mod tests {
     use xtra::Actor as _;
     use xtra::Address;
     use xtra::Context;
+    use xtra_libp2p::endpoint::Subscribers;
     use xtra_libp2p::libp2p::identity::Keypair;
     use xtra_libp2p::libp2p::multiaddr::Protocol;
     use xtra_libp2p::libp2p::transport::MemoryTransport;
@@ -79,6 +80,7 @@ mod tests {
         assert!(!bob_to_alice_latency.is_zero());
     }
 
+    #[allow(clippy::type_complexity)]
     fn create_endpoint_with_ping() -> (PeerId, Address<ping::Actor>, Address<Endpoint>) {
         let (endpoint_address, endpoint_context) = Context::new(None);
 
@@ -93,6 +95,16 @@ mod tests {
             id.clone(),
             Duration::from_secs(10),
             [(PROTOCOL_NAME, pong_address.clone_channel())],
+            Subscribers::new(
+                vec![xtra::message_channel::MessageChannel::clone_channel(
+                    &ping_address,
+                )],
+                vec![xtra::message_channel::MessageChannel::clone_channel(
+                    &ping_address,
+                )],
+                vec![],
+                vec![],
+            ),
         );
 
         #[allow(clippy::disallowed_methods)]

--- a/xtra-libp2p/examples/hello_world_dialer.rs
+++ b/xtra-libp2p/examples/hello_world_dialer.rs
@@ -13,6 +13,7 @@ use tokio::time::sleep;
 use xtra::prelude::*;
 use xtra::spawn::TokioGlobalSpawnExt;
 use xtra_libp2p::dialer;
+use xtra_libp2p::endpoint::Subscribers;
 use xtra_libp2p::Endpoint;
 use xtra_libp2p::OpenSubstream;
 use xtras::supervisor;
@@ -34,9 +35,15 @@ async fn main() -> Result<()> {
 
     let id = Keypair::generate_ed25519();
 
-    let endpoint_addr = Endpoint::new(TokioTcpConfig::new(), id, Duration::from_secs(20), [])
-        .create(None)
-        .spawn_global();
+    let endpoint_addr = Endpoint::new(
+        TokioTcpConfig::new(),
+        id,
+        Duration::from_secs(20),
+        [],
+        Subscribers::default(),
+    )
+    .create(None)
+    .spawn_global();
 
     let dialer_constructor = {
         let connect_addr = opts.multiaddr.clone();

--- a/xtra-libp2p/examples/hello_world_listener.rs
+++ b/xtra-libp2p/examples/hello_world_listener.rs
@@ -13,6 +13,7 @@ use tokio_tasks::Tasks;
 use tracing::Level;
 use xtra::prelude::*;
 use xtra::spawn::TokioGlobalSpawnExt;
+use xtra_libp2p::endpoint::Subscribers;
 use xtra_libp2p::listener;
 use xtra_libp2p::Endpoint;
 use xtra_libp2p::NewInboundSubstream;
@@ -58,6 +59,7 @@ async fn main() -> Result<()> {
             "/hello-world/1.0.0",
             xtra::message_channel::StrongMessageChannel::clone_channel(&hello_world_addr),
         )],
+        Subscribers::default(),
     )
     .create(None)
     .spawn_global();

--- a/xtra-libp2p/src/lib.rs
+++ b/xtra-libp2p/src/lib.rs
@@ -19,7 +19,7 @@ use libp2p_core::Negotiated;
 use libp2p_core::PeerId;
 
 pub mod dialer;
-mod endpoint;
+pub mod endpoint;
 pub mod listener;
 pub mod multiaddress_ext;
 mod substream;

--- a/xtra-libp2p/tests/basic.rs
+++ b/xtra-libp2p/tests/basic.rs
@@ -13,6 +13,7 @@ use xtra::message_channel::StrongMessageChannel;
 use xtra::spawn::TokioGlobalSpawnExt;
 use xtra::Actor;
 use xtra::Address;
+use xtra_libp2p::endpoint::Subscribers;
 use xtra_libp2p::libp2p::identity::Keypair;
 use xtra_libp2p::libp2p::transport::MemoryTransport;
 use xtra_libp2p::libp2p::PeerId;
@@ -240,6 +241,7 @@ fn make_endpoint<const N: usize>(
         id,
         Duration::from_secs(20),
         substream_handlers,
+        Subscribers::default(),
     )
     .create(None)
     .spawn_global();


### PR DESCRIPTION
Furthermore, we can now push connection information (such as connected peer or
listen addresses) to interested subscribers instead of polling this information.

Roll out the usage in the existing actors, so they don't need to poll Endpoint continuously.

This helps to overcome the problem that all actors interested in connection
information bombard the endpoint with `GetConnectionStats`.

Co-authored-by: Mariusz Klochowicz <mariusz@klochowicz.com>