### PR TITLE
No refund-tx if CET was confirmed

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -474,6 +474,12 @@ impl Cfd {
                 self.aggregated.state = CfdState::OpenCommitted;
             }
             CetConfirmed => {
+                // Needed for cases where CET gets priority over refund in case the refund timelock
+                // is already expired. If the CET is confirmed we have to ensure the
+                // refund-tx is not set, otherwise the UI will show the refund-tx.
+                self.aggregated.refund_tx = None;
+                self.aggregated.refund_published = false;
+
                 self.aggregated.state = CfdState::Closed;
             }
             RefundConfirmed => {


### PR DESCRIPTION
fixes https://github.com/itchysats/itchysats/issues/2168

It can happen that upon startup of the application that the refund timelock is already expired, but we publish the CET and not refund.
This is because the CET has priority over refund even if the refund timelock is already expired.
In `RefundTimelockExpired` we cannot know if the CET was confirmed or not (becuase this is a later state).
We opt for setting `refund_tx` to `None` and `refund_published` to `false` to ensure we do not wrongly show the refund-tx in the user interface if the CET was confirmed on chain.

---

I am not super happy about this, but I did not find a better solution for now. Not setting the refund tx in case we have a CET available might have weird side effects. 
The projection should be refactored to be more driven by the state on chain. If we have a spend transaction confirmed on chain there is not point in arguing about other events! But this is a bigger changes.