### PR TITLE
Allow more time between reconnection attempts in the dialer

### DIFF
--- a/xtra-libp2p/src/dialer.rs
+++ b/xtra-libp2p/src/dialer.rs
@@ -137,7 +137,10 @@ impl Actor {
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Dialer failed")]
-    Failed { source: anyhow::Error },
+    Failed {
+        #[from]
+        source: anyhow::Error,
+    },
     #[error("Endpoint actor is disconnected")]
     NoEndpoint,
     #[error("Connection dropped from endpoint")]

--- a/xtra-libp2p/src/dialer.rs
+++ b/xtra-libp2p/src/dialer.rs
@@ -120,12 +120,14 @@ impl Actor {
 impl Actor {
     async fn handle(&mut self, msg: endpoint::ConnectionEstablished) {
         if msg.peer == self.peer_id() {
+            tracing::debug!("Dialer connected successfully");
             self.connected = true;
         }
     }
 
     async fn handle(&mut self, msg: endpoint::ConnectionDropped, ctx: &mut xtra::Context<Self>) {
         if msg.peer == self.peer_id() {
+            tracing::debug!("Dialer noticed connection got dropped");
             self.connected = false;
             self.stop_with_error(Error::ConnectionDropped, ctx);
         }

--- a/xtra-libp2p/src/dialer.rs
+++ b/xtra-libp2p/src/dialer.rs
@@ -58,6 +58,7 @@ impl xtra::Actor for Actor {
     type Stop = Error;
 
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
+        tracing::debug!("Starting dialer actor");
         match self
             .connect_address
             .clone()
@@ -71,9 +72,9 @@ impl xtra::Actor for Actor {
         }
 
         if let Err(e) = self.connect().await {
-            tracing::warn!("Failed to connect to maker: {e:#}");
-
-            self.stop_with_error(e, ctx);
+            tracing::warn!("Failed to request connection from endpoint: {e:#}");
+        } else {
+            tracing::debug!("Endpoint took the connection request");
         }
 
         let this = ctx.address().expect("self to be alive");

--- a/xtra-libp2p/src/listener.rs
+++ b/xtra-libp2p/src/listener.rs
@@ -105,7 +105,10 @@ impl Actor {
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Listener failed")]
-    Failed { source: anyhow::Error },
+    Failed {
+        #[from]
+        source: anyhow::Error,
+    },
     #[error("Endpoint actor is disconnected")]
     NoEndpoint,
     #[error("Connection dropped from endpoint")]


### PR DESCRIPTION
Recent logs in the taker showed that we could have accidentally hammered the maker with a lot of unnecessary requests when the maker was already trying to process a connection request from the dialer.