### PR TITLE
Use file-based db for wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Migrate away from JSON blobs in the DB to a more normalized database for RolloverCompleted events
+- Use sled database for wallet. The wallet file is stored in your data-dir as either `maker-wallet` for the maker and `taker-wallet` for the taker respectively
 
 ## [0.4.20] - 2022-05-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "bdk",
  "rand 0.6.5",
  "secp256k1",
+ "tempfile",
 ]
 
 [[package]]
@@ -1090,6 +1091,15 @@ name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "figment"
@@ -4327,13 +4337,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",

--- a/bdk-ext/Cargo.toml
+++ b/bdk-ext/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.18", default-features = false }
+bdk = { version = "0.18", default-features = false, features = ["key-value-db"] }
 rand = "0.6"
 secp256k1 = { version = "0.20", features = ["rand", "global-context-less-secure"] }
+tempfile = "3.3.0"

--- a/bdk-ext/src/lib.rs
+++ b/bdk-ext/src/lib.rs
@@ -6,6 +6,7 @@ use bdk::bitcoin::secp256k1::SECP256K1;
 use bdk::bitcoin::util::bip32::ExtendedPrivKey;
 use bdk::bitcoin::Amount;
 use bdk::bitcoin::Network;
+use bdk::sled;
 use rand::CryptoRng;
 use rand::RngCore;
 
