### PR TITLE
Retire heartbeats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,6 +1915,7 @@ dependencies = [
  "rocket-basicauth",
  "rust-embed",
  "rust-embed-rocket",
+ "semver",
  "serde",
  "shared-bin",
  "sqlite-db",

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -86,13 +86,6 @@ pub struct MakerConfig {
 }
 
 impl MakerConfig {
-    pub fn with_heartbeat_interval(self, interval: Duration) -> Self {
-        Self {
-            heartbeat_interval: interval,
-            ..self
-        }
-    }
-
     pub fn with_dedicated_port(self, port: u16) -> Self {
         Self {
             dedicated_port: Some(port),
@@ -125,17 +118,7 @@ impl Default for MakerConfig {
 pub struct TakerConfig {
     oracle_pk: schnorrsig::PublicKey,
     seed: RandomSeed,
-    pub heartbeat_interval: Duration,
     n_payouts: usize,
-}
-
-impl TakerConfig {
-    pub fn with_heartbeat_interval(self, timeout: Duration) -> Self {
-        Self {
-            heartbeat_interval: timeout,
-            ..self
-        }
-    }
 }
 
 impl Default for TakerConfig {
@@ -143,7 +126,6 @@ impl Default for TakerConfig {
         Self {
             oracle_pk: oracle_pk(),
             seed: RandomSeed::default(),
-            heartbeat_interval: HEARTBEAT_INTERVAL,
             n_payouts: N_PAYOUTS,
         }
     }
@@ -411,7 +393,6 @@ impl Taker {
             },
             move || price_feed.clone(),
             config.n_payouts,
-            config.heartbeat_interval,
             Duration::from_secs(10),
             projection_actor,
             maker_identity,

--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -3,7 +3,6 @@ use daemon::bdk::bitcoin::Amount;
 use daemon::bdk::bitcoin::SignedAmount;
 use daemon::bdk::bitcoin::Txid;
 use daemon::connection::ConnectionStatus;
-use daemon::connection::MAX_RECONNECT_INTERVAL_SECONDS;
 use daemon::projection::CfdOrder;
 use daemon::projection::CfdState;
 use daemon::projection::MakerOffers;
@@ -852,16 +851,14 @@ async fn open_cfd_is_refunded() {
 
 #[tokio::test]
 async fn taker_notices_lack_of_maker() {
-    let short_interval = Duration::from_secs(1);
-
     let _guard = init_tracing();
 
     let maker_config = MakerConfig::default()
-        .with_heartbeat_interval(short_interval)
-        .with_dedicated_port(35123); // set a fixed port so the taker can reconnect
+        .with_dedicated_port(35123)
+        .with_dedicated_libp2p_port(35124); // set fixed ports so the taker can reconnect
     let maker = Maker::start(&maker_config).await;
 
-    let taker_config = TakerConfig::default().with_heartbeat_interval(short_interval);
+    let taker_config = TakerConfig::default();
     let mut taker = Taker::start(
         &taker_config,
         maker.listen_addr,
@@ -870,6 +867,8 @@ async fn taker_notices_lack_of_maker() {
     )
     .await;
 
+    sleep(Duration::from_secs(5)).await; // wait a bit until taker notices change
+
     assert_eq!(
         ConnectionStatus::Online,
         next(taker.maker_status_feed()).await.unwrap()
@@ -877,7 +876,7 @@ async fn taker_notices_lack_of_maker() {
 
     drop(maker);
 
-    sleep(taker_config.heartbeat_interval).await;
+    sleep(Duration::from_secs(5)).await; // wait a bit until taker notices change
 
     assert_eq!(
         ConnectionStatus::Offline { reason: None },
@@ -886,8 +885,7 @@ async fn taker_notices_lack_of_maker() {
 
     let _maker = Maker::start(&maker_config).await;
 
-    sleep(Duration::from_secs(MAX_RECONNECT_INTERVAL_SECONDS) + taker_config.heartbeat_interval)
-        .await;
+    sleep(Duration::from_secs(5)).await; // wait a bit until taker notices change
 
     assert_eq!(
         ConnectionStatus::Online,

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -51,6 +51,7 @@ mod future_ext;
 pub mod libp2p_utils;
 pub mod monitor;
 pub mod noise;
+mod online_status;
 pub mod oracle;
 pub mod position_metrics;
 pub mod process_manager;
@@ -102,6 +103,7 @@ pub struct TakerActorSystem<O, W, P> {
     _close_cfds_actor: Address<archive_closed_cfds::Actor>,
     _archive_failed_cfds_actor: Address<archive_failed_cfds::Actor>,
     _pong_actor: Address<pong::Actor>,
+    _online_status_actor: Address<online_status::Actor>,
 
     pub maker_online_status_feed_receiver: watch::Receiver<ConnectionStatus>,
 
@@ -128,7 +130,6 @@ where
         monitor_constructor: impl FnOnce(command::Executor) -> Result<M>,
         price_feed_constructor: impl (Fn() -> P) + Send + 'static,
         n_payouts: usize,
-        maker_heartbeat_interval: Duration,
         connect_timeout: Duration,
         projection_actor: Address<projection::Actor>,
         maker_identity: Identity,
@@ -228,14 +229,23 @@ where
             .create(None)
             .spawn(&mut tasks);
 
+        let online_status_actor = online_status::Actor::new(
+            endpoint_addr.clone(),
+            maker_multiaddr
+                .clone()
+                .extract_peer_id()
+                .expect("to be able to extract peer id"),
+            maker_online_status_feed_sender,
+        )
+        .create(None)
+        .spawn(&mut tasks);
+
         tasks.add(
             connection_actor_ctx
                 .with_handler_timeout(Duration::from_secs(120))
                 .run(connection::Actor::new(
-                    maker_online_status_feed_sender,
                     identity.identity_sk.clone(),
                     identity.peer_id(),
-                    maker_heartbeat_interval,
                     connect_timeout,
                     environment,
                 )),
@@ -274,10 +284,13 @@ where
                 ),
             ],
             endpoint::Subscribers::new(
-                vec![],
                 vec![xtra::message_channel::MessageChannel::clone_channel(
-                    &dialer_actor,
+                    &online_status_actor,
                 )],
+                vec![
+                    xtra::message_channel::MessageChannel::clone_channel(&dialer_actor),
+                    xtra::message_channel::MessageChannel::clone_channel(&online_status_actor),
+                ],
                 vec![],
                 vec![],
             ),
@@ -324,6 +337,7 @@ where
             _archive_failed_cfds_actor: archive_failed_cfds_actor,
             _tasks: tasks,
             maker_online_status_feed_receiver,
+            _online_status_actor: online_status_actor,
             _pong_actor: pong_address,
         })
     }

--- a/daemon/src/online_status.rs
+++ b/daemon/src/online_status.rs
@@ -1,0 +1,105 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use libp2p_core::PeerId;
+use tokio::sync::watch;
+use xtra::prelude::*;
+use xtra_libp2p::endpoint;
+use xtra_libp2p::Endpoint;
+use xtra_libp2p::GetConnectionStats;
+use xtra_productivity::xtra_productivity;
+
+use crate::connection::ConnectionStatus;
+
+/// Actor that transmits updates of ConnectionStatus of a specified PeerId based on
+/// information transmitted by the Endpoint via a watch channel.
+pub struct Actor {
+    endpoint: Address<Endpoint>,
+    watched_peer: PeerId,
+    sender: watch::Sender<ConnectionStatus>,
+}
+
+impl Actor {
+    pub fn new(
+        endpoint: Address<Endpoint>,
+        watched_peer: PeerId,
+        sender: watch::Sender<ConnectionStatus>,
+    ) -> Self {
+        Self {
+            endpoint,
+            watched_peer,
+            sender,
+        }
+    }
+}
+
+#[async_trait]
+impl xtra::Actor for Actor {
+    type Stop = ();
+
+    async fn started(&mut self, ctx: &mut Context<Self>) {
+        tracing::debug!(
+            "Online status watch actor started. Monitoring for peer id changes: {:?}",
+            self.watched_peer
+        );
+
+        match self.endpoint.send(GetConnectionStats).await {
+            Ok(connection_stats) => {
+                let status = if connection_stats
+                    .connected_peers
+                    .contains(&self.watched_peer)
+                {
+                    ConnectionStatus::Online
+                } else {
+                    ConnectionStatus::Offline { reason: None }
+                };
+                self.sender
+                    .send(status)
+                    .expect("Receiver to outlive this actor");
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Unable to receive connection stats from the endpoint upon startup: {e:#}"
+                );
+                // This code path should not be hit, but in case we run into an error this sleep
+                // prevents a continuous endless loup of restarts.
+                self.sender
+                    .send(ConnectionStatus::Offline { reason: None })
+                    .expect("Receiver to outlive this actor");
+                tokio::time::sleep(Duration::from_secs(2)).await;
+
+                ctx.stop();
+            }
+        }
+    }
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+#[xtra_productivity(message_impl = false)]
+impl Actor {
+    async fn handle_connection_established(&mut self, msg: endpoint::ConnectionEstablished) {
+        tracing::debug!(
+            "Adding newly established connection to online_status: {:?}",
+            msg.peer
+        );
+        if msg.peer == self.watched_peer {
+            self.sender
+                .send(ConnectionStatus::Online)
+                .expect("Receiver to outlive this actor");
+        }
+    }
+
+    async fn handle_connection_dropped(&mut self, msg: endpoint::ConnectionDropped) {
+        tracing::debug!(
+            "Remove dropped connection from online_status: {:?}",
+            msg.peer
+        );
+
+        if msg.peer == self.watched_peer {
+            self.sender
+                .send(ConnectionStatus::Offline { reason: None })
+                .expect("Receiver to outlive this actor");
+        }
+    }
+}

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -23,6 +23,7 @@ rocket = { version = "0.5.0-rc.2", features = ["json", "uuid"] }
 rocket-basicauth = { path = "../rocket-basicauth" }
 rust-embed = "6.4"
 rust-embed-rocket = { path = "../rust-embed-rocket" }
+semver = "1.0.10"
 serde = { version = "1", features = ["derive"] }
 shared-bin = { path = "../shared-bin" }
 sqlite-db = { path = "../sqlite-db" }

--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -37,6 +37,15 @@ use xtras::SendInterval;
 
 const TCP_TIMEOUT: Duration = Duration::from_secs(10);
 
+fn parse_vergen_version(vergen_string: &str) -> semver::Version {
+    let vergen = semver::Version::parse(vergen_string).expect("daemon version to parse");
+
+    // vergen appends git tag at the end, which is wrongfully parsed by
+    // semver as a pre-release (it's in fact the opposite, the tag only
+    // comes *after* release). Here we strip it out.
+    semver::Version::new(vergen.major, vergen.minor, vergen.patch)
+}
+
 #[derive(Clone)]
 pub struct BroadcastOffers(pub Option<MakerOffers>);
 
@@ -481,7 +490,18 @@ impl Actor {
                 }
             },
         );
-        tasks.add(this.send_interval(self.heartbeat_interval, move || SendHeartbeat(identity)));
+
+        let daemon_semver = parse_vergen_version(&daemon_version);
+        let no_need_for_heartbeats =
+            semver::VersionReq::parse(">= 0.4.20").expect("to parse VersionReq");
+
+        if no_need_for_heartbeats.matches(&daemon_semver) {
+            tracing::info!(
+                "Omitting legacy heartbeat protocol - libp2p connection monitoring should suffice"
+            );
+        } else {
+            tasks.add(this.send_interval(self.heartbeat_interval, move || SendHeartbeat(identity)));
+        }
 
         self.connections.insert(
             identity,

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -21,7 +21,6 @@ use daemon::wallet;
 use daemon::wallet::TAKER_WALLET_ID;
 use daemon::Environment;
 use daemon::TakerActorSystem;
-use daemon::HEARTBEAT_INTERVAL;
 use daemon::N_PAYOUTS;
 use libp2p_core::PeerId;
 use model::olivia;
@@ -378,7 +377,6 @@ async fn main() -> Result<()> {
         },
         move || xtra_bitmex_price_feed::Actor::new(price_feed_network),
         N_PAYOUTS,
-        HEARTBEAT_INTERVAL,
         Duration::from_secs(10),
         projection_actor.clone(),
         Identity::new(maker_id),


### PR DESCRIPTION
Details in the commits.

Mostly removed unused code and added a simple actor that adapts connection information onto the watch channel, which was used before.

Fixes #2234 