### PR TITLE
Introduce `/itchysats/order` protocol

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -369,7 +369,6 @@ impl Taker {
             config.heartbeat_interval,
             Duration::from_secs(10),
             projection_actor,
-            maker_identity,
             maker_multiaddr.clone(),
             Environment::Test,
         )
@@ -459,8 +458,6 @@ macro_rules! wait_next_state {
             taker_cfd.order_id, maker_cfd.order_id,
             "order id mismatch between maker and taker"
         );
-        assert_eq!(taker_cfd.order_id, $id, "unexpected order id in the taker");
-        assert_eq!(maker_cfd.order_id, $id, "unexpected order id in the maker");
     };
     ($id:expr, $maker:expr, $taker:expr, $state:expr) => {
         wait_next_state!($id, $maker, $taker, $state, $state)

--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -23,12 +23,11 @@ use daemon_tests::MakerConfig;
 use daemon_tests::Taker;
 use daemon_tests::TakerConfig;
 use model::olivia;
+use model::Contracts;
 use model::Identity;
 use model::Leverage;
 use model::OrderId;
 use model::Position;
-use model::Usd;
-use rust_decimal_macros::dec;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -204,7 +203,7 @@ async fn taker_takes_order_and_maker_rejects() {
     maker.mocks.mock_oracle_announcement().await;
     taker
         .system
-        .take_offer(order_id, Usd::new(dec!(10)), Leverage::TWO)
+        .place_order(order_id, Contracts::new(10), Leverage::TWO)
         .await
         .unwrap();
 
@@ -236,7 +235,7 @@ async fn another_offer_is_automatically_created_after_taker_takes_order() {
     maker.mocks.mock_oracle_announcement().await;
     taker
         .system
-        .take_offer(order_id_take, Usd::new(dec!(10)), Leverage::TWO)
+        .place_order(order_id_take, Contracts::new(10), Leverage::TWO)
         .await
         .unwrap();
 
@@ -281,14 +280,14 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
         .await
         .unwrap();
 
-    let order_id = received.short.unwrap().id;
+    let offer_id = received.short.unwrap().id;
 
     taker.mocks.mock_oracle_announcement().await;
     maker.mocks.mock_oracle_announcement().await;
 
-    taker
+    let order_id = taker
         .system
-        .take_offer(order_id, Usd::new(dec!(5)), Leverage::TWO)
+        .place_order(offer_id, Contracts::new(5), Leverage::TWO)
         .await
         .unwrap();
     wait_next_state!(order_id, maker, taker, CfdState::PendingSetup);
@@ -704,7 +703,7 @@ async fn start_from_open_cfd_state(
 
     taker
         .system
-        .take_offer(order_to_take.id, Usd::new(dec!(5)), Leverage::TWO)
+        .place_order(order_to_take.id, Contracts::new(5), Leverage::TWO)
         .await
         .unwrap();
     wait_next_state!(order_to_take.id, maker, taker, CfdState::PendingSetup);

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -12,13 +12,12 @@ use libp2p_tcp::TokioTcpConfig;
 use maia_core::secp256k1_zkp::schnorrsig;
 use model::libp2p::PeerId;
 use model::olivia;
-use model::Identity;
+use model::Contracts;
 use model::Leverage;
 use model::Order;
 use model::OrderId;
 use model::Price;
 use model::Role;
-use model::Usd;
 use parse_display::Display;
 use seed::Identities;
 use std::time::Duration;
@@ -50,6 +49,7 @@ pub mod libp2p_utils;
 pub mod monitor;
 pub mod noise;
 pub mod oracle;
+pub mod order;
 pub mod position_metrics;
 pub mod process_manager;
 pub mod projection;
@@ -75,15 +75,17 @@ pub const PING_INTERVAL: Duration = Duration::from_secs(5);
 pub const N_PAYOUTS: usize = 200;
 
 pub struct TakerActorSystem<O, W, P> {
-    pub cfd_actor: Address<taker_cfd::Actor<O, W>>,
+    pub cfd_actor: Address<taker_cfd::Actor>,
     pub connection_actor: Address<connection::Actor>,
     wallet_actor: Address<W>,
+    _oracle_actor: Address<O>, // NOTE: Hard to supervise because of our tests
     pub auto_rollover_actor: Address<auto_rollover::Actor>,
     pub price_feed_actor: Address<P>,
     executor: command::Executor,
     /// Keep this one around to avoid the supervisor being dropped due to ref-count changes on the
     /// address.
     _price_feed_supervisor: Address<supervisor::Actor<P, xtra_bitmex_price_feed::Error>>,
+    _order_supervisor: Address<supervisor::Actor<order::taker::Actor, supervisor::UnitReason>>,
     _collab_settlement_supervisor:
         Address<supervisor::Actor<collab_settlement::taker::Actor, supervisor::UnitReason>>,
     _rollover_supervisor:
@@ -124,7 +126,6 @@ where
         maker_heartbeat_interval: Duration,
         connect_timeout: Duration,
         projection_actor: Address<projection::Actor>,
-        maker_identity: Identity,
         maker_multiaddr: Multiaddr,
         environment: Environment,
     ) -> Result<Self>
@@ -165,6 +166,27 @@ where
 
         let (endpoint_addr, endpoint_context) = Context::new(None);
 
+        let (order_supervisor, order) = supervisor::Actor::new({
+            let oracle = oracle_addr.clone();
+            let db = db.clone();
+            let process_manager = process_manager_addr;
+            let wallet = wallet_actor_addr.clone();
+            let projection = projection_actor.clone();
+            let endpoint = endpoint_addr.clone();
+            move || {
+                order::taker::Actor::new(
+                    n_payouts,
+                    oracle_pk,
+                    &oracle,
+                    (db.clone(), process_manager.clone()),
+                    (&wallet, &wallet),
+                    projection.clone(),
+                    endpoint.clone(),
+                )
+            }
+        });
+        let order_supervisor = order_supervisor.create(None).spawn(&mut tasks);
+
         let (collab_settlement_supervisor, libp2p_collab_settlement_addr) =
             supervisor::Actor::new({
                 let endpoint_addr = endpoint_addr.clone();
@@ -183,15 +205,9 @@ where
         let (connection_actor_addr, connection_actor_ctx) = Context::new(None);
         let cfd_actor_addr = taker_cfd::Actor::new(
             db.clone(),
-            wallet_actor_addr.clone(),
-            oracle_pk,
             projection_actor,
-            process_manager_addr,
-            connection_actor_addr.clone(),
-            oracle_addr.clone(),
             libp2p_collab_settlement_addr,
-            n_payouts,
-            maker_identity,
+            order,
             PeerId::from(
                 maker_multiaddr
                     .clone()
@@ -205,6 +221,7 @@ where
         let (rollover_supervisor, libp2p_rollover_addr) = supervisor::Actor::new({
             let endpoint_addr = endpoint_addr.clone();
             let executor = executor.clone();
+            let oracle_addr = oracle_addr.clone();
             move || {
                 rollover::taker::Actor::new(
                     endpoint_addr.clone(),
@@ -306,10 +323,12 @@ where
             cfd_actor: cfd_actor_addr,
             connection_actor: connection_actor_addr,
             wallet_actor: wallet_actor_addr,
+            _oracle_actor: oracle_addr,
             auto_rollover_actor: auto_rollover_addr,
             price_feed_actor,
             executor,
             _price_feed_supervisor: price_feed_supervisor,
+            _order_supervisor: order_supervisor,
             _rollover_supervisor: rollover_supervisor,
             _collab_settlement_supervisor: collab_settlement_supervisor,
             _dialer_supervisor: dialer_supervisor,
@@ -323,20 +342,22 @@ where
         })
     }
 
-    pub async fn take_offer(
+    pub async fn place_order(
         &self,
-        order_id: OrderId,
-        quantity: Usd,
+        offer_id: OrderId,
+        contracts: Contracts,
         leverage: Leverage,
-    ) -> Result<()> {
-        self.cfd_actor
-            .send(taker_cfd::TakeOffer {
-                order_id,
-                quantity,
+    ) -> Result<OrderId> {
+        let order_id = self
+            .cfd_actor
+            .send(taker_cfd::PlaceOrder {
+                offer_id,
+                contracts,
                 leverage,
             })
             .await??;
-        Ok(())
+
+        Ok(order_id)
     }
 
     pub async fn commit(&self, order_id: OrderId) -> Result<()> {

--- a/daemon/src/order.rs
+++ b/daemon/src/order.rs
@@ -1,0 +1,5 @@
+pub const PROTOCOL_NAME: &str = "/ipfs/order/0.1.0";
+
+pub mod maker;
+mod protocol;
+pub mod taker;

--- a/daemon/src/order/maker.rs
+++ b/daemon/src/order/maker.rs
@@ -1,0 +1,331 @@
+use crate::command;
+use crate::oracle;
+use crate::order::protocol;
+use crate::order::protocol::MakerMessage;
+use crate::order::protocol::TakerMessage;
+use crate::process_manager;
+use crate::projection;
+use crate::setup_contract;
+use crate::wallet;
+use crate::wire::SetupMsg;
+use anyhow::anyhow;
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
+use async_trait::async_trait;
+use asynchronous_codec::Framed;
+use asynchronous_codec::JsonCodec;
+use futures::channel::oneshot;
+use futures::future;
+use futures::SinkExt;
+use futures::StreamExt;
+use maia_core::secp256k1_zkp::schnorrsig;
+use model::Cfd;
+use model::Identity;
+use model::OrderId;
+use model::Role;
+use model::Usd;
+use rust_decimal::Decimal;
+use std::collections::HashMap;
+use std::fmt;
+use xtra::prelude::MessageChannel;
+use xtra::spawn::TokioGlobalSpawnExt;
+use xtra::Actor as _;
+use xtra_libp2p::NewInboundSubstream;
+use xtra_productivity::xtra_productivity;
+use xtras::spawner;
+use xtras::spawner::SpawnFallible;
+use xtras::SendAsyncSafe;
+
+pub struct Actor {
+    executor: command::Executor,
+    oracle_pk: schnorrsig::PublicKey,
+    get_announcement: Box<dyn MessageChannel<oracle::GetAnnouncement>>,
+    build_party_params: Box<dyn MessageChannel<wallet::BuildPartyParams> + 'static>,
+    sign: Box<dyn MessageChannel<wallet::Sign> + 'static>,
+    projection: xtra::Address<projection::Actor>,
+    n_payouts: usize,
+    decision_senders: HashMap<OrderId, oneshot::Sender<protocol::Decision>>,
+    db: sqlite_db::Connection,
+    spawner: xtra::Address<spawner::Actor>,
+}
+
+impl Actor {
+    pub fn new(
+        n_payouts: usize,
+        oracle_pk: schnorrsig::PublicKey,
+        get_announcement: &(impl MessageChannel<oracle::GetAnnouncement> + 'static),
+        (db, process_manager): (sqlite_db::Connection, xtra::Address<process_manager::Actor>),
+        (build_party_params, sign): (
+            &(impl MessageChannel<wallet::BuildPartyParams> + 'static),
+            &(impl MessageChannel<wallet::Sign> + 'static),
+        ),
+        projection: xtra::Address<projection::Actor>,
+    ) -> Self {
+        let spawner = spawner::Actor::new().create(None).spawn_global();
+
+        Self {
+            executor: command::Executor::new(db.clone(), process_manager),
+            oracle_pk,
+            get_announcement: get_announcement.clone_channel(),
+            build_party_params: build_party_params.clone_channel(),
+            sign: sign.clone_channel(),
+            projection,
+            n_payouts,
+            decision_senders: HashMap::default(),
+            db,
+            spawner,
+        }
+    }
+
+    pub async fn handle_new_inbound_stream(&mut self, msg: NewInboundSubstream) -> Result<()> {
+        let NewInboundSubstream { peer, stream } = msg;
+
+        let mut framed = Framed::new(stream, JsonCodec::<MakerMessage, TakerMessage>::new());
+
+        let (
+            id,
+            contracts,
+            leverage,
+            position,
+            opening_price,
+            settlement_interval,
+            opening_fee,
+            funding_rate,
+            tx_fee_rate,
+            oracle_event_id,
+        ) = match framed.next().await.context("Stream terminated")?? {
+            TakerMessage::PlaceOrder {
+                id,
+                contracts,
+                leverage,
+                position,
+                opening_price,
+                settlement_interval,
+                opening_fee,
+                funding_rate,
+                tx_fee_rate,
+                oracle_event_id,
+            } => (
+                id,
+                contracts,
+                leverage,
+                position,
+                opening_price,
+                settlement_interval,
+                opening_fee,
+                funding_rate,
+                tx_fee_rate,
+                oracle_event_id,
+            ),
+            TakerMessage::ContractSetupMsg(_) => bail!("Unexpected message"),
+        };
+
+        tracing::info!(taker = %peer, %contracts, order_id = %id, "Taker wants to place an order");
+
+        let cfd = Cfd::new(
+            id,
+            position,
+            opening_price,
+            leverage,
+            settlement_interval,
+            Role::Maker,
+            Usd::new(Decimal::from(u64::from(contracts))),
+            // Completely irrelevant when using libp2p
+            Identity::new(x25519_dalek::PublicKey::from(
+                *b"hello world, oh what a beautiful",
+            )),
+            Some(peer.into()),
+            opening_fee,
+            funding_rate,
+            tx_fee_rate,
+        );
+
+        // TODO: If this fails we shouldn't try to append
+        // `ContractSetupFailed` to the nonexistent CFD
+        self.db.insert_cfd(&cfd).await?;
+
+        self.projection
+            .send_async_safe(projection::CfdChanged(cfd.id()))
+            .await?;
+
+        let (sender, receiver) = oneshot::channel();
+        self.decision_senders.insert(id, sender);
+
+        let task = {
+            let build_party_params = self.build_party_params.clone_channel();
+            let sign = self.sign.clone_channel();
+            let get_announcement = self.get_announcement.clone_channel();
+            let executor = self.executor.clone();
+            let oracle_pk = self.oracle_pk;
+            let n_payouts = self.n_payouts;
+            async move {
+                match receiver.await? {
+                    protocol::Decision::Accept => {
+                        framed
+                            .send(MakerMessage::Decision(protocol::Decision::Accept))
+                            .await?;
+
+                        tracing::info!(taker = %peer, %contracts, order_id = %id, "Order accepted");
+                    }
+                    protocol::Decision::Reject => {
+                        framed
+                            .send(MakerMessage::Decision(protocol::Decision::Reject))
+                            .await?;
+
+                        tracing::info!(taker = %peer, %contracts, order_id = %id, "Order rejected");
+
+                        executor
+                            .execute(id, |cfd| {
+                                cfd.reject_contract_setup(anyhow::anyhow!("Unknown"))
+                            })
+                            .await?;
+
+                        return anyhow::Ok(());
+                    }
+                }
+
+                let (setup_params, position) = executor
+                    .execute(id, |cfd| cfd.start_contract_setup())
+                    .await?;
+
+                let (sink, stream) = framed.split();
+
+                let announcement = get_announcement
+                    .send(oracle::GetAnnouncement(oracle_event_id))
+                    .await??;
+
+                let dlc = setup_contract::new(
+                    sink.with(|msg| future::ok(MakerMessage::ContractSetupMsg(Box::new(msg)))),
+                    Box::pin(stream.filter_map(|msg| async move {
+                        let msg = match msg {
+                            Ok(msg) => msg,
+                            Err(e) => {
+                                tracing::error!("Failed to deserialize MakerMessage: {e:#}");
+                                return None;
+                            }
+                        };
+
+                        match SetupMsg::try_from(msg) {
+                            Ok(msg) => Some(msg),
+                            Err(e) => {
+                                tracing::error!("Failed to convert to SetupMsg: {e:#}");
+                                None
+                            }
+                        }
+                    }))
+                    .fuse(),
+                    (oracle_pk, announcement),
+                    setup_params,
+                    build_party_params,
+                    sign,
+                    Role::Maker,
+                    position,
+                    n_payouts,
+                )
+                .await?;
+
+                if let Err(e) = executor
+                    .execute(id, |cfd| cfd.complete_contract_setup(dlc))
+                    .await
+                {
+                    tracing::error!(%id, "Failed to execute contract_setup_completed: {e:#}");
+                }
+
+                anyhow::Ok(())
+            }
+        };
+
+        let err_handler = {
+            let executor = self.executor.clone();
+            move |e| async move {
+                if let Err(e) = executor
+                    .execute(id, |cfd| Ok(cfd.fail_contract_setup(e)))
+                    .await
+                {
+                    tracing::error!(%id, "Failed to execute fail_contract_setup: {e:#}");
+                }
+            }
+        };
+
+        if let Err(e) = self
+            .spawner
+            .send_async_safe(SpawnFallible::new(task, err_handler))
+            .await
+        {
+            tracing::error!("Failed to spawn task to take order: {e:#}");
+        }
+
+        Ok(())
+    }
+}
+
+#[xtra_productivity(message_impl = false)]
+impl Actor {
+    async fn handle(&mut self, msg: NewInboundSubstream) {
+        if let Err(e) = self.handle_new_inbound_stream(msg).await {
+            tracing::error!("Failed to handle new inbound substream: {e:#}");
+        }
+    }
+}
+
+#[xtra_productivity]
+impl Actor {
+    async fn handle(&mut self, msg: Decision) -> Result<()> {
+        let id = msg.id();
+
+        tracing::debug!("Instructed to {msg} order {id}");
+
+        let sender = self
+            .decision_senders
+            .remove(&id)
+            .context("Can't make decision on nonexistent order {id}")?;
+
+        sender
+            .send(msg.into())
+            .map_err(|_| anyhow!("Can't deliver decision on taking order {id}"))?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum Decision {
+    Accept(OrderId),
+    Reject(OrderId),
+}
+
+impl Decision {
+    fn id(&self) -> OrderId {
+        match self {
+            Decision::Accept(id) | Decision::Reject(id) => *id,
+        }
+    }
+}
+
+impl From<Decision> for protocol::Decision {
+    fn from(decision: Decision) -> Self {
+        match decision {
+            Decision::Accept(_) => protocol::Decision::Accept,
+            Decision::Reject(_) => protocol::Decision::Reject,
+        }
+    }
+}
+
+impl fmt::Display for Decision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Decision::Accept(_) => "accept",
+            Decision::Reject(_) => "reject",
+        };
+
+        s.fmt(f)
+    }
+}
+
+#[async_trait]
+impl xtra::Actor for Actor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}

--- a/daemon/src/order/protocol.rs
+++ b/daemon/src/order/protocol.rs
@@ -1,0 +1,66 @@
+use crate::wire::SetupMsg;
+use anyhow::bail;
+use anyhow::Result;
+use model::olivia::BitMexPriceEventId;
+use model::Contracts;
+use model::FundingRate;
+use model::Leverage;
+use model::OpeningFee;
+use model::OrderId;
+use model::Position;
+use model::Price;
+use model::TxFeeRate;
+use serde::Deserialize;
+use serde::Serialize;
+use time::Duration;
+
+#[derive(Serialize, Deserialize)]
+pub(crate) enum TakerMessage {
+    PlaceOrder {
+        id: OrderId,
+        contracts: Contracts,
+        leverage: Leverage,
+        position: Position,
+        opening_price: Price,
+        settlement_interval: Duration,
+        opening_fee: OpeningFee,
+        funding_rate: FundingRate,
+        tx_fee_rate: TxFeeRate,
+        oracle_event_id: BitMexPriceEventId,
+    },
+    ContractSetupMsg(Box<SetupMsg>),
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) enum MakerMessage {
+    Decision(Decision),
+    ContractSetupMsg(Box<SetupMsg>),
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) enum Decision {
+    Accept,
+    Reject,
+}
+
+impl TryFrom<MakerMessage> for SetupMsg {
+    type Error = anyhow::Error;
+
+    fn try_from(value: MakerMessage) -> Result<Self> {
+        match value {
+            MakerMessage::Decision(_) => bail!("Expected SetupMsg, got decision"),
+            MakerMessage::ContractSetupMsg(msg) => Ok(*msg),
+        }
+    }
+}
+
+impl TryFrom<TakerMessage> for SetupMsg {
+    type Error = anyhow::Error;
+
+    fn try_from(value: TakerMessage) -> Result<Self> {
+        match value {
+            TakerMessage::PlaceOrder { .. } => bail!("Expected SetupMsg, got order placement"),
+            TakerMessage::ContractSetupMsg(msg) => Ok(*msg),
+        }
+    }
+}

--- a/daemon/src/order/taker.rs
+++ b/daemon/src/order/taker.rs
@@ -1,0 +1,305 @@
+use crate::command;
+use crate::oracle;
+use crate::order::protocol::Decision;
+use crate::order::protocol::MakerMessage;
+use crate::order::protocol::TakerMessage;
+use crate::order::PROTOCOL_NAME;
+use crate::process_manager;
+use crate::projection;
+use crate::setup_contract;
+use crate::wallet;
+use crate::wire::SetupMsg;
+use anyhow::bail;
+use anyhow::Context;
+use async_trait::async_trait;
+use asynchronous_codec::Framed;
+use asynchronous_codec::JsonCodec;
+use futures::future;
+use futures::SinkExt;
+use futures::StreamExt;
+use libp2p_core::PeerId;
+use maia_core::secp256k1_zkp::schnorrsig;
+use model::olivia::BitMexPriceEventId;
+use model::Cfd;
+use model::Contracts;
+use model::FundingRate;
+use model::Identity;
+use model::Leverage;
+use model::OpeningFee;
+use model::OrderId;
+use model::Position;
+use model::Price;
+use model::Role;
+use model::TxFeeRate;
+use model::Usd;
+use rust_decimal::Decimal;
+use time::Duration;
+use xtra::prelude::MessageChannel;
+use xtra::spawn::TokioGlobalSpawnExt;
+use xtra::Actor as _;
+use xtra_libp2p::Endpoint;
+use xtra_libp2p::OpenSubstream;
+use xtra_productivity::xtra_productivity;
+use xtras::spawner;
+use xtras::spawner::SpawnFallible;
+use xtras::SendAsyncSafe;
+
+pub struct Actor {
+    endpoint: xtra::Address<Endpoint>,
+    executor: command::Executor,
+    oracle_pk: schnorrsig::PublicKey,
+    get_announcement: Box<dyn MessageChannel<oracle::GetAnnouncement>>,
+    build_party_params: Box<dyn MessageChannel<wallet::BuildPartyParams> + 'static>,
+    sign: Box<dyn MessageChannel<wallet::Sign> + 'static>,
+    projection: xtra::Address<projection::Actor>,
+    n_payouts: usize,
+    db: sqlite_db::Connection,
+    spawner: xtra::Address<spawner::Actor>,
+}
+
+impl Actor {
+    pub fn new(
+        n_payouts: usize,
+        oracle_pk: schnorrsig::PublicKey,
+        get_announcement: &(impl MessageChannel<oracle::GetAnnouncement> + 'static),
+        (db, process_manager): (sqlite_db::Connection, xtra::Address<process_manager::Actor>),
+        (build_party_params, sign): (
+            &(impl MessageChannel<wallet::BuildPartyParams> + 'static),
+            &(impl MessageChannel<wallet::Sign> + 'static),
+        ),
+        projection: xtra::Address<projection::Actor>,
+        endpoint: xtra::Address<Endpoint>,
+    ) -> Self {
+        let spawner = spawner::Actor::new().create(None).spawn_global();
+
+        Self {
+            endpoint,
+            executor: command::Executor::new(db.clone(), process_manager),
+            oracle_pk,
+            get_announcement: get_announcement.clone_channel(),
+            build_party_params: build_party_params.clone_channel(),
+            sign: sign.clone_channel(),
+            projection,
+            n_payouts,
+            db,
+            spawner,
+        }
+    }
+}
+
+#[xtra_productivity]
+impl Actor {
+    pub async fn handle(&mut self, msg: PlaceOrder) {
+        let id = msg.id;
+
+        let task = {
+            let build_party_params = self.build_party_params.clone_channel();
+            let sign = self.sign.clone_channel();
+            let get_announcement = self.get_announcement.clone_channel();
+            let endpoint = self.endpoint.clone();
+            let executor = self.executor.clone();
+            let db = self.db.clone();
+            let oracle_pk = self.oracle_pk;
+            let n_payouts = self.n_payouts;
+            let projection = self.projection.clone();
+            async move {
+                tracing::info!(order = ?msg, "Placing order");
+
+                let PlaceOrder {
+                    id,
+                    contracts,
+                    leverage,
+                    position,
+                    opening_price,
+                    settlement_interval,
+                    opening_fee,
+                    funding_rate,
+                    tx_fee_rate,
+                    oracle_event_id,
+                    maker_peer_id: maker,
+                } = msg;
+
+                let cfd = Cfd::new(
+                    id,
+                    position.counter_position(),
+                    opening_price,
+                    leverage,
+                    settlement_interval,
+                    Role::Taker,
+                    Usd::new(Decimal::from(u64::from(contracts))),
+                    // Completely irrelevant when using libp2p
+                    Identity::new(x25519_dalek::PublicKey::from(
+                        *b"hello world, oh what a beautiful",
+                    )),
+                    Some(maker.into()),
+                    opening_fee,
+                    funding_rate,
+                    tx_fee_rate,
+                );
+
+                // TODO: If this fails we shouldn't try to append
+                // `ContractSetupFailed` to the nonexistent CFD
+                db.insert_cfd(&cfd).await?;
+
+                projection.send(projection::CfdChanged(cfd.id())).await?;
+
+                let stream = endpoint
+                    .send(OpenSubstream::single_protocol(maker, PROTOCOL_NAME))
+                    .await??;
+
+                let mut framed =
+                    Framed::new(stream, JsonCodec::<TakerMessage, MakerMessage>::new());
+
+                framed
+                    .send(TakerMessage::PlaceOrder {
+                        id,
+                        contracts,
+                        leverage,
+                        position,
+                        opening_price,
+                        settlement_interval,
+                        opening_fee,
+                        funding_rate,
+                        tx_fee_rate,
+                        oracle_event_id,
+                    })
+                    .await?;
+
+                match framed.next().await.context("Stream terminated")?? {
+                    MakerMessage::Decision(Decision::Accept) => {
+                        tracing::info!(order_id = %msg.id, peer = %maker, "Order accepted");
+                    }
+                    MakerMessage::Decision(Decision::Reject) => {
+                        tracing::info!(order_id = %msg.id, peer = %maker, "Order rejected");
+
+                        executor
+                            .execute(id, |cfd| {
+                                cfd.reject_contract_setup(anyhow::anyhow!("Unknown"))
+                            })
+                            .await?;
+
+                        return anyhow::Ok(());
+                    }
+                    MakerMessage::ContractSetupMsg(_) => bail!("Unexpected message"),
+                };
+
+                let (setup_params, position) = executor
+                    .execute(id, |cfd| cfd.start_contract_setup())
+                    .await?;
+
+                let (sink, stream) = framed.split();
+
+                let announcement = get_announcement
+                    .send(oracle::GetAnnouncement(oracle_event_id))
+                    .await??;
+
+                let dlc = setup_contract::new(
+                    sink.with(|msg| future::ok(TakerMessage::ContractSetupMsg(Box::new(msg)))),
+                    Box::pin(stream.filter_map(|msg| async move {
+                        let msg = match msg {
+                            Ok(msg) => msg,
+                            Err(e) => {
+                                tracing::error!("Failed to deserialize MakerMessage: {e:#}");
+                                return None;
+                            }
+                        };
+
+                        match SetupMsg::try_from(msg) {
+                            Ok(msg) => Some(msg),
+                            Err(e) => {
+                                tracing::error!("Failed to convert to SetupMsg: {e:#}");
+                                None
+                            }
+                        }
+                    }))
+                    .fuse(),
+                    (oracle_pk, announcement),
+                    setup_params,
+                    build_party_params,
+                    sign,
+                    Role::Taker,
+                    position,
+                    n_payouts,
+                )
+                .await?;
+
+                if let Err(e) = executor
+                    .execute(id, |cfd| cfd.complete_contract_setup(dlc))
+                    .await
+                {
+                    tracing::error!(%id, "Failed to execute contract_setup_completed: {e:#}");
+                }
+
+                anyhow::Ok(())
+            }
+        };
+
+        let err_handler = {
+            let executor = self.executor.clone();
+            move |e| async move {
+                if let Err(e) = executor
+                    .execute(id, |cfd| Ok(cfd.fail_contract_setup(e)))
+                    .await
+                {
+                    tracing::error!(%id, "Failed to execute fail_contract_setup: {e:#}");
+                }
+            }
+        };
+
+        if let Err(e) = self
+            .spawner
+            .send_async_safe(SpawnFallible::new(task, err_handler))
+            .await
+        {
+            tracing::error!("Failed to spawn task to take order: {e:#}");
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PlaceOrder {
+    id: OrderId,
+    contracts: Contracts,
+    leverage: Leverage,
+    position: Position,
+    opening_price: Price,
+    settlement_interval: Duration,
+    opening_fee: OpeningFee,
+    funding_rate: FundingRate,
+    tx_fee_rate: TxFeeRate,
+    oracle_event_id: BitMexPriceEventId,
+    maker_peer_id: PeerId,
+}
+
+impl PlaceOrder {
+    pub(crate) fn new(
+        id: OrderId,
+        (contracts, leverage, position): (Contracts, Leverage, Position),
+        opening_price: Price,
+        settlement_interval: Duration,
+        (opening_fee, funding_rate, tx_fee_rate): (OpeningFee, FundingRate, TxFeeRate),
+        oracle_event_id: BitMexPriceEventId,
+        maker_peer_id: PeerId,
+    ) -> Self {
+        Self {
+            id,
+            contracts,
+            leverage,
+            position,
+            opening_price,
+            settlement_interval,
+            opening_fee,
+            funding_rate,
+            tx_fee_rate,
+            oracle_event_id,
+            maker_peer_id,
+        }
+    }
+}
+
+#[async_trait]
+impl xtra::Actor for Actor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -1,41 +1,33 @@
 use crate::collab_settlement;
 use crate::collab_settlement::taker::Settle;
-use crate::connection;
-use crate::oracle;
-use crate::process_manager;
+use crate::order;
 use crate::projection;
-use crate::setup_taker;
-use crate::wallet;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use async_trait::async_trait;
-use bdk::bitcoin::secp256k1::schnorrsig;
 use model::libp2p::PeerId;
 use model::market_closing_price;
 use model::Cfd;
-use model::Identity;
+use model::Contracts;
 use model::Leverage;
 use model::MakerOffers;
 use model::OrderId;
 use model::Origin;
 use model::Price;
 use model::Role;
-use model::Usd;
 use sqlite_db;
 use time::OffsetDateTime;
-use tokio_tasks::Tasks;
-use xtra::Actor as _;
 use xtra_productivity::xtra_productivity;
-use xtras::AddressMap;
+use xtras::SendAsyncSafe;
 
 #[derive(Clone)]
 pub struct CurrentMakerOffers(pub Option<MakerOffers>);
 
 #[derive(Clone, Copy)]
-pub struct TakeOffer {
-    pub order_id: OrderId,
-    pub quantity: Usd,
+pub struct PlaceOrder {
+    pub offer_id: OrderId,
+    pub contracts: Contracts,
     pub leverage: Leverage,
 }
 
@@ -47,62 +39,37 @@ pub struct ProposeSettlement {
     pub quote_timestamp: String,
 }
 
-pub struct Actor<O, W> {
+pub struct Actor {
     db: sqlite_db::Connection,
-    wallet: xtra::Address<W>,
-    oracle_pk: schnorrsig::PublicKey,
     projection_actor: xtra::Address<projection::Actor>,
-    process_manager_actor: xtra::Address<process_manager::Actor>,
-    conn_actor: xtra::Address<connection::Actor>,
-    setup_actors: AddressMap<OrderId, setup_taker::Actor>,
     libp2p_collab_settlement_actor: xtra::Address<collab_settlement::taker::Actor>,
-    oracle_actor: xtra::Address<O>,
-    n_payouts: usize,
-    tasks: Tasks,
+    order_actor: xtra::Address<order::taker::Actor>,
     current_maker_offers: Option<MakerOffers>,
-    maker_identity: Identity,
     maker_peer_id: PeerId,
 }
 
-impl<O, W> Actor<O, W>
-where
-    W: xtra::Handler<wallet::Sign> + xtra::Handler<wallet::BuildPartyParams>,
-{
+impl Actor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         db: sqlite_db::Connection,
-        wallet: xtra::Address<W>,
-        oracle_pk: schnorrsig::PublicKey,
         projection_actor: xtra::Address<projection::Actor>,
-        process_manager_actor: xtra::Address<process_manager::Actor>,
-        conn_actor: xtra::Address<connection::Actor>,
-        oracle_actor: xtra::Address<O>,
         libp2p_collab_settlement_actor: xtra::Address<collab_settlement::taker::Actor>,
-        n_payouts: usize,
-        maker_identity: Identity,
+        order_actor: xtra::Address<order::taker::Actor>,
         maker_peer_id: PeerId,
     ) -> Self {
         Self {
             db,
-            wallet,
-            oracle_pk,
             projection_actor,
-            process_manager_actor,
-            conn_actor,
-            oracle_actor,
             libp2p_collab_settlement_actor,
-            n_payouts,
-            setup_actors: AddressMap::default(),
-            tasks: Tasks::default(),
+            order_actor,
             current_maker_offers: None,
-            maker_identity,
             maker_peer_id,
         }
     }
 }
 
 #[xtra_productivity(message_impl = false)]
-impl<O, W> Actor<O, W> {
+impl Actor {
     async fn handle_current_offers(&mut self, msg: xtra_libp2p_offer::taker::LatestMakerOffers) {
         let takers_perspective_of_maker_offers = msg.0.map(|mut maker_offers| {
             maker_offers.long = maker_offers.long.map(|mut long| {
@@ -133,7 +100,7 @@ impl<O, W> Actor<O, W> {
 }
 
 #[xtra_productivity]
-impl<O, W> Actor<O, W> {
+impl Actor {
     async fn handle_propose_settlement(&mut self, msg: ProposeSettlement) -> Result<()> {
         let ProposeSettlement {
             order_id,
@@ -164,98 +131,52 @@ impl<O, W> Actor<O, W> {
 }
 
 #[xtra_productivity]
-impl<O, W> Actor<O, W>
-where
-    O: xtra::Handler<oracle::GetAnnouncement> + xtra::Handler<oracle::MonitorAttestation>,
-    W: xtra::Handler<wallet::BuildPartyParams> + xtra::Handler<wallet::Sign>,
-{
-    async fn handle_take_offer(&mut self, msg: TakeOffer) -> Result<()> {
-        let TakeOffer {
-            order_id,
-            quantity,
+impl Actor {
+    async fn handle(&mut self, msg: PlaceOrder) -> Result<OrderId> {
+        let PlaceOrder {
+            offer_id,
+            contracts,
             leverage,
         } = msg;
 
-        let disconnected = self
-            .setup_actors
-            .get_disconnected(order_id)
-            .with_context(|| {
-                format!("Contract setup for order {order_id} is already in progress")
-            })?;
-
-        let (order_to_take, maker_offers) = self
+        let offer = self
             .current_maker_offers
             .clone()
             .context("No maker offers available to take")?
-            .take_order(order_id);
+            .take_order(offer_id)
+            .0
+            .context("Offer to take could not be found in current maker offers, you might have an outdated offer")?;
 
-        let order_to_take = order_to_take.context("Order to take could not be found in current maker offers, you might have an outdated offer")?;
-
-        // The offer we are instructed to take is removed from the
-        // set of available offers immediately so that we don't attempt
-        // to take it more than once
-        {
-            self.current_maker_offers.replace(maker_offers);
-            self.projection_actor
-                .send(projection::Update(self.current_maker_offers.clone()))
-                .await?;
+        // TODO: Consider removing this. Why can't we just place the
+        // order we want, if it's the want we selected in the UI? The
+        // maker should simply reject our request to place an order if
+        // it's outdated
+        if !offer.is_safe_to_take(OffsetDateTime::now_utc()) {
+            bail!("The maker's offer appears to be outdated, refusing to place order");
         }
 
-        if !order_to_take.is_safe_to_take(OffsetDateTime::now_utc()) {
-            bail!("The maker's offer appears to be outdated, refusing to take offer",);
-        }
-
-        tracing::info!("Taking current order: {:?}", &order_to_take);
-
-        // We create the cfd here without any events yet, only static data
-        // Once the contract setup completes (rejected / accepted / failed) the first event will be
-        // recorded
-        let cfd = Cfd::from_order(
-            &order_to_take,
-            quantity,
-            self.maker_identity,
-            Some(self.maker_peer_id),
-            Role::Taker,
-            leverage,
+        let order_id = OrderId::default();
+        let place_order = order::taker::PlaceOrder::new(
+            order_id,
+            (contracts, leverage, offer.position_maker.counter_position()),
+            offer.price,
+            offer.settlement_interval,
+            (offer.opening_fee, offer.funding_rate, offer.tx_fee_rate),
+            offer.oracle_event_id,
+            self.maker_peer_id.inner(),
         );
 
-        self.db.insert_cfd(&cfd).await?;
-        self.projection_actor
-            .send(projection::CfdChanged(cfd.id()))
-            .await?;
+        self.order_actor
+            .send_async_safe(place_order)
+            .await
+            .context("Failed to place order")?;
 
-        let price_event_id = order_to_take.oracle_event_id;
-        let announcement = self
-            .oracle_actor
-            .send(oracle::GetAnnouncement(price_event_id))
-            .await?
-            .with_context(|| format!("Announcement {price_event_id} not found"))?;
-
-        let addr = setup_taker::Actor::new(
-            self.db.clone(),
-            self.process_manager_actor.clone(),
-            (
-                cfd.id(),
-                cfd.quantity(),
-                cfd.taker_leverage(),
-                self.n_payouts,
-            ),
-            (self.oracle_pk, announcement),
-            &self.wallet,
-            &self.wallet,
-            self.conn_actor.clone(),
-        )
-        .create(None)
-        .spawn(&mut self.tasks);
-
-        disconnected.insert(addr);
-
-        Ok(())
+        Ok(order_id)
     }
 }
 
 #[async_trait]
-impl<O: 'static, W: 'static> xtra::Actor for Actor<O, W> {
+impl xtra::Actor for Actor {
     type Stop = ();
 
     async fn stopped(self) -> Self::Stop {}

--- a/model/src/contract_setup.rs
+++ b/model/src/contract_setup.rs
@@ -7,7 +7,7 @@ use crate::Usd;
 use anyhow::Result;
 use bdk::bitcoin::Amount;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct SetupParams {
     pub margin: Amount,
     pub counterparty_margin: Amount,

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1016,6 +1016,12 @@ impl From<&Contracts> for i64 {
     }
 }
 
+impl fmt::Display for Contracts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl_sqlx_type_integer!(Contracts);
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -985,7 +985,7 @@ impl From<&Fees> for i64 {
 impl_sqlx_type_integer!(Fees);
 
 /// The number of contracts per position.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Contracts(u64);
 
 impl Contracts {

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -381,7 +381,6 @@ async fn main() -> Result<()> {
         HEARTBEAT_INTERVAL,
         Duration::from_secs(10),
         projection_actor.clone(),
-        Identity::new(maker_id),
         maker_multiaddr,
         environment,
     )?;

--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -12,6 +12,7 @@ use daemon::wallet;
 use daemon::TakerActorSystem;
 use http_api_problem::HttpApiProblem;
 use http_api_problem::StatusCode;
+use model::Contracts;
 use model::Leverage;
 use model::OrderId;
 use model::Price;
@@ -143,7 +144,7 @@ impl Heartbeat {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CfdOrderRequest {
     pub order_id: OrderId,
-    pub quantity: Usd,
+    pub contracts: Contracts,
     pub leverage: Leverage,
 }
 
@@ -154,9 +155,9 @@ pub async fn post_order_request(
     _auth: Authenticated,
 ) -> Result<(), HttpApiProblem> {
     taker
-        .take_offer(
+        .place_order(
             cfd_order_request.order_id,
-            cfd_order_request.quantity,
+            cfd_order_request.contracts,
             cfd_order_request.leverage,
         )
         .await


### PR DESCRIPTION
- The key test `taker_takes_order_and_maker_accepts_and_contract_setup` passes. Adapting the rest of the actor tests should be trivial.

- I am not sold at all on using an internal channel over handling the decision at the actor level on the maker. The current design was motivated by the possibility of testing the protocol in isolation, but it's basically impossible given all the coupling with actors in
`daemon`.

- The file `taker_cfd.rs` is not very clean. Conversely, `maker_cfd.rs` gets more complicated because we have to support the
legacy connection for a while longer. The logic there is to first try to accept/reject using the new protocol and if it fails attempt it
over the legacy connection. This is very stupid, but I would rather do something stupid rather than trying to differentiate between different types of CFDs.

- You can see that the new design follows the proposal in https://github.com/itchysats/itchysats/issues/1770. This means that
the taker now generates an `OrderId` when _placing_ the order. We currently reuse the same type for the offer (legacy) and the taker's order, which is a bit confusing (but hard to avoid, because our model wants an `OrderId`). With the new protocol the taker ignores the `OrderId` associated with the offer, but we have to keep it around for legacy connections.