### PR TITLE
Rename error variant for clarity

### DIFF
--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -162,8 +162,8 @@ pub enum Error {
     BadConnection(#[from] yamux::ConnectionError), // TODO(public-api): Consider removing this.
     #[error("Address {0} does not end with a peer ID")]
     NoPeerIdInAddress(Multiaddr),
-    #[error("Either currently connecting or already connected to peer {0}")]
-    AlreadyConnected(PeerId),
+    #[error("Already trying to connect to peer {0}")]
+    AlreadyTryingToConnected(PeerId),
 }
 
 /// Subscribers that get notified on connection changes
@@ -392,7 +392,7 @@ impl Endpoint {
             .ok_or_else(|| Error::NoPeerIdInAddress(msg.0.clone()))?;
 
         if self.inflight_connections.contains(&peer) || self.controls.contains_key(&peer) {
-            return Err(Error::AlreadyConnected(peer));
+            return Err(Error::AlreadyTryingToConnected(peer));
         }
 
         self.inflight_connections.insert(peer);

--- a/xtra-libp2p/tests/basic.rs
+++ b/xtra-libp2p/tests/basic.rs
@@ -233,7 +233,7 @@ async fn cannot_connect_twice() {
 
     assert!(matches!(
         error,
-        xtra_libp2p::Error::AlreadyConnected(twin) if twin == alice.peer_id
+        xtra_libp2p::Error::AlreadyTryingToConnected(twin) if twin == alice.peer_id
     ))
 }
 


### PR DESCRIPTION
We only use this error variant for `inflight` connections, i.e. when we are *trying* to connect.
Seeing the error message in the logs is misleading because this error is only relevant when we are trying to connect, not when already connected.