### PR TITLE
Improve rollover tests

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -164,6 +164,16 @@ impl Maker {
         &mut self.feeds.cfds
     }
 
+    pub fn first_cfd(&mut self) -> Cfd {
+        self.cfd_feed()
+            .borrow()
+            .as_ref()
+            .unwrap()
+            .first()
+            .unwrap()
+            .clone()
+    }
+
     pub fn offers_feed(&mut self) -> &mut watch::Receiver<MakerOffers> {
         &mut self.feeds.offers
     }
@@ -310,6 +320,16 @@ pub struct Taker {
 impl Taker {
     pub fn cfd_feed(&mut self) -> &mut watch::Receiver<Option<Vec<Cfd>>> {
         &mut self.feeds.cfds
+    }
+
+    pub fn first_cfd(&mut self) -> Cfd {
+        self.cfd_feed()
+            .borrow()
+            .as_ref()
+            .unwrap()
+            .first()
+            .unwrap()
+            .clone()
     }
 
     pub fn offers_feed(&mut self) -> &mut watch::Receiver<MakerOffers> {

--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -395,16 +395,24 @@ async fn force_close_open_cfd(maker_position: Position) {
 #[tokio::test]
 async fn rollover_an_open_cfd_maker_going_short() {
     let _guard = init_tracing();
-    rollover_an_open_cfd(Position::Short).await;
+    rollover_an_open_cfd(Position::Short, 1).await;
 }
 
 #[tokio::test]
 async fn rollover_an_open_cfd_maker_going_long() {
     let _guard = init_tracing();
-    rollover_an_open_cfd(Position::Long).await;
+    rollover_an_open_cfd(Position::Long, 1).await;
 }
 
-async fn rollover_an_open_cfd(maker_position: Position) {
+#[tokio::test]
+async fn double_rollover_an_open_cfd() {
+    // double rollover ensures that both parties properly succeeded and can do another rollover
+
+    let _guard = init_tracing();
+    rollover_an_open_cfd(Position::Short, 2).await;
+}
+
+async fn rollover_an_open_cfd(maker_position: Position, nr_rollovers: u8) {
     let oracle_data = OliviaData::example_0();
     let (mut maker, mut taker, order_id) =
         start_from_open_cfd_state(oracle_data.announcement(), maker_position).await;


### PR DESCRIPTION
This should help get more assurance on rollovers from the tests.

Note that the double rollover is not significantly more expensive - the rollover itself is fast, the setup is what takes most time. I still opted for keeping the single rollover tests in parallel. We could drop those but then it is a bit harder to know which one failed. We would have to look at the logs then.