### PR TITLE
Rework dialer and listener to not assume anything at startup

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -267,9 +267,7 @@ where
                 ),
             ],
             endpoint::Subscribers::new(
-                vec![xtra::message_channel::MessageChannel::clone_channel(
-                    &dialer_actor,
-                )],
+                vec![],
                 vec![xtra::message_channel::MessageChannel::clone_channel(
                     &dialer_actor,
                 )],

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -214,7 +214,7 @@ where
                     ping_address.clone_channel(),
                     maker_offer_address.clone_channel(),
                 ],
-                vec![listener_actor.clone_channel()],
+                vec![],
                 vec![listener_actor.clone_channel()],
             ),
         );

--- a/xtra-libp2p/src/dialer.rs
+++ b/xtra-libp2p/src/dialer.rs
@@ -47,6 +47,7 @@ impl Actor {
     }
 
     fn stop_with_error(&mut self, e: Error, ctx: &mut xtra::Context<Self>) {
+        tracing::debug!("Stopping dialer with an error: {e:#}");
         self.stop_reason = Some(e);
         ctx.stop();
     }

--- a/xtra-libp2p/src/dialer.rs
+++ b/xtra-libp2p/src/dialer.rs
@@ -122,10 +122,6 @@ impl Actor {
             self.stop_with_error(Error::Failed { source: e }, ctx);
         }
     }
-
-    async fn handle(&mut self, msg: Error, ctx: &mut xtra::Context<Self>) {
-        self.stop_with_error(msg, ctx);
-    }
 }
 
 #[xtra_productivity(message_impl = false)]

--- a/xtra-libp2p/src/dialer.rs
+++ b/xtra-libp2p/src/dialer.rs
@@ -18,7 +18,8 @@ pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// xtra actor that takes care of dialing (connecting) to an Endpoint.
 ///
