### PR TITLE
Move rollover into respective rollover protocol actors

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -59,6 +59,7 @@ pub mod setup_contract;
 // TODO: Remove setup_contract_deprecated module after phasing out legacy networking
 pub mod setup_contract_deprecated;
 pub mod setup_taker;
+pub mod shared_protocol;
 pub mod taker_cfd;
 mod transaction_ext;
 pub mod version;

--- a/daemon/src/rollover/protocol.rs
+++ b/daemon/src/rollover/protocol.rs
@@ -1,18 +1,57 @@
+use crate::bitcoin::secp256k1::SecretKey;
+use crate::bitcoin::PublicKey;
 use crate::command;
-use crate::wire::CompleteFee;
-use crate::wire::RolloverMsg;
+use crate::shared_protocol::verify_adaptor_signature;
+use crate::shared_protocol::verify_cets;
+use crate::shared_protocol::verify_signature;
+use crate::transaction_ext::TransactionExt;
 use anyhow::anyhow;
 use anyhow::bail;
+use anyhow::Context;
 use anyhow::Result;
+use bdk::bitcoin::secp256k1::schnorrsig;
+use bdk::bitcoin::secp256k1::Signature;
+use bdk::bitcoin::secp256k1::SECP256K1;
+use bdk::bitcoin::util::psbt::PartiallySignedTransaction;
+use bdk::bitcoin::Amount;
+use bdk::bitcoin::Transaction;
+use bdk::descriptor::Descriptor;
+use bdk::miniscript::DescriptorTrait;
+use maia::commit_descriptor;
+use maia::renew_cfd_transactions;
+use maia_core::secp256k1_zkp;
+use maia_core::secp256k1_zkp::EcdsaAdaptorSignature;
+use maia_core::Announcement;
+use maia_core::CfdTransactions;
+use maia_core::PartyParams;
+use model::calculate_payouts;
+use model::olivia;
 use model::olivia::BitMexPriceEventId;
+use model::Cet;
 use model::Dlc;
+use model::FeeFlow;
 use model::FundingFee;
 use model::FundingRate;
 use model::OrderId;
+use model::Position;
+use model::RevokedCommit;
+use model::Role;
+use model::RolloverParams;
 use model::Timestamp;
 use model::TxFeeRate;
+use model::CET_TIMELOCK;
 use serde::Deserialize;
 use serde::Serialize;
