### PR TITLE
Add timeout on the TCP socket in the maker

### DIFF
--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -35,6 +35,8 @@ use xtras::AddressMap;
 use xtras::SendAsyncSafe;
 use xtras::SendInterval;
 
+const TCP_TIMEOUT: Duration = Duration::from_secs(10);
+
 #[derive(Clone)]
 pub struct BroadcastOffers(pub Option<MakerOffers>);
 
@@ -177,9 +179,9 @@ impl Connection {
 
         self.write
             .send(msg)
+            .timeout(TCP_TIMEOUT)
             .await
-            .with_context(|| format!("Failed to send msg {msg_str} to taker {taker_id}"))?;
-
+            .with_context(|| format!("Failed to send msg {msg_str} to taker {taker_id}"))??;
         Ok(())
     }
 }


### PR DESCRIPTION
Without this, we can block interaction with particular taker for arbitrary
length of time (and new connections from the same taker will be ignored).

Same timeout exists already on the taker side.

I went down to a rabbit hole why `send_interval()` stops working for `maker::connection` actor (see:  #2170 ). It turned out that we time out on a message handler for `SendHeartbeat`, which is set to 120s (which is pretty generous, nothing should take this long). One layer deeper I found this - the maker waits arbitrarily long to send the message.

New behaviour will drop the incoming connection, which will allow taker to reconnect clearly (less warnings, and much quicker turnaround for the other party).