### PR TITLE
Add taker ID context when logging protocol errors

### DIFF
--- a/daemon/src/collab_settlement/maker.rs
+++ b/daemon/src/collab_settlement/maker.rs
@@ -88,7 +88,9 @@ impl Actor {
 
                 anyhow::Ok(())
             },
-            |e| async move { tracing::warn!("Failed to handle incoming collab settlement: {e:#}") },
+            move |e| async move {
+                tracing::warn!(%peer, "Failed to handle incoming collab settlement: {e:#}")
+            },
         );
     }
 }

--- a/daemon/src/rollover/maker.rs
+++ b/daemon/src/rollover/maker.rs
@@ -102,7 +102,9 @@ impl Actor {
 
                 anyhow::Ok(())
             },
-            |e| async move { tracing::warn!("Failed to handle incoming rollover protocol: {e:#}") },
+            move |e| async move {
+                tracing::warn!(%peer, "Failed to handle incoming rollover protocol: {e:#}")
+            },
         );
     }
 }


### PR DESCRIPTION
This way we can more easily identify patterns for particular peers e.g. a taker who consistently fails to complete all protocols.