+use std::collections::HashMap;
+use std::iter::FromIterator;
+use std::ops::RangeInclusive;
+use std::time::Duration;
+
+/// How long rollover protocol waits for the next message before giving up
+///
+/// 60s timeout are acceptable here because rollovers are automatically retried; a few failed
+/// rollovers are not a big deal.
+pub(crate) const ROLLOVER_MSG_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub struct RolloverCompletedParams {
     pub dlc: Dlc,
@@ -31,7 +70,7 @@ pub enum DialerError {
 }
 
 #[derive(Serialize, Deserialize)]
-pub enum DialerMessage {
+pub(crate) enum DialerMessage {
     Propose(Propose),
     RolloverMsg(Box<RolloverMsg>),
 }
@@ -59,7 +98,7 @@ pub enum Decision {
 }
 
 #[derive(Serialize, Deserialize)]
-pub enum ListenerMessage {
+pub(crate) enum ListenerMessage {
     Decision(Decision),
     RolloverMsg(Box<RolloverMsg>),
 }
@@ -102,6 +141,126 @@ pub struct Reject {
     pub order_id: OrderId,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload")]
+pub(crate) enum RolloverMsg {
+    Msg0(RolloverMsg0),
+    Msg1(RolloverMsg1),
+    Msg2(RolloverMsg2),
+    Msg3(RolloverMsg3),
+}
+
+impl RolloverMsg {
+    pub fn try_into_msg0(self) -> Result<RolloverMsg0> {
+        if let Self::Msg0(v) = self {
+            Ok(v)
+        } else {
+            bail!("Not Msg0")
+        }
+    }
+
+    pub fn try_into_msg1(self) -> Result<RolloverMsg1> {
+        if let Self::Msg1(v) = self {
+            Ok(v)
+        } else {
+            bail!("Not Msg1")
+        }
+    }
+
+    pub fn try_into_msg2(self) -> Result<RolloverMsg2> {
+        if let Self::Msg2(v) = self {
+            Ok(v)
+        } else {
+            bail!("Not Msg2")
+        }
+    }
+
+    pub fn try_into_msg3(self) -> Result<RolloverMsg3> {
+        if let Self::Msg3(v) = self {
+            Ok(v)
+        } else {
+            bail!("Not Msg3")
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub(crate) struct RolloverMsg0 {
+    pub revocation_pk: PublicKey,
+    pub publish_pk: PublicKey,
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct RolloverMsg1 {
+    pub commit: EcdsaAdaptorSignature,
+    pub cets: HashMap<String, Vec<(RangeInclusive<u64>, EcdsaAdaptorSignature)>>,
+    pub refund: Signature,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub(crate) struct RolloverMsg2 {
+    pub revocation_sk: SecretKey,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub(crate) struct RolloverMsg3;
+
+impl From<CfdTransactions> for RolloverMsg1 {
+    fn from(txs: CfdTransactions) -> Self {
+        let cets = txs
+            .cets
+            .into_iter()
+            .map(|grouped_cets| {
+                (
+                    grouped_cets.event.id,
+                    grouped_cets
+                        .cets
+                        .into_iter()
+                        .map(|(_, encsig, digits)| (digits.range(), encsig))
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        Self {
+            commit: txs.commit.1,
+            cets,
+            refund: txs.refund.1,
+        }
+    }
+}
+
+/// Fee to be paid for the rollover.
+///
+/// The maker comes up with this amount so that both parties are on the same page
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum CompleteFee {
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    LongPaysShort(Amount),
+    #[serde(with = "::bdk::bitcoin::util::amount::serde::as_sat")]
+    ShortPaysLong(Amount),
+    Nein,
+}
+
+impl From<FeeFlow> for CompleteFee {
+    fn from(fee_flow: FeeFlow) -> Self {
+        match fee_flow {
+            FeeFlow::LongPaysShort(a) => CompleteFee::LongPaysShort(a),
+            FeeFlow::ShortPaysLong(a) => CompleteFee::ShortPaysLong(a),
+            FeeFlow::Nein => CompleteFee::Nein,
+        }
+    }
+}
+
+impl From<CompleteFee> for FeeFlow {
+    fn from(fee_flow: CompleteFee) -> Self {
+        match fee_flow {
+            CompleteFee::LongPaysShort(a) => FeeFlow::LongPaysShort(a),
+            CompleteFee::ShortPaysLong(a) => FeeFlow::ShortPaysLong(a),
+            CompleteFee::Nein => FeeFlow::Nein,
+        }
+    }
+}
+
 pub(crate) async fn emit_completed(
     order_id: OrderId,
     dlc: Dlc,
@@ -140,4 +299,312 @@ pub(crate) async fn emit_failed(order_id: OrderId, e: anyhow::Error, executor: &
     {
         tracing::error!(%order_id, "Failed to execute rollover failed: {e:#}")
     }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct PunishParams {
+    maker_identity: PublicKey,
+    maker_params: maia_core::PunishParams,
+    taker_identity: PublicKey,
+    taker_params: maia_core::PunishParams,
+    own_role: Role,
+}
+
+impl PunishParams {
+    pub fn counterparty_params(&self) -> maia_core::PunishParams {
+        match self.own_role {
+            Role::Maker => self.taker_params,
+            Role::Taker => self.maker_params,
+        }
+    }
+}
+
+pub(crate) fn build_punish_params(
+    own_role: Role,
+    own_sk: SecretKey,
+    counterparty_pk: PublicKey,
+    counterparty_msg0: RolloverMsg0,
+    rev_pk: PublicKey,
+    publish_pk: PublicKey,
+) -> PunishParams {
+    let msg0 = counterparty_msg0;
+
+    let own_pk = PublicKey::new(secp256k1_zkp::PublicKey::from_secret_key(
+        SECP256K1, &own_sk,
+    ));
+
+    let counterparty_punish_params = maia_core::PunishParams {
+        revocation_pk: msg0.revocation_pk,
+        publish_pk: msg0.publish_pk,
+    };
+
+    let own_punish_params = maia_core::PunishParams {
+        revocation_pk: rev_pk,
+        publish_pk,
+    };
+
+    match own_role {
+        Role::Maker => PunishParams {
+            maker_identity: own_pk,
+            maker_params: own_punish_params,
+            taker_identity: counterparty_pk,
+            taker_params: counterparty_punish_params,
+            own_role,
+        },
+        Role::Taker => PunishParams {
+            maker_identity: counterparty_pk,
+            maker_params: counterparty_punish_params,
+            taker_identity: own_pk,
+            taker_params: own_punish_params,
+            own_role,
+        },
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn build_own_cfd_transactions(
+    dlc: &Dlc,
+    rollover_params: RolloverParams,
+    announcement: &olivia::Announcement,
+    oracle_pk: schnorrsig::PublicKey,
+    our_position: Position,
+    n_payouts: usize,
+    complete_fee: FeeFlow,
+    punish_params: PunishParams,
+) -> Result<CfdTransactions> {
+    let sk = dlc.identity;
+
+    let maker_lock_amount = dlc.maker_lock_amount;
+    let taker_lock_amount = dlc.taker_lock_amount;
+    let payouts = HashMap::from_iter([(
+        Announcement {
+            id: announcement.id.to_string(),
+            nonce_pks: announcement.nonce_pks.clone(),
+        },
+        calculate_payouts(
+            our_position,
+            punish_params.own_role,
+            rollover_params.price,
+            rollover_params.quantity,
+            rollover_params.long_leverage,
+            rollover_params.short_leverage,
+            n_payouts,
+            complete_fee,
+        )?,
+    )]);
+
+    // unsign lock tx because PartiallySignedTransaction needs an unsigned tx
+    let mut unsigned_lock_tx = dlc.lock.0.clone();
+    unsigned_lock_tx
+        .input
+        .iter_mut()
+        .for_each(|input| input.witness.clear());
+
+    let lock_tx = PartiallySignedTransaction::from_unsigned_tx(unsigned_lock_tx)?;
+    let own_cfd_txs = tokio::task::spawn_blocking({
+        let maker_address = dlc.maker_address.clone();
+        let taker_address = dlc.taker_address.clone();
+        let lock_tx = lock_tx.clone();
+
+        move || {
+            renew_cfd_transactions(
+                lock_tx,
+                (
+                    punish_params.maker_identity,
+                    maker_lock_amount,
+                    maker_address,
+                    punish_params.maker_params,
+                ),
+                (
+                    punish_params.taker_identity,
+                    taker_lock_amount,
+                    taker_address,
+                    punish_params.taker_params,
+                ),
+                oracle_pk,
+                (CET_TIMELOCK, rollover_params.refund_timelock),
+                payouts,
+                sk,
+                rollover_params.fee_rate.to_u32(),
+            )
+        }
+    })
+    .await?
+    .context("Failed to create new CFD transactions")?;
+
+    Ok(own_cfd_txs)
+}
+
+pub(crate) fn build_commit_descriptor(punish_params: PunishParams) -> Descriptor<PublicKey> {
+    commit_descriptor(
+        (
+            punish_params.maker_identity,
+            punish_params.maker_params.revocation_pk,
+            punish_params.maker_params.publish_pk,
+        ),
+        (
+            punish_params.taker_identity,
+            punish_params.taker_params.revocation_pk,
+            punish_params.taker_params.publish_pk,
+        ),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn build_and_verify_cets_and_refund(
+    dlc: &Dlc,
+    announcement: &olivia::Announcement,
+    oracle_pk: schnorrsig::PublicKey,
+    publish_pk: PublicKey,
+    our_role: Role,
+    own_cfd_txs: &CfdTransactions,
+    commit_desc: &Descriptor<PublicKey>,
+    msg1: &RolloverMsg1,
+) -> Result<(HashMap<BitMexPriceEventId, Vec<Cet>>, Transaction)> {
+    let lock_amount = dlc.taker_lock_amount + dlc.maker_lock_amount;
+
+    let own_cets = own_cfd_txs.cets.clone();
+    let commit_tx = own_cfd_txs.commit.0.clone();
+
+    let commit_amount = Amount::from_sat(commit_tx.output[0].value);
+
+    verify_adaptor_signature(
+        &commit_tx,
+        &dlc.lock.1,
+        lock_amount,
+        &msg1.commit,
+        &publish_pk,
+        &dlc.identity_counterparty,
+    )
+    .context("Commit adaptor signature does not verify")?;
+
+    let counterparty_address = match our_role {
+        Role::Maker => dlc.taker_address.clone(),
+        Role::Taker => dlc.maker_address.clone(),
+    };
+
+    for own_grouped_cets in own_cets.iter() {
+        let counterparty_cets = msg1
+            .cets
+            .get(&own_grouped_cets.event.id)
+            .cloned()
+            .context("Expect event to exist in msg")?;
+
+        verify_cets(
+            (oracle_pk, announcement.nonce_pks.clone()),
+            PartyParams {
+                lock_psbt: own_cfd_txs.lock.clone(),
+                identity_pk: dlc.identity_counterparty,
+                lock_amount,
+                address: counterparty_address.clone(),
+            },
+            own_grouped_cets.cets.clone(),
+            counterparty_cets,
+            commit_desc.clone(),
+            commit_amount,
+        )
+        .await
+        .context("CET signatures don't verify")?;
+    }
+
+    let refund_tx = own_cfd_txs.refund.0.clone();
+
+    verify_signature(
+        &refund_tx,
+        commit_desc,
+        commit_amount,
+        &msg1.refund,
+        &dlc.identity_counterparty,
+    )
+    .context("Refund signature does not verify")?;
+
+    let maker_address = &dlc.maker_address;
+    let taker_address = &dlc.taker_address;
+    let cets = own_cets
+        .into_iter()
+        .map(|grouped_cets| {
+            let event_id = grouped_cets.event.id;
+            let counterparty_cets = msg1
+                .cets
+                .get(&event_id)
+                .with_context(|| format!("Counterparty CETs for event {event_id} missing"))?;
+            let cets = grouped_cets
+                .cets
+                .into_iter()
+                .map(|(tx, _, digits)| {
+                    let counterparty_encsig = counterparty_cets
+                        .iter()
+                        .find_map(|(counterparty_range, counterparty_encsig)| {
+                            (counterparty_range == &digits.range()).then(|| counterparty_encsig)
+                        })
+                        .with_context(|| {
+                            let range = digits.range();
+
+                            format!(
+                                "Missing counterparty adaptor signature for CET corresponding to
+                                 price range {range:?}"
+                            )
+                        })?;
+
+                    let maker_amount = tx
+                        .find_output_amount(&maker_address.script_pubkey())
+                        .unwrap_or_default();
+                    let taker_amount = tx
+                        .find_output_amount(&taker_address.script_pubkey())
+                        .unwrap_or_default();
+                    let cet = Cet {
+                        maker_amount,
+                        taker_amount,
+                        adaptor_sig: *counterparty_encsig,
+                        range: digits.range(),
+                        n_bits: digits.len(),
+                        txid: tx.txid(),
+                    };
+
+                    debug_assert_eq!(
+                        cet.to_tx((&commit_tx, commit_desc), maker_address, taker_address)
+                            .expect("can reconstruct CET")
+                            .txid(),
+                        tx.txid()
+                    );
+
+                    Ok(cet)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok((event_id.parse()?, cets))
+        })
+        .collect::<Result<HashMap<_, _>>>()?;
+
+    Ok((cets, refund_tx))
+}
+
+pub(crate) fn finalize_revoked_commits(
+    dlc: &Dlc,
+    commit_tx_adaptor_sig: EcdsaAdaptorSignature,
+    msg2: RolloverMsg2,
+) -> Result<Vec<RevokedCommit>> {
+    let revocation_sk_theirs = msg2.revocation_sk;
+
+    {
+        let derived_rev_pk = PublicKey::new(secp256k1_zkp::PublicKey::from_secret_key(
+            SECP256K1,
+            &revocation_sk_theirs,
+        ));
+
+        if derived_rev_pk != dlc.revocation_pk_counterparty {
+            anyhow::bail!("Counterparty sent invalid revocation sk");
+        }
+    }
+
+    let mut revoked_commit = dlc.revoked_commit.clone();
+    let transaction = dlc.commit.0.clone();
+    revoked_commit.push(RevokedCommit {
+        encsig_ours: commit_tx_adaptor_sig,
+        revocation_sk_theirs,
+        publication_pk_theirs: dlc.publish_pk_counterparty,
+        txid: transaction.txid(),
+        script_pubkey: dlc.commit.2.script_pubkey(),
+    });
+
+    Ok(revoked_commit)
 }

--- a/daemon/src/shared_protocol.rs
+++ b/daemon/src/shared_protocol.rs
@@ -1,0 +1,113 @@
+use anyhow::Context;
+use anyhow::Result;
+use bdk::bitcoin::secp256k1::schnorrsig;
+use bdk::bitcoin::secp256k1::Signature;
+use bdk::bitcoin::secp256k1::SECP256K1;
+use bdk::bitcoin::Amount;
+use bdk::bitcoin::Transaction;
+use bdk::descriptor::Descriptor;
+use maia::compute_adaptor_pk;
+use maia::spending_tx_sighash;
+use maia_core::interval;
+use maia_core::secp256k1_zkp::EcdsaAdaptorSignature;
+use maia_core::PartyParams;
+use std::ops::RangeInclusive;
+use std::time::Duration;
+
+pub(crate) async fn verify_cets(
+    (oracle_pk, nonce_pks): (schnorrsig::PublicKey, Vec<schnorrsig::PublicKey>),
+    counterparty: PartyParams,
+    own_cets: Vec<(Transaction, EcdsaAdaptorSignature, interval::Digits)>,
+    counterparty_cets: Vec<(RangeInclusive<u64>, EcdsaAdaptorSignature)>,
+    commit_desc: Descriptor<bdk::bitcoin::PublicKey>,
+    commit_amount: Amount,
+) -> Result<()> {
+    tokio::task::spawn_blocking(move || {
+        for (tx, _, digits) in own_cets.iter() {
+            let counterparty_encsig = counterparty_cets
+                .iter()
+                .find_map(|(range, encsig)| (range == &digits.range()).then(|| encsig))
+                .with_context(|| {
+                    let range = digits.range();
+
+                    format!("no enc sig from counterparty for price range {range:?}",)
+                })?;
+
+            verify_cet_encsig(
+                tx,
+                counterparty_encsig,
+                digits,
+                &counterparty.identity_pk,
+                (&oracle_pk, &nonce_pks),
+                &commit_desc,
+                commit_amount,
+            )
+            .context("enc sig on CET does not verify")?;
+        }
+
+        anyhow::Ok(())
+    })
+    .await??;
+
+    Ok(())
+}
+
+pub(crate) fn verify_adaptor_signature(
+    tx: &Transaction,
+    spent_descriptor: &Descriptor<bdk::bitcoin::PublicKey>,
+    spent_amount: Amount,
+    encsig: &EcdsaAdaptorSignature,
+    encryption_point: &bdk::bitcoin::PublicKey,
+    pk: &bdk::bitcoin::PublicKey,
+) -> Result<()> {
+    let sighash = spending_tx_sighash(tx, spent_descriptor, spent_amount);
+
+    encsig
+        .verify(SECP256K1, &sighash, &pk.key, &encryption_point.key)
+        .context("failed to verify encsig spend tx")
+}
+
+pub(crate) fn verify_signature(
+    tx: &Transaction,
+    spent_descriptor: &Descriptor<bdk::bitcoin::PublicKey>,
+    spent_amount: Amount,
+    sig: &Signature,
+    pk: &bdk::bitcoin::PublicKey,
+) -> Result<()> {
+    let sighash = spending_tx_sighash(tx, spent_descriptor, spent_amount);
+    SECP256K1.verify(&sighash, sig, &pk.key)?;
+    Ok(())
+}
+
+pub(crate) fn verify_cet_encsig(
+    tx: &Transaction,
+    encsig: &EcdsaAdaptorSignature,
+    digits: &interval::Digits,
+    pk: &bdk::bitcoin::PublicKey,
+    (oracle_pk, nonce_pks): (&schnorrsig::PublicKey, &[schnorrsig::PublicKey]),
+    spent_descriptor: &Descriptor<bdk::bitcoin::PublicKey>,
+    spent_amount: Amount,
+) -> Result<()> {
+    let index_nonce_pairs = &digits
+        .to_indices()
+        .into_iter()
+        .zip(nonce_pks.iter().cloned())
+        .collect::<Vec<_>>();
+    let adaptor_point = compute_adaptor_pk(oracle_pk, index_nonce_pairs)
+        .context("could not calculate adaptor point")?;
+    verify_adaptor_signature(
+        tx,
+        spent_descriptor,
+        spent_amount,
+        encsig,
+        &bdk::bitcoin::PublicKey::new(adaptor_point),
+        pk,
+    )
+}
+
+/// Wrapper for the msg
+pub(crate) fn format_expect_msg_within(msg: &str, timeout: Duration) -> String {
+    let seconds = timeout.as_secs();
+
+    format!("Expected {msg} within {seconds} seconds")
+}


### PR DESCRIPTION
This allows to ensure the message order, i.e. taker always sends message first then waits to receive, maker always waits to receive first then sends.
This also makes sense in the context of the maker starting to wait to receive the first message after accepting and if the taker never comes back nothing no message is ever sent.

I recommend reviewing by commit but please keep the following in mind:
I am planning to `drop` the commits that change the code in `setup_contract.rs` - we could actually keep it, but given that this code will be removed I would drop the commits and keep the changeset to the resulted code in the `rollover` module.

The commits are structured to ensure that the code is the same and works. I always refactored a part and then ran the tests to ensure that it still works as expected.
I first extracted all code to be called from both parties into function in `setup_contract.rs`, then moved the code into the `rollover` module and the respective `maker` and `taker` actor.
For the `maker` I flipped the order to first wait to receive messages and then send.