### PR TITLE
Remove `timestamp` field from `SettlementProposal`

### DIFF
--- a/maker/src/cfd.rs
+++ b/maker/src/cfd.rs
@@ -776,7 +776,7 @@ where
                 order_id,
                 msg:
                     wire::taker_to_maker::Settlement::Propose {
-                        timestamp,
+                        timestamp: _,
                         taker,
                         maker,
                         price,
@@ -787,7 +787,6 @@ where
                         taker_id,
                         SettlementProposal {
                             order_id,
-                            timestamp,
                             taker,
                             maker,
                             price,

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1031,12 +1031,9 @@ impl Cfd {
         current_price: Price,
         n_payouts: usize,
     ) -> Result<(CfdEvent, SettlementTransaction, SettlementProposal)> {
-        anyhow::ensure!(
-            !self.is_in_collaborative_settlement()
-                && self.role == Role::Taker
-                && self.can_settle_collaboratively(),
-            "Failed to propose collaborative settlement"
-        );
+        anyhow::ensure!(!self.is_in_collaborative_settlement());
+        anyhow::ensure!(self.role == Role::Taker);
+        anyhow::ensure!(self.can_settle_collaboratively());
 
         let (collab_settlement_tx, proposal) = self.make_proposal(current_price, n_payouts)?;
 
@@ -1057,12 +1054,9 @@ impl Cfd {
         n_payouts: usize,
         proposed_settlement_transaction: &bitcoin::Transaction,
     ) -> Result<(CfdEvent, SettlementTransaction, SettlementProposal)> {
-        anyhow::ensure!(
-            !self.is_in_collaborative_settlement()
-                && self.role == Role::Maker
-                && self.can_settle_collaboratively(),
-            "Failed to start collaborative settlement"
-        );
+        anyhow::ensure!(!self.is_in_collaborative_settlement());
+        anyhow::ensure!(self.role == Role::Maker);
+        anyhow::ensure!(self.can_settle_collaboratively());
 
         let (settlement_tx, proposal) = self.make_proposal(current_price, n_payouts)?;
 
@@ -1135,13 +1129,10 @@ impl Cfd {
         proposal: SettlementProposal,
         n_payouts: usize,
     ) -> Result<CfdEvent> {
-        anyhow::ensure!(
-            !self.is_in_collaborative_settlement()
-                && self.role == Role::Maker
-                && self.can_settle_collaboratively()
-                && proposal.order_id == self.id,
-            "Failed to start collaborative settlement"
-        );
+        anyhow::ensure!(!self.is_in_collaborative_settlement());
+        anyhow::ensure!(self.role == Role::Maker);
+        anyhow::ensure!(self.can_settle_collaboratively());
+        anyhow::ensure!(proposal.order_id == self.id);
 
         // Validate that the amounts sent by the taker are sane according to the payout curve
 
@@ -1178,9 +1169,8 @@ impl Cfd {
         self,
         proposal: &SettlementProposal,
     ) -> Result<CfdEvent> {
-        anyhow::ensure!(
-            self.role == Role::Maker && self.settlement_proposal.as_ref() == Some(proposal)
-        );
+        anyhow::ensure!(self.role == Role::Maker);
+        anyhow::ensure!(self.settlement_proposal.as_ref() == Some(proposal));
 
         Ok(CfdEvent::new(
             self.id,

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -346,7 +346,6 @@ impl Order {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct SettlementProposal {
     pub order_id: OrderId,
-    pub timestamp: Timestamp,
     #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
     pub taker: Amount,
     #[serde(with = "::bdk::bitcoin::util::amount::serde::as_btc")]
@@ -1115,7 +1114,6 @@ impl Cfd {
 
         let proposal = SettlementProposal {
             order_id: self.id,
-            timestamp: Timestamp::now(),
             taker: *payout.taker_amount(),
             maker: *payout.maker_amount(),
             price: current_price,
@@ -3917,7 +3915,6 @@ mod tests {
                 event: EventKind::CollaborativeSettlementStarted {
                     proposal: SettlementProposal {
                         order_id,
-                        timestamp: Timestamp::now(),
                         taker: Default::default(),
                         maker: Default::default(),
                         price: Price::new(dec!(10000)).unwrap(),

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1165,10 +1165,15 @@ impl Cfd {
 
     pub fn accept_collaborative_settlement_proposal(
         self,
-        proposal: &SettlementProposal,
+        theirs: &SettlementProposal,
     ) -> Result<CfdEvent> {
         anyhow::ensure!(self.role == Role::Maker);
-        anyhow::ensure!(self.settlement_proposal.as_ref() == Some(proposal));
+
+        let ours = self.settlement_proposal;
+        anyhow::ensure!(
+            self.settlement_proposal.as_ref() == Some(theirs),
+            "Settlement proposal mismatch: calculated {ours:?}, got {theirs:?}",
+        );
 
         Ok(CfdEvent::new(
             self.id,

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1192,10 +1192,10 @@ impl Cfd {
     }
 
     pub fn reject_contract_setup(self, reason: anyhow::Error) -> Result<CfdEvent> {
+        let version = self.version;
         anyhow::ensure!(
-            self.version <= 1,
-            "Rejecting contract setup not allowed because cfd in version {}",
-            self.version
+            version <= 1,
+            "Rejecting contract setup not allowed because cfd in version {version}",
         );
 
         tracing::info!(order_id = %self.id, "Contract setup was rejected: {reason:#}");


### PR DESCRIPTION
Fixes #2162.

The motivation for this is that we don't want to compare the timestamps generated by taker and maker when deciding if the maker
should accept a settlement proposal.

We could just modify the `PartialEq` implementation of `SettlementProposal`, but it turns out that this field is never used.
We therefore remove it altogether.

We do no modify `wire::taker_to_maker::Settlement::Propose` because this code is on the way out anyway. We simply ignore the `timestamp` field if we receive it over the wire.

---

Because we don't know what caused #2162 and we can't easily reproduce it, we're only guessing that this fixes the problem.