### PR TITLE
Allow waiting before restarting a supervised actor

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -34,6 +34,7 @@ use xtra_libp2p::Endpoint;
 use xtra_libp2p_ping::ping;
 use xtra_libp2p_ping::pong;
 use xtras::supervisor;
+use xtras::supervisor::always_restart;
 
 pub use bdk;
 pub use maia;
@@ -241,10 +242,8 @@ where
             let endpoint_addr = endpoint_addr.clone();
             move || dialer::Actor::new(endpoint_addr.clone(), maker_multiaddr.clone())
         };
-        let (dialer_supervisor, dialer_actor) = supervisor::Actor::with_policy(
-            dialer_constructor,
-            |_: &dialer::Error| true, // always restart dialer actor
-        );
+        let (dialer_supervisor, dialer_actor) =
+            supervisor::Actor::with_policy(dialer_constructor, always_restart());
 
         let (offers_supervisor, libp2p_offer_addr) = supervisor::Actor::new({
             let cfd_actor_addr = cfd_actor_addr.clone();
@@ -286,10 +285,8 @@ where
         let dialer_supervisor = dialer_supervisor.create(None).spawn(&mut tasks);
         let offers_supervisor = offers_supervisor.create(None).spawn(&mut tasks);
 
-        let (supervisor, price_feed_actor) = supervisor::Actor::with_policy(
-            price_feed_constructor,
-            |_| true, // always restart price feed actor
-        );
+        let (supervisor, price_feed_actor) =
+            supervisor::Actor::with_policy(price_feed_constructor, always_restart());
 
         let price_feed_supervisor = supervisor.create(None).spawn(&mut tasks);
 

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -42,6 +42,7 @@ use xtra_libp2p::Endpoint;
 use xtra_libp2p_ping::ping;
 use xtra_libp2p_ping::pong;
 use xtras::supervisor;
+use xtras::supervisor::always_restart;
 
 const ENDPOINT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(20);
 const PING_INTERVAL: Duration = Duration::from_secs(5);
@@ -178,7 +179,7 @@ where
 
         let (listener_supervisor, listener_actor) = supervisor::Actor::with_policy(
             move || listener::Actor::new(endpoint_addr.clone(), listen_multiaddr.clone()),
-            |_: &listener::Error| true, // always restart listener actor
+            always_restart(),
         );
 
         let pong_address = pong::Actor::default().create(None).spawn(&mut tasks);

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -42,10 +42,14 @@ use xtra_libp2p::Endpoint;
 use xtra_libp2p_ping::ping;
 use xtra_libp2p_ping::pong;
 use xtras::supervisor;
-use xtras::supervisor::always_restart;
+use xtras::supervisor::always_restart_after;
 
 const ENDPOINT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(20);
 const PING_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Duration between the restart attempts after a supervised actor has quit with
+/// a failure.
+pub const RESTART_INTERVAL: Duration = Duration::from_secs(5);
 
 pub struct ActorSystem<O, W> {
     pub cfd_actor: Address<cfd::Actor<O, connection::Actor, W>>,
@@ -179,7 +183,7 @@ where
 
         let (listener_supervisor, listener_actor) = supervisor::Actor::with_policy(
             move || listener::Actor::new(endpoint_addr.clone(), listen_multiaddr.clone()),
-            always_restart(),
+            always_restart_after(RESTART_INTERVAL),
         );
 
         let pong_address = pong::Actor::default().create(None).spawn(&mut tasks);

--- a/xtra-libp2p/examples/hello_world_dialer.rs
+++ b/xtra-libp2p/examples/hello_world_dialer.rs
@@ -17,6 +17,7 @@ use xtra_libp2p::endpoint::Subscribers;
 use xtra_libp2p::Endpoint;
 use xtra_libp2p::OpenSubstream;
 use xtras::supervisor;
+use xtras::supervisor::always_restart;
 
 #[derive(Parser)]
 struct Opts {
@@ -51,10 +52,8 @@ async fn main() -> Result<()> {
         move || dialer::Actor::new(endpoint_addr.clone(), connect_addr.clone())
     };
 
-    let (supervisor, _dialer_actor) = supervisor::Actor::with_policy(
-        dialer_constructor,
-        |_: &dialer::Error| true, // always restart dialer actor
-    );
+    let (supervisor, _dialer_actor) =
+        supervisor::Actor::with_policy(dialer_constructor, always_restart::<dialer::Error>());
     let _dialer_supervisor = supervisor.create(None).spawn_global();
 
     sleep(Duration::from_secs(1)).await;

--- a/xtra-libp2p/examples/hello_world_listener.rs
+++ b/xtra-libp2p/examples/hello_world_listener.rs
@@ -19,6 +19,7 @@ use xtra_libp2p::Endpoint;
 use xtra_libp2p::NewInboundSubstream;
 use xtra_productivity::xtra_productivity;
 use xtras::supervisor;
+use xtras::supervisor::always_restart;
 
 // Listen on TCP
 
@@ -71,10 +72,8 @@ async fn main() -> Result<()> {
         let endpoint_addr = endpoint_addr.clone();
         listener::Actor::new(endpoint_addr, endpoint_listen)
     };
-    let (supervisor, _listener_actor) = supervisor::Actor::with_policy(
-        listener_constructor,
-        |_: &listener::Error| true, // always restart listener actor
-    );
+    let (supervisor, _listener_actor) =
+        supervisor::Actor::with_policy(listener_constructor, always_restart::<listener::Error>());
     let _listener_supervisor = supervisor.create(None).spawn_global();
 
     sleep(Duration::from_secs(opts.duration_secs)).await;

--- a/xtras/src/supervisor.rs
+++ b/xtras/src/supervisor.rs
@@ -1,10 +1,12 @@
 use crate::ActorName;
 use async_trait::async_trait;
+use futures::Future;
 use futures::FutureExt;
 use std::any::Any;
 use std::error::Error;
 use std::fmt;
 use std::panic::AssertUnwindSafe;
+use std::pin::Pin;
 use tokio_tasks::Tasks;
 use xtra::Address;
 use xtra::Context;
@@ -17,9 +19,23 @@ pub struct Actor<T, R> {
     context: Context<T>,
     ctor: Box<dyn Fn() -> T + Send + 'static>,
     tasks: Tasks,
-    restart_policy: Box<dyn FnMut(&R) -> bool + Send + 'static>,
+    restart_policy: AsyncClosure<R>,
     _actor: Address<T>, // kept around to ensure that the supervised actor stays alive
     metrics: Metrics,
+}
+
+type AsyncClosure<R> = Box<
+    dyn for<'a> FnMut(&'a R) -> Pin<Box<dyn Future<Output = bool> + 'a + Send + Sync>>
+        + Send
+        + Sync,
+>;
+
+/// Closure that configures the supervisor to restart on every kind of error
+pub fn always_restart<E>() -> AsyncClosure<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    Box::new(|_: &E| Box::pin(async move { true }))
 }
 
 #[derive(Default, Clone, Copy)]
@@ -64,7 +80,7 @@ where
             context,
             ctor: Box::new(ctor),
             tasks: Tasks::default(),
-            restart_policy: Box::new(|UnitReason {}| true),
+            restart_policy: always_restart(),
             _actor: address.clone(),
             metrics: Metrics::default(),
         };
@@ -86,7 +102,7 @@ where
     /// 2. When to construct an instance of the actor.
     pub fn with_policy(
         ctor: impl (Fn() -> T) + Send + 'static,
-        restart_policy: impl (FnMut(&R) -> bool) + Send + 'static,
+        restart_policy: AsyncClosure<R>,
     ) -> (Self, Address<T>) {
         let (address, context) = Context::new(None);
 
@@ -94,7 +110,7 @@ where
             context,
             ctor: Box::new(ctor),
             tasks: Tasks::default(),
-            restart_policy: Box::new(restart_policy),
+            restart_policy,
             _actor: address.clone(),
             metrics: Metrics::default(),
         };
@@ -156,7 +172,7 @@ where
 {
     pub fn handle(&mut self, msg: Stopped<R>, ctx: &mut Context<Self>) {
         let actor = T::name();
-        let should_restart = (self.restart_policy)(&msg.reason);
+        let should_restart = (self.restart_policy)(&msg.reason).await;
         let reason_str = format!("{:#}", anyhow::Error::new(msg.reason)); // Anyhow will format the entire chain of errors when using `alternate` Display (`#`)
 
         tracing::info!(actor = %&actor, reason = %reason_str, restart = %should_restart, "Actor stopped");
@@ -242,7 +258,8 @@ mod tests {
     async fn supervisor_tracks_spawn_metrics() {
         let _guard = tracing_subscriber::fmt().with_test_writer().set_default();
 
-        let (supervisor, address) = Actor::with_policy(|| RemoteShutdown, |_: &io::Error| true);
+        let (supervisor, address) =
+            Actor::with_policy(|| RemoteShutdown, always_restart::<io::Error>());
         let (supervisor, task) = supervisor.create(None).run();
 
         #[allow(clippy::disallowed_methods)]
@@ -267,7 +284,8 @@ mod tests {
     async fn restarted_actor_is_usable() {
         let _guard = tracing_subscriber::fmt().with_test_writer().set_default();
 
-        let (supervisor, address) = Actor::with_policy(|| RemoteShutdown, |_: &io::Error| true);
+        let (supervisor, address) =
+            Actor::with_policy(|| RemoteShutdown, always_restart::<io::Error>());
         let (_supervisor, task) = supervisor.create(None).run();
 
         #[allow(clippy::disallowed_methods)]
@@ -286,7 +304,8 @@ mod tests {
 
         std::panic::set_hook(Box::new(|_| ())); // Override hook to avoid panic printing to log.
 
-        let (supervisor, address) = Actor::with_policy(|| PanickingActor, |_: &io::Error| true);
+        let (supervisor, address) =
+            Actor::with_policy(|| PanickingActor, always_restart::<io::Error>());
         let (supervisor, task) = supervisor.create(None).run();
 
         #[allow(clippy::disallowed_methods)]

--- a/xtras/src/supervisor.rs
+++ b/xtras/src/supervisor.rs
@@ -7,6 +7,7 @@ use std::error::Error;
 use std::fmt;
 use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
+use std::time::Duration;
 use tokio_tasks::Tasks;
 use xtra::Address;
 use xtra::Context;
@@ -36,6 +37,23 @@ where
     E: Error + Send + Sync + 'static,
 {
     Box::new(|_: &E| Box::pin(async move { true }))
+}
+
+/// Closure that configures the supervisor to restart on every kind of error,
+/// after waiting for the specified `wait_time`.
+///
+/// Useful for preventing tight loops.
+pub fn always_restart_after<E>(wait_time: Duration) -> AsyncClosure<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    let wait_time = wait_time;
+    Box::new(move |_: &E| {
+        Box::pin(async move {
+            tokio::time::sleep(wait_time).await;
+            true
+        })
+    })
 }
 
 #[derive(Default, Clone, Copy)]
@@ -250,7 +268,9 @@ struct GetMetrics;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SendAsyncSafe;
     use std::io;
+    use std::time::Duration;
     use tracing_subscriber::util::SubscriberInitExt;
     use xtra::Actor as _;
 
@@ -277,6 +297,48 @@ mod tests {
         assert_eq!(
             metrics.num_spawns, 2,
             "after shutdown, should have 2 spawns"
+        );
+    }
+
+    #[tokio::test]
+    async fn supervisor_can_delay_respawn() {
+        let _guard = tracing_subscriber::fmt().with_test_writer().set_default();
+
+        let wait_time_seconds = 2;
+        let wait_time = Duration::from_secs(wait_time_seconds);
+
+        let (supervisor, address) = Actor::with_policy(
+            || RemoteShutdown,
+            always_restart_after::<io::Error>(wait_time),
+        );
+        let (supervisor, task) = supervisor.create(None).run();
+
+        #[allow(clippy::disallowed_methods)]
+        tokio::spawn(task);
+
+        let metrics = supervisor.send(GetMetrics).await.unwrap();
+        assert_eq!(
+            metrics.num_spawns, 1,
+            "after initial spawn, should have 1 spawn"
+        );
+
+        // Don't wait for the result of the message, as the wait_time between
+        // restart happens when stopping the actor context - otherwise it
+        // would be hard to verify the wait in a test.
+        address.send_async_safe(Shutdown).await.unwrap();
+
+        let metrics = supervisor.send(GetMetrics).await.unwrap();
+        assert_eq!(
+            metrics.num_spawns, 1,
+            "Right after shutdown, supervisor should wait for {wait_time_seconds}s to respawn the actor"
+        );
+
+        tokio::time::sleep(wait_time + Duration::from_secs(1)).await;
+
+        let metrics = supervisor.send(GetMetrics).await.unwrap();
+        assert_eq!(
+            metrics.num_spawns, 2,
+            "after waiting longer than {wait_time_seconds}s, should have 2 spawns"
         );
     }
 


### PR DESCRIPTION
In order to allow waiting, first I refactored the restart policy to allow passing in an async closure. Second commit adds the new capability, and adds a test to cover it.
Last but not least, dialer and listener use the new capability.