### PR TITLE
Don't sort events by timestamp

### DIFF
--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -53,7 +53,6 @@ use rust_decimal_macros::dec;
 use serde::de::Error as _;
 use serde::Deserialize;
 use serde::Serialize;
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::ops::RangeInclusive;
@@ -384,32 +383,6 @@ impl CfdEvent {
             id,
             event,
         }
-    }
-
-    /// Comparison function to order two events chronologically.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use model::{CfdEvent, Timestamp, EventKind, OrderId};
-    ///
-    /// # let id = OrderId::default();
-    /// # let make_event_at = move |seconds| CfdEvent {
-    /// #    timestamp: Timestamp::new(seconds),
-    /// #    id,
-    /// #    event: EventKind::LockConfirmed,
-    /// # };
-    /// #
-    /// let first = make_event_at(2000);
-    /// let second = make_event_at(3000);
-    ///
-    /// let mut events = vec![second.clone(), first.clone()];
-    /// events.sort_unstable_by(CfdEvent::chronologically);
-    ///
-    /// assert_eq!(events, vec![first, second])
-    /// ```
-    pub fn chronologically(left: &CfdEvent, right: &CfdEvent) -> Ordering {
-        left.timestamp.cmp(&right.timestamp)
     }
 }
 

--- a/sqlite-db/sqlx-data.json
+++ b/sqlite-db/sqlx-data.json
@@ -780,42 +780,6 @@
       "nullable": []
     }
   },
-  "d5513680f4dac0197543942a21e735204bcc3c92fd02f3fc9fab69b6c64913f4": {
-    "query": "\n\n        select\n            events.id,\n            name,\n            data,\n            created_at as \"created_at: model::Timestamp\"\n        from\n            events\n        join\n            cfds c on c.id = events.cfd_id\n        where\n            uuid = $1\n        limit $2,-1\n            ",
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "data",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "created_at: model::Timestamp",
-          "ordinal": 3,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 2
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
   "d87c695f2f1f67e9acbc2ed4dac9a083738e82c52e419f5f025f8c4e327b4858": {
     "query": "\n            INSERT OR IGNORE INTO time_to_first_position\n            (\n                taker_id,\n                first_seen_timestamp\n            )\n            VALUES ($1, $2)\n            ",
     "describe": {
@@ -901,6 +865,42 @@
         false,
         false,
         false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "e7069da5f66aeb5554bf7ec7cb70faeb28ae799253012cd4b1ab2093cf3ab651": {
+    "query": "\n\n        select\n            events.id,\n            name,\n            data,\n            created_at as \"created_at: model::Timestamp\"\n        from\n            events\n        join\n            cfds c on c.id = events.cfd_id\n        where\n            uuid = $1\n        order by events.id asc\n        limit $2,-1\n            ",
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "data",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at: model::Timestamp",
+          "ordinal": 3,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 2
+      },
+      "nullable": [
         false,
         false,
         false,

--- a/sqlite-db/src/lib.rs
+++ b/sqlite-db/src/lib.rs
@@ -607,6 +607,7 @@ async fn load_cfd_events(
             cfds c on c.id = events.cfd_id
         where
             uuid = $1
+        order by events.id asc
         limit $2,-1
             "#,
         id,
@@ -638,12 +639,10 @@ async fn load_cfd_events(
         }
     }
 
-    let mut events = events
+    let events = events
         .into_iter()
         .map(|(_, event)| event)
         .collect::<Vec<CfdEvent>>();
-
-    events.sort_unstable_by(CfdEvent::chronologically);
 
     Ok(events)
 }


### PR DESCRIPTION
fixes https://github.com/itchysats/itchysats/issues/2196

It appears that it can happen that two events in the database have the same timestamp.
This was observed for collab started and completed as well as rollover started and accepted events.
If they have the same timestamp, and the event history is sorted by that timestamp it can happen that the order is incorrect.

Iterating over the list of events should not change any ordering.
Thus, the database query can ensure the order and we don't need an additional sorting step.

---

I remember we discussed that we want to be totally sure that the order is guaranteed that's this sorting step was added. But when looking at the code again I don't understand why we opted for this. We only use iterators - why would an iterator change the order? 