### PR TITLE
Distinguish network for bitmex price feed

### DIFF
--- a/bitmex-stream/examples/xbt_usd_quote_testnet.rs
+++ b/bitmex-stream/examples/xbt_usd_quote_testnet.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<()> {
         .with_env_filter("info,bitmex_stream=trace")
         .init();
 
-    let mut stream = bitmex_stream::subscribe(["quoteBin1m:XBTUSD".to_owned()], Network::Mainnet);
+    let mut stream = bitmex_stream::subscribe(["quoteBin1m:XBTUSD".to_owned()], Network::Testnet);
 
     while let Some(result) = stream.try_next().await? {
         tracing::info!("{result}");

--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -116,6 +116,15 @@ impl Network {
         }
     }
 
+    pub fn price_feed_network(&self) -> xtra_bitmex_price_feed::Network {
+        match self {
+            Network::Mainnet { .. } => xtra_bitmex_price_feed::Network::Mainnet,
+            Network::Testnet { .. } | Network::Signet { .. } => {
+                xtra_bitmex_price_feed::Network::Testnet
+            }
+        }
+    }
+
     pub fn data_dir(&self, base: PathBuf) -> PathBuf {
         match self {
             Network::Mainnet { .. } => base.join("mainnet"),

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -137,13 +137,15 @@ async fn main() -> Result<()> {
         endpoint_listen,
     )?;
 
-    let (supervisor, price_feed) =
-        supervisor::Actor::with_policy(xtra_bitmex_price_feed::Actor::default, |e| match e {
+    let (supervisor, price_feed) = supervisor::Actor::with_policy(
+        move || xtra_bitmex_price_feed::Actor::new(opts.network.price_feed_network()),
+        |e| match e {
             xtra_bitmex_price_feed::Error::FailedToParseQuote { .. }
             | xtra_bitmex_price_feed::Error::Failed { .. }
             | xtra_bitmex_price_feed::Error::Unspecified
             | xtra_bitmex_price_feed::Error::StreamEnded => true, // always restart price feed actor
-        });
+        },
+    );
 
     let _supervisor_address = supervisor.create(None).spawn(&mut tasks);
 


### PR DESCRIPTION
For the `testnet` and `signet` setup we should use query the `testnet` price and not `mainnet`.