-/// Periodically polls Endpoint to check whether connection is still active.
+/// Polls Endpoint at startup to check whether connection got established correctly, and
+/// then listens for ConnectionDropped message to stop itself.
 /// Should be used in conjunction with supervisor maintaining resilient connection.
 pub struct Actor {
     endpoint: Address<Endpoint>,

--- a/xtra-libp2p/src/listener.rs
+++ b/xtra-libp2p/src/listener.rs
@@ -1,13 +1,14 @@
 use crate::endpoint;
 use crate::Endpoint;
+use crate::GetConnectionStats;
 use crate::ListenOn;
-use anyhow::anyhow;
+use anyhow::Result;
 use async_trait::async_trait;
 use libp2p_core::Multiaddr;
 use std::time::Duration;
-use tokio_tasks::Tasks;
 use xtra::Address;
 use xtra_productivity::xtra_productivity;
+use xtras::SendAsyncSafe;
 
 /// If we're not connected by this time, stop the actor.
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
@@ -17,10 +18,8 @@ pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 /// Periodically polls Endpoint to check whether connection is still active.
 /// Should be used in conjunction with supervisor for continuous and resilient listening.
 pub struct Actor {
-    tasks: Tasks,
     endpoint: Address<Endpoint>,
     listen_address: Multiaddr,
-    is_listening: bool,
     /// Contains the reason we are stopping.
     stop_reason: Option<Error>,
 }
@@ -28,10 +27,8 @@ pub struct Actor {
 impl Actor {
     pub fn new(endpoint: Address<Endpoint>, listen_address: Multiaddr) -> Self {
         Self {
-            tasks: Tasks::default(),
             endpoint,
             listen_address,
-            is_listening: false,
             stop_reason: None,
         }
     }
@@ -40,6 +37,33 @@ impl Actor {
         self.stop_reason = Some(e);
         ctx.stop();
     }
+
+    async fn is_listening(&self) -> Result<bool> {
+        Ok(self
+            .endpoint
+            .send(GetConnectionStats)
+            .await?
+            .listen_addresses
+            .contains(&self.listen_address))
+    }
+
+    async fn listen(&self) -> Result<()> {
+        anyhow::ensure!(
+            !self.is_listening().await?,
+            "We should not be listening yet"
+        );
+
+        self.endpoint
+            .send(ListenOn(self.listen_address.clone()))
+            .await?;
+        tokio::time::sleep(CONNECTION_TIMEOUT).await;
+
+        anyhow::ensure!(
+            self.is_listening().await?,
+            "Endpoint did not start listening in time"
+        );
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -47,20 +71,10 @@ impl xtra::Actor for Actor {
     type Stop = Error;
 
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
-        let endpoint = self.endpoint.clone();
-        let listen_address = self.listen_address.clone();
-
-        if let Err(e) = endpoint.send(ListenOn(listen_address)).await {
-            self.stop_with_error(Error::Failed { source: anyhow!(e) }, ctx);
-        };
-
         let this = ctx.address().expect("self to be alive");
-        self.tasks.add(async move {
-            tokio::time::sleep(CONNECTION_TIMEOUT).await;
-            this.send(StopIfNotListening)
-                .await
-                .expect("to deliver stop message");
-        })
+        this.send_async_safe(Listen)
+            .await
+            .expect("self to be alive");
     }
 
     async fn stopped(self) -> Self::Stop {
@@ -74,29 +88,17 @@ impl Actor {
         self.stop_with_error(msg, ctx);
     }
 
-    async fn handle(&mut self, _msg: StopIfNotListening, ctx: &mut xtra::Context<Self>) {
-        if !self.is_listening {
-            self.stop_with_error(
-                Error::Failed {
-                    source: anyhow!("Did not connect in time"),
-                },
-                ctx,
-            )
+    async fn handle(&mut self, _msg: Listen, ctx: &mut xtra::Context<Self>) {
+        if let Err(e) = self.listen().await {
+            self.stop_with_error(Error::Failed { source: e }, ctx);
         }
     }
 }
 
 #[xtra_productivity(message_impl = false)]
 impl Actor {
-    async fn handle(&mut self, msg: endpoint::ListenAddressAdded) {
-        if msg.address == self.listen_address {
-            self.is_listening = true;
-        }
-    }
-
     async fn handle(&mut self, msg: endpoint::ListenAddressRemoved, ctx: &mut xtra::Context<Self>) {
         if msg.address == self.listen_address {
-            self.is_listening = false;
             self.stop_with_error(Error::ConnectionDropped, ctx);
         }
     }
@@ -109,12 +111,10 @@ pub enum Error {
         #[from]
         source: anyhow::Error,
     },
-    #[error("Endpoint actor is disconnected")]
-    NoEndpoint,
     #[error("Connection dropped from endpoint")]
     ConnectionDropped,
     #[error("Stop reason was not specified")]
     Unspecified,
 }
 
-struct StopIfNotListening;
+struct Listen;

--- a/xtra-libp2p/src/listener.rs
+++ b/xtra-libp2p/src/listener.rs
@@ -15,7 +15,8 @@ pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// xtra actor that taker care of listening for incoming connections to the Endpoint.
 ///
-/// Periodically polls Endpoint to check whether connection is still active.
+/// Polls Endpoint at startup to check whether listening got started correctly, and
+/// then listens for ListenerRemoved message to stop itself.
 /// Should be used in conjunction with supervisor for continuous and resilient listening.
 pub struct Actor {
     endpoint: Address<Endpoint>,

--- a/xtra-libp2p/src/listener.rs
+++ b/xtra-libp2p/src/listener.rs
@@ -85,10 +85,6 @@ impl xtra::Actor for Actor {
 
 #[xtra_productivity]
 impl Actor {
-    async fn handle(&mut self, msg: Error, ctx: &mut xtra::Context<Self>) {
-        self.stop_with_error(msg, ctx);
-    }
-
     async fn handle(&mut self, _msg: Listen, ctx: &mut xtra::Context<Self>) {
         if let Err(e) = self.listen().await {
             self.stop_with_error(Error::Failed { source: e }, ctx);

--- a/xtra-libp2p/src/listener.rs
+++ b/xtra-libp2p/src/listener.rs
@@ -35,6 +35,7 @@ impl Actor {
     }
 
     fn stop_with_error(&mut self, e: Error, ctx: &mut xtra::Context<Self>) {
+        tracing::debug!("Stopping listener with an error: {e:#}");
         self.stop_reason = Some(e);
         ctx.stop();
     }


### PR DESCRIPTION
In short, supervised actors can be restarted at any time. If they subscribe to changes in the Endpoint, they first need to figure out the current state at startup. 
Establishing this assumption allowed to rework and simplify the code of these actors. 

See commit messages for details.