### PR TITLE
Bump libp2p stack to 0.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -563,6 +563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1128,7 +1137,7 @@ checksum = "24c3fd473b3a903a62609e413ed7538f99e10b665ecb502b5e481a95283f8ab4"
 dependencies = [
  "futures-core",
  "futures-sink",
- "pin-project 1.0.10",
+ "pin-project",
  "spin 0.9.2",
 ]
 
@@ -1426,15 +1435,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -1708,9 +1708,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "libp2p-core"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5b02602099fb75cb2d16f9ea860a320d6eb82ce41e95ab680912c454805cd5"
+checksum = "42d46fca305dee6757022e2f5a4f6c023315084d0ed7441c3ab244e76666d979"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1726,7 +1726,7 @@ dependencies = [
  "multihash",
  "multistream-select",
  "parking_lot 0.12.0",
- "pin-project 1.0.10",
+ "pin-project",
  "prost",
  "prost-build",
  "rand 0.8.4",
@@ -1743,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd7e0c94051cda67123be68cf6b65211ba3dde7277be9068412de3e7ffd63ef"
+checksum = "cf2cee1dad1c83325bbd182a8e94555778699cec8a9da00086efb7522c4c15ad"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
@@ -1765,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193447aa729c85aac2376828df76d171c1a589c9e6b58fcc7f9d9a020734122c"
+checksum = "4f4933e38ef21b50698aefc87799c24f2a365c9d3f6cf50471f3f6a0bc410892"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2157,7 +2157,7 @@ dependencies = [
  "bytes",
  "futures",
  "log",
- "pin-project 1.0.10",
+ "pin-project",
  "smallvec",
  "unsigned-varint",
 ]
@@ -2600,31 +2600,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9615c18d31137579e9ff063499264ddc1278e7b1982757ebc111028c4d1dc909"
-dependencies = [
- "pin-project-internal 0.4.29",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
- "pin-project-internal 1.0.10",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044964427019eed9d49d9d5bbce6047ef18f37100ea400912a9fa4a3523ab12a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -2829,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2839,12 +2819,14 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
 dependencies = [
  "bytes",
- "heck 0.3.3",
+ "cfg-if 1.0.0",
+ "cmake",
+ "heck",
  "itertools",
  "lazy_static",
  "log",
@@ -2859,9 +2841,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2872,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
  "prost",
@@ -3507,12 +3489,12 @@ checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "rw-stream-sink"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
+checksum = "26338f5e09bb721b85b135ea05af7767c90b52f6de4f087d4f4a3a9d64e7dc04"
 dependencies = [
  "futures",
- "pin-project 0.4.29",
+ "pin-project",
  "static_assertions",
 ]
 
@@ -4084,7 +4066,7 @@ checksum = "bc0fba2b0cae21fc00fe6046f8baa4c7fcb49e379f0f592b04696607f69ed2e1"
 dependencies = [
  "dotenv",
  "either",
- "heck 0.4.0",
+ "heck",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -4564,7 +4546,7 @@ checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
 dependencies = [
  "futures-util",
  "log",
- "pin-project 1.0.10",
+ "pin-project",
  "rustls 0.19.1",
  "tokio",
  "tokio-rustls 0.22.0",
@@ -5262,7 +5244,7 @@ dependencies = [
  "libp2p-noise",
  "libp2p-tcp",
  "multistream-select",
- "pin-project 1.0.10",
+ "pin-project",
  "prometheus",
  "rand 0.8.4",
  "thiserror",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -19,9 +19,9 @@ derivative = "2"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hkdf = "0.12"
 itertools = "0.10"
-libp2p-core = { version = "0.32", default-features = false }
-libp2p-noise = "0.35"
-libp2p-tcp = { version = "0.32", default-features = false, features = ["tokio"] }
+libp2p-core = { version = "0.33", default-features = false }
+libp2p-noise = "0.36"
+libp2p-tcp = { version = "0.33", default-features = false, features = ["tokio"] }
 maia = "0.2.0"
 maia-core = "0.1.0"
 maia-deprecated = { git = "https://github.com/comit-network/maia", rev = "e419cb2cf19bed6ec53eaa3672408a6205a9b705", package = "maia" } # includes subtract-fee bug, needed for protocols over legacy networking

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -253,7 +253,7 @@ where
 
         let pong_address = pong::Actor::default().create(None).spawn(&mut tasks);
         let endpoint = Endpoint::new(
-            TokioTcpConfig::new(),
+            Box::new(TokioTcpConfig::new),
             identity.libp2p,
             ENDPOINT_CONNECTION_TIMEOUT,
             [

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -14,7 +14,7 @@ daemon = { path = "../daemon" }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hex = "0.4"
 http-api-problem = { version = "0.52.0", features = ["rocket"] }
-libp2p-tcp = { version = "0.32", default-features = false, features = ["tokio"] }
+libp2p-tcp = { version = "0.33", default-features = false, features = ["tokio"] }
 maia = "0.2.0"
 maia-core = "0.1.0"
 model = { path = "../model" }

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -184,7 +184,7 @@ where
         let pong_address = pong::Actor::default().create(None).spawn(&mut tasks);
 
         let endpoint = Endpoint::new(
-            TokioTcpConfig::new(),
+            Box::new(TokioTcpConfig::new),
             identity.libp2p,
             ENDPOINT_CONNECTION_TIMEOUT,
             [

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -9,7 +9,7 @@ bdk = { version = "0.18", default-features = false }
 conquer-once = "0.3"
 hex = "0.4"
 itertools = "0.10"
-libp2p-core = { version = "0.32.1", default-features = false, features = ["serde"] }
+libp2p-core = { version = "0.33", default-features = false, features = ["serde"] }
 maia = "0.2.0"
 maia-core = "0.1.0"
 maia-deprecated = { git = "https://github.com/comit-network/maia", rev = "e419cb2cf19bed6ec53eaa3672408a6205a9b705", package = "maia" } # includes subtract-fee bug, needed for protocols over legacy networking

--- a/taker/Cargo.toml
+++ b/taker/Cargo.toml
@@ -13,7 +13,7 @@ daemon = { path = "../daemon" }
 hex = "0.4"
 http-api-problem = { version = "0.52.0", features = ["rocket"] }
 itertools = "0.10"
-libp2p-core = { version = "0.32", default-features = false }
+libp2p-core = { version = "0.33", default-features = false }
 model = { path = "../model" }
 prometheus = { version = "0.13", default-features = false }
 rocket = { version = "0.5.0-rc.1", features = ["json", "uuid"] }

--- a/xtra-libp2p-offer/src/lib.rs
+++ b/xtra-libp2p-offer/src/lib.rs
@@ -112,7 +112,7 @@ mod tests {
             .spawn_global();
 
         let endpoint = Endpoint::new(
-            MemoryTransport::default(),
+            Box::new(MemoryTransport::default),
             id.clone(),
             Duration::from_secs(10),
             [],
@@ -142,7 +142,7 @@ mod tests {
             .spawn_global();
 
         let endpoint_addr = Endpoint::new(
-            MemoryTransport::default(),
+            Box::new(MemoryTransport::default),
             Keypair::generate_ed25519(),
             Duration::from_secs(10),
             [(PROTOCOL_NAME, offer_taker_addr.clone_channel())],

--- a/xtra-libp2p-ping/src/lib.rs
+++ b/xtra-libp2p-ping/src/lib.rs
@@ -91,7 +91,7 @@ mod tests {
         let pong_address = pong::Actor::default().create(None).spawn_global();
 
         let endpoint = Endpoint::new(
-            MemoryTransport::default(),
+            Box::new(MemoryTransport::default),
             id.clone(),
             Duration::from_secs(10),
             [(PROTOCOL_NAME, pong_address.clone_channel())],

--- a/xtra-libp2p/Cargo.toml
+++ b/xtra-libp2p/Cargo.toml
@@ -11,8 +11,8 @@ anyhow = "1"
 async-trait = "0.1"
 conquer-once = "0.3"
 futures = "0.3"
-libp2p-core = { version = "0.32", default-features = false }
-libp2p-noise = "0.35"
+libp2p-core = { version = "0.33", default-features = false }
+libp2p-noise = "0.36"
 multistream-select = "0.11"
 pin-project = "1"
 prometheus = { version = "0.13", default-features = false }
@@ -29,7 +29,7 @@ yamux = "0.10"
 [dev-dependencies]
 asynchronous-codec = "0.6"
 clap = { version = "3.1", features = ["derive"] }
-libp2p-tcp = { version = "0.32", default-features = false, features = ["tokio"] }
+libp2p-tcp = { version = "0.33", default-features = false, features = ["tokio"] }
 rand = "0.8"
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }

--- a/xtra-libp2p/examples/hello_world_dialer.rs
+++ b/xtra-libp2p/examples/hello_world_dialer.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
     let id = Keypair::generate_ed25519();
 
     let endpoint_addr = Endpoint::new(
-        TokioTcpConfig::new(),
+        Box::new(TokioTcpConfig::new),
         id,
         Duration::from_secs(20),
         [],

--- a/xtra-libp2p/examples/hello_world_listener.rs
+++ b/xtra-libp2p/examples/hello_world_listener.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
     let hello_world_addr = HelloWorld::default().create(None).spawn_global();
 
     let endpoint_addr = Endpoint::new(
-        TokioTcpConfig::new(),
+        Box::new(TokioTcpConfig::new),
         id,
         Duration::from_secs(30),
         [(

--- a/xtra-libp2p/src/upgrade.rs
+++ b/xtra-libp2p/src/upgrade.rs
@@ -33,7 +33,7 @@ pub fn transport<T>(
     connection_timeout: Duration,
 ) -> Boxed<Connection>
 where
-    T: Transport + Clone + Send + Sync + 'static,
+    T: Transport + Send + Sync + 'static,
     T::Output: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     T::Error: Send + Sync,
     T::Listener: Send + 'static,

--- a/xtra-libp2p/src/verify_peer_id.rs
+++ b/xtra-libp2p/src/verify_peer_id.rs
@@ -53,7 +53,7 @@ where
     type ListenerUpgrade = BoxFuture<'static, Result<Self::Output, Self::Error>>;
     type Dial = BoxFuture<'static, Result<Self::Output, Self::Error>>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<Self::Listener, TransportError<Self::Error>>
+    fn listen_on(&mut self, addr: Multiaddr) -> Result<Self::Listener, TransportError<Self::Error>>
     where
         Self: Sized,
     {
@@ -71,7 +71,7 @@ where
         Ok(listener)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>>
+    fn dial(&mut self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>>
     where
         Self: Sized,
     {
@@ -85,7 +85,10 @@ where
         Ok(dial_and_verify_peer_id::<TInner, C>(dial, expected_peer_id).boxed())
     }
 
-    fn dial_as_listener(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>>
+    fn dial_as_listener(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>>
     where
         Self: Sized,
     {
@@ -166,7 +169,8 @@ mod tests {
 
     #[test]
     fn rejects_address_without_peer_id() {
-        let transport = VerifyPeerId::new(MemoryTransport::default().map(simulate_auth_upgrade));
+        let mut transport =
+            VerifyPeerId::new(MemoryTransport::default().map(simulate_auth_upgrade));
 
         let result = transport.dial("/memory/10000".parse().unwrap());
 
@@ -182,7 +186,7 @@ mod tests {
             .map(simulate_auth_upgrade)
             .listen_on("/memory/10000".parse().unwrap())
             .unwrap();
-        let bob = VerifyPeerId::new(MemoryTransport::default().map(simulate_auth_upgrade));
+        let mut bob = VerifyPeerId::new(MemoryTransport::default().map(simulate_auth_upgrade));
 
         let result = bob
             .dial(

--- a/xtra-libp2p/tests/basic.rs
+++ b/xtra-libp2p/tests/basic.rs
@@ -369,7 +369,7 @@ fn make_node<const N: usize>(
         .spawn_global();
 
     let endpoint = Endpoint::new(
-        MemoryTransport::default(),
+        Box::new(MemoryTransport::default),
         id,
         Duration::from_secs(20),
         substream_handlers,


### PR DESCRIPTION
Endpoint API had to be adjusted, as Transport is not cloneable anymore. Instead,
we box a closure that can create and upgrade a transport when needed.