### PR TITLE
Activate info logs for `xtras` crate

### DIFF
--- a/shared-bin/src/logger.rs
+++ b/shared-bin/src/logger.rs
@@ -29,6 +29,7 @@ pub fn init(level: LevelFilter, json_format: bool) -> Result<()> {
         .add_directive("multistream_select=warn".parse()?)
         .add_directive("libp2p_noise=warn".parse()?)
         .add_directive("xtra_libp2p_offer=debug".parse()?)
+        .add_directive("xtras=info".parse()?)
         .add_directive("bdk::blockchain::script_sync=off".parse()?) // bdk logs duration of sync on INFO
         .add_directive("bdk::wallet=off".parse()?) // bdk logs derivation of addresses on INFO
         .add_directive("_=off".parse()?) // rocket logs headers on INFO and uses `_` as the log target for it?


### PR DESCRIPTION
We actually don't see when supervised actors are restarted in the logs at the moment.
I do think we want to see that.

---

Note: Recently we started splitting the system into multiple crates. That's OK, but I feel we did not properly configure logging for all these crates. 