### PR TITLE
xtras: Panic if send_interval fails

### DIFF
--- a/xtras/src/send_interval.rs
+++ b/xtras/src/send_interval.rs
@@ -37,8 +37,6 @@ where
         }
         let type_name = std::any::type_name::<M>();
 
-        tracing::warn!(
-            "Task for periodically sending message {type_name} stopped because actor shut down"
-        );
+        panic!("Task for periodically sending message {type_name} stopped because actor shut down");
     }
 }


### PR DESCRIPTION
We rely on SendInterval trait to send periodic messages for the whole lifetime
of an actor. If for whatever reason we stop sending periodic messages, we should
panic to trigger spawning a new instance. Otherwise, we risk at continuing
running the actor that *appears* to work on the surface level, but in reality
some of its functionality is crippled.

Note for the reviewers: This will only be merged when I update all the actors to be supervised
(submitting a draft early to get feedback)