@@ -15,7 +16,7 @@ pub fn new_test_wallet(
     rng: &mut (impl RngCore + CryptoRng),
     utxo_amount: Amount,
     num_utxos: u8,
-) -> Result<bdk::Wallet<bdk::database::MemoryDatabase>> {
+) -> Result<bdk::Wallet<sled::Tree>> {
     use bdk::populate_test_db;
     use bdk::testutils;
 
@@ -25,7 +26,10 @@ pub fn new_test_wallet(
     let key = ExtendedPrivKey::new_master(Network::Regtest, &seed)?;
     let descriptors = testutils!(@descriptors (&format!("wpkh({key}/*)")));
 
-    let mut database = bdk::database::MemoryDatabase::new();
+    let wallet_dir = tempfile::tempdir()?;
+
+    let database = sled::open(wallet_dir.path())?;
+    let mut database = database.open_tree("tmp")?;
 
     for index in 0..num_utxos {
         populate_test_db!(

--- a/bdk-ext/src/lib.rs
+++ b/bdk-ext/src/lib.rs
@@ -6,7 +6,6 @@ use bdk::bitcoin::secp256k1::SECP256K1;
 use bdk::bitcoin::util::bip32::ExtendedPrivKey;
 use bdk::bitcoin::Amount;
 use bdk::bitcoin::Network;
-use bdk::sled;
 use rand::CryptoRng;
 use rand::RngCore;
 
@@ -16,7 +15,7 @@ pub fn new_test_wallet(
     rng: &mut (impl RngCore + CryptoRng),
     utxo_amount: Amount,
     num_utxos: u8,
-) -> Result<bdk::Wallet<sled::Tree>> {
+) -> Result<bdk::Wallet<bdk::database::MemoryDatabase>> {
     use bdk::populate_test_db;
     use bdk::testutils;
 
@@ -26,10 +25,7 @@ pub fn new_test_wallet(
     let key = ExtendedPrivKey::new_master(Network::Regtest, &seed)?;
     let descriptors = testutils!(@descriptors (&format!("wpkh({key}/*)")));
 
-    let wallet_dir = tempfile::tempdir()?;
-
-    let database = sled::open(wallet_dir.path())?;
-    let mut database = database.open_tree("tmp")?;
+    let mut database = bdk::database::MemoryDatabase::new();
 
     for index in 0..num_utxos {
         populate_test_db!(

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 async-stream = "0.3"
 async-trait = "0.1.56"
 asynchronous-codec = { version = "0.6.0", features = ["json"] }
-bdk = { version = "0.18", default-features = false, features = ["electrum"] }
+bdk = { version = "0.18", default-features = false, features = ["key-value-db"] }
 bdk-ext = { path = "../bdk-ext" }
 btsieve = { path = "../btsieve" }
 bytes = "1"

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -294,15 +294,6 @@ impl xtra::Actor for Actor<ElectrumBlockchain> {
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("self to be alive");
 
-        // We only cache the addresses at startup
-        if let Err(e) = self
-            .wallet
-            .ensure_addresses_cached(1000)
-            .with_context(|| "Could not cache addresses")
-        {
-            tracing::warn!("{:#}", e);
-        }
-
         self.tasks.add(this.send_interval(SYNC_INTERVAL, || Sync));
     }
 

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -9,6 +9,7 @@ use daemon::projection;
 use daemon::seed::RandomSeed;
 use daemon::seed::Seed;
 use daemon::wallet;
+use daemon::wallet::MAKER_WALLET_ID;
 use daemon::HEARTBEAT_INTERVAL;
 use daemon::N_PAYOUTS;
 use maker::routes;
@@ -65,7 +66,15 @@ async fn main() -> Result<()> {
 
     let mut tasks = Tasks::default();
 
-    let (wallet, wallet_feed_receiver) = wallet::Actor::new(opts.network.electrum(), ext_priv_key)?;
+    let mut wallet_dir = data_dir.clone();
+
+    wallet_dir.push(MAKER_WALLET_ID);
+    let (wallet, wallet_feed_receiver) = wallet::Actor::new(
+        opts.network.electrum(),
+        ext_priv_key,
+        wallet_dir,
+        MAKER_WALLET_ID.to_string(),
+    )?;
 
     let wallet = wallet.create(None).spawn(&mut tasks);
 

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -1,5 +1,6 @@
 use crate::actor_system::ActorSystem;
 use anyhow::Result;
+use bdk::sled;
 use daemon::bdk::blockchain::ElectrumBlockchain;
 use daemon::oracle;
 use daemon::projection::Cfd;
@@ -35,7 +36,7 @@ use tokio::select;
 use tokio::sync::watch;
 use uuid::Uuid;
 
-pub type Maker = ActorSystem<oracle::Actor, wallet::Actor<ElectrumBlockchain>>;
+pub type Maker = ActorSystem<oracle::Actor, wallet::Actor<ElectrumBlockchain, sled::Tree>>;
 
 #[allow(clippy::too_many_arguments)]
 #[rocket::get("/feed")]

--- a/shared-bin/src/logger.rs
+++ b/shared-bin/src/logger.rs
@@ -34,7 +34,8 @@ pub fn init(level: LevelFilter, json_format: bool) -> Result<()> {
         .add_directive("bdk::wallet=off".parse()?) // bdk logs derivation of addresses on INFO
         .add_directive("_=off".parse()?) // rocket logs headers on INFO and uses `_` as the log target for it?
         .add_directive("rocket=off".parse()?) // disable rocket logs: we have our own
-        .add_directive("xtra=warn".parse()?);
+        .add_directive("xtra=warn".parse()?)
+        .add_directive("sled=warn".parse()?); // downgrade sled log level: it is spamming too much on DEBUG
 
     let builder = tracing_subscriber::fmt()
         .with_env_filter(filter)

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -18,6 +18,7 @@ use daemon::seed::RandomSeed;
 use daemon::seed::Seed;
 use daemon::seed::UmbrelSeed;
 use daemon::wallet;
+use daemon::wallet::TAKER_WALLET_ID;
 use daemon::Environment;
 use daemon::TakerActorSystem;
 use daemon::HEARTBEAT_INTERVAL;
@@ -299,7 +300,14 @@ async fn main() -> Result<()> {
 
     let mut tasks = Tasks::default();
 
-    let (wallet, wallet_feed_receiver) = wallet::Actor::new(network.electrum(), ext_priv_key)?;
+    let mut wallet_dir = data_dir.clone();
+    wallet_dir.push(TAKER_WALLET_ID);
+    let (wallet, wallet_feed_receiver) = wallet::Actor::new(
+        network.electrum(),
+        ext_priv_key,
+        wallet_dir,
+        TAKER_WALLET_ID.to_string(),
+    )?;
 
     let wallet = wallet.create(None).spawn(&mut tasks);
 

--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -2,6 +2,7 @@ use daemon::bdk;
 use daemon::bdk::bitcoin::Amount;
 use daemon::bdk::bitcoin::Network;
 use daemon::bdk::blockchain::ElectrumBlockchain;
+use daemon::bdk::sled;
 use daemon::connection::ConnectionStatus;
 use daemon::oracle;
 use daemon::projection;
@@ -38,7 +39,7 @@ use uuid::Uuid;
 
 type Taker = TakerActorSystem<
     oracle::Actor,
-    wallet::Actor<ElectrumBlockchain>,
+    wallet::Actor<ElectrumBlockchain, sled::Tree>,
     xtra_bitmex_price_feed::Actor,
 >;
 


### PR DESCRIPTION
This will improve performance because
- we don't have to generate the addresses on every restart, we can just read them from the db
- we don't have to generate 1000 addresses after are restart to miss unspent addresses: if the wallet db grows naturally, i.e. all addresses are cached, we don't have to pre-cache addresses
- we use less memory as we don't have to store the whole db in memory: particularly when having 1000s spent addresses this is a significant amount of data
- sync is faster because we don't have re-fetch the whole raw tx which is stored in the db

Note: if you have used the daemon for some time in the past the first restart can be scary because it will not immediately fetch all addresses. It will take some time until the wallet has caught up because we only sync for 100 addresses at a time.

Fixes #2158 

Note 2: this depends on a bdk fork "https://github.com/coblox/bdk", branch = "sqlite-version-bumps"  because of incompatible dependency versions. I'll see to contribute this upstream
