### PR TITLE
Allow maker to provide wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow maker to provide extended private key as argument when starting. This key will be used to derive the internal wallet according to (Bip84)[https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki]
+
 ### Changed
 
 - Migrate away from JSON blobs in the DB to a more normalized database for RolloverCompleted events

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -177,7 +177,7 @@ impl Actor<ElectrumBlockchain> {
         let wallet_info_update = match self.sync_internal() {
             Ok(wallet_info) => Some(wallet_info),
             Err(e) => {
-                tracing::debug!("{:#}", e);
+                tracing::warn!("Syncing failed: {:#}", e);
                 None
             }
         };

--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -1,3 +1,4 @@
+use bdk::bitcoin::util::bip32::ExtendedPrivKey;
 use clap::Parser;
 use clap::Subcommand;
 use daemon::bdk;
@@ -36,6 +37,11 @@ pub struct Opts {
     /// If enabled logs will be in json format
     #[clap(short, long)]
     pub json: bool,
+
+    /// If provided will be used for internal wallet instead of a random key. The keys will be
+    /// derived according to Bip84
+    #[clap(short, long)]
+    pub wallet_xprv: Option<ExtendedPrivKey>,
 
     /// Configure the log level, e.g.: one of Error, Warn, Info, Debug, Trace
     #[clap(short, long, default_value = "Debug")]


### PR DESCRIPTION
By allowing the maker to provide a private key as arg we split the identity generation from the wallet

I opted for passing in an xprv key directly instead of a seed. This should allow us to reuse the key in other wallets. 

If you want to try it out, use `wagyu`: https://github.com/AleoHQ/wagyu

e.g. `wagyu bitcoin hd -d "m/84'/0'/0'" -n testnet`

fix #2183 