### PR TITLE
Rollover 2.0

### DIFF
--- a/daemon-tests/src/maia.rs
+++ b/daemon-tests/src/maia.rs
@@ -6,6 +6,7 @@ use model::olivia::BitMexPriceEventId;
 use std::str::FromStr;
 
 #[allow(dead_code)]
+#[derive(Clone)]
 pub struct OliviaData {
     id: BitMexPriceEventId,
     pk: schnorrsig::PublicKey,
@@ -15,14 +16,21 @@ pub struct OliviaData {
 }
 
 impl OliviaData {
-    // Note: protocol tests have example 1 as well, but so far we are not asserting on that level of
-    // granularity; example 1 can be pulled in once needed
     pub fn example_0() -> Self {
         Self::example(
             Self::EVENT_ID_0,
             Self::PRICE_0,
             &Self::NONCE_PKS_0,
             &Self::ATTESTATIONS_0,
+        )
+    }
+
+    pub fn example_1() -> Self {
+        Self::example(
+            Self::EVENT_ID_1,
+            Self::PRICE_1,
+            &Self::NONCE_PKS_1,
+            &Self::ATTESTATIONS_1,
         )
     }
 
@@ -116,5 +124,52 @@ impl OliviaData {
         "0818c9c245d7d2162cd393c562a121f80405a27d22ae465e95030c31ebb4bd24",
         "b7c03f0bd6d63bd78ad4ea0f3452ff9717ba65ca42038e6e90a1aa558b7942dc",
         "90c4d8ec9f408ccb62a62daa993c20f2f86799e1fdea520c6d060418e55fd216",
+    ];
+
+    const EVENT_ID_1: &'static str = "/x/BitMEX/BXBT/2021-10-05T08:00:00.price?n=20";
+    const NONCE_PKS_1: [&'static str; 20] = [
+        "150df2e64f39706e726eaa1fe081af3edf376d9644723e135a99328fd194caca",
+        "b90629cedc7cb8430b4d15c84bbe1fe173e70e626d40c465e64de29d4879e20f",
+        "ae14ffb8701d3e224b6632a1bb7b099c8aa90979c3fb788422daa08bca25fa68",
+        "3717940a7e8c35b48b3596498ed93e4d54ba01a2bcbb645d30dae2fc98f087a8",
+        "91beb5da91cc8b4ee6ae603e7ae41cc041d5ea2c13bae9f0e630c69f6c0adfad",
+        "c51cafb450b01f30ec8bd2b4b5fed6f7e179f49945959f0d7609b4b9c5ab3781",
+        "75f2d9332aa1b2d84446a4b2aa276b4c2853659ab0ba74f0881289d3ab700f0c",
+        "5367de73acb53e69b0a4f777e564f87055fede5d4492ddafae876a815fa6166c",
+        "2087a513adb1aa2cc8506ca58306723ed13ba82e054f5bf29fcbeef1ab915c5a",
+        "71c980fb6adae9c121405628c91daffcc5ab52a8a0b6f53c953e8a0236b05782",
+        "d370d22f06751fc649f6ee930ac7f8f3b00389fdad02883a8038a81c46c33b19",
+        "fa6f7d37dc88b510c250dcae1023cce5009d5beb85a75f5b8b10c973b62348aa",
+        "a658077f9c963d1f41cf63b7ebf6e08331f5d201554b3af7814673108abe1bf3",
+        "8a816bf4caa2d6114b2e4d3ab9bff0d470ee0b90163c78c9b67f90238ead9319",
+        "c2519a4e764a65204c469062e260d8565f7730847c507b92c987e478ca91abe1",
+        "59cb6b5beac6511a671076530cc6cc9f1926f54c640828f38c363b110dd8a0cd",
+        "4625b1f3ab9ee01455fa1a98d15fc8d73a7cf41becb4ca5c6eab88db0ba7c114",
+        "82a4de403c604fe40aa3804c5ada6af54c425c0576980b50f259d32dc1a0fcff",
+        "5c4fb87b3812982759ed7264676e713e4e477a41759261515b04797db393ef62",
+        "f3f6b9134c0fdd670767fbf478fd0dd3430f195ce9c21cabb84f3c1dd4848a11",
+    ];
+    const PRICE_1: u64 = 49493;
+    const ATTESTATIONS_1: [&'static str; 20] = [
+        "605f458e9a7bd216ff522e45f6cd14378c03ccfd4d35a69b9b6ce5c4ebfc89fa",
+        "edc7215277d2c24a7a4659ff8831352db609fcc467fead5e27fdada172cdfd86",
+        "1c2d76fcbe724b1fabd2622b991e90bbb2ea9244489de960747134c9fd695dcb",
+        "26b4f078c9ca2233b18b0e42c4bb9867e5de8ee35b500e30b28d9b1742322e49",
+        "2b59aeaacb80056b45dc12d6525d5c75343ef75730623c8d9893e2b681bf4b85",
+        "782e38e777d527e7cb0028a6d03e8f760c6202dbc5ac605f67f995919dee6182",
+        "a902f37f71a78e4bcf431a778024bd775db6d7ade0626a9e7bc4cdf0b1e52dfd",
+        "3927eb5ef3b56817c08709e0af1bb643ad4d95dbf5a92a49e1e9c8c811e929c4",
+        "9ff44fa9d8377a3531792cd6362e4a5b24b86d85602749d301f8449859065b77",
+        "6a2156ff0aaef174b36d5f8adc597fdcb26f306f7ef6e9a485faabc8eb29da2e",
+        "53445b507c0de312959fe4566b82db93987dd0b854f1a33bbad7768512bcaf69",
+        "793c40e0ec3a830c46658bfaed7df74e3fc6781e421e00db5b5f46b26ce4d092",
+        "db7f800da2f22878c8fc8368047308146e1ebd6316c389303c07ebeed7488fc9",
+        "73921d09e0d567a03f3a411c0f3455f9f652bbede808a694cca0fa94619f5ba9",
+        "3d4bd70d93f20aa6b1621ccd077c90bcdee47ce2bae15155434a77a3153a3235",
+        "90fc10577ab737e311b43288a266490f222a6ecb9f9667e01d7a54c0437d145f",
+        "51d350616c6fdf90254240b757184fc0dd226328adb42be214ec25832854950e",
+        "bab3a6269e172ac590fd36683724f087b4add293bb0ee4ef3d21fb5929985c75",
+        "d65a4c71062fc0b0210bb3e239f60d826a37d28caadfc52edd7afde6e91ff818",
+        "ea5dfd972784808a15543f850c7bc86bff2b51cff81ec68fc4c3977d5e7d38de",
     ];
 }

--- a/daemon-tests/src/mocks/mod.rs
+++ b/daemon-tests/src/mocks/mod.rs
@@ -7,7 +7,6 @@ use model::olivia;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::sync::MutexGuard;
-
 pub mod monitor;
 pub mod oracle;
 pub mod price_feed;

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -426,12 +426,22 @@ impl Cfd {
             OfferRejected => {
                 self.aggregated.state = CfdState::Rejected;
             }
-            RolloverCompleted { dlc, funding_fee } => {
+            RolloverCompleted {
+                dlc,
+                funding_fee,
+                complete_fee,
+            } => {
                 self.aggregated.rollover_state = None;
                 self.expiry_timestamp = dlc.as_ref().map(|dlc| dlc.settlement_event_id.timestamp());
                 self.aggregated.latest_dlc = dlc;
-                self.aggregated.fee_account =
-                    self.aggregated.fee_account.add_funding_fee(funding_fee);
+
+                self.aggregated.fee_account = match complete_fee {
+                    None => self.aggregated.fee_account.add_funding_fee(funding_fee),
+                    Some(complete_fee) => {
+                        self.aggregated.fee_account.from_complete_fee(complete_fee)
+                    }
+                };
+
                 self.accumulated_fees = self.aggregated.fee_account.balance();
 
                 self.aggregated.state = CfdState::Open;

--- a/daemon/src/rollover/maker.rs
+++ b/daemon/src/rollover/maker.rs
@@ -303,8 +303,12 @@ impl Actor {
                         .await
                         .context("Failed to send Msg2")?;
 
-                    let revoked_commit =
-                        finalize_revoked_commits(&dlc, own_cfd_txs.commit.1, msg2)?;
+                    let revoked_commit = finalize_revoked_commits(
+                        &dlc,
+                        own_cfd_txs.commit.1,
+                        msg2,
+                        rollover_params.complete_fee_before_rollover(),
+                    )?;
 
                     let dlc = Dlc {
                         identity: dlc.identity,
@@ -328,7 +332,7 @@ impl Actor {
                         refund_timelock: rollover_params.refund_timelock,
                     };
 
-                    emit_completed(order_id, dlc, funding_fee, &executor).await;
+                    emit_completed(order_id, dlc, funding_fee, complete_fee, &executor).await;
 
                     Ok(())
                 }

--- a/daemon/src/rollover/maker.rs
+++ b/daemon/src/rollover/maker.rs
@@ -306,23 +306,6 @@ impl Actor {
                     let revoked_commit =
                         finalize_revoked_commits(&dlc, own_cfd_txs.commit.1, msg2)?;
 
-                    let _msg3 = framed
-                        .next()
-                        .timeout(ROLLOVER_MSG_TIMEOUT)
-                        .await
-                        .with_context(|| format_expect_msg_within("Msg3", ROLLOVER_MSG_TIMEOUT))?
-                        .context("Empty stream instead of Msg3")?
-                        .context("Unable to decode dialer Msg3")?
-                        .into_rollover_msg()?
-                        .try_into_msg3()?;
-
-                    framed
-                        .send(ListenerMessage::RolloverMsg(Box::new(RolloverMsg::Msg3(
-                            RolloverMsg3,
-                        ))))
-                        .await
-                        .context("Failed to send Msg3")?;
-
                     let dlc = Dlc {
                         identity: dlc.identity,
                         identity_counterparty: dlc.identity_counterparty,

--- a/daemon/src/rollover/protocol.rs
+++ b/daemon/src/rollover/protocol.rs
@@ -15,6 +15,7 @@ use bdk::bitcoin::secp256k1::SECP256K1;
 use bdk::bitcoin::util::psbt::PartiallySignedTransaction;
 use bdk::bitcoin::Amount;
 use bdk::bitcoin::Transaction;
+use bdk::bitcoin::Txid;
 use bdk::descriptor::Descriptor;
 use bdk::miniscript::DescriptorTrait;
 use maia::commit_descriptor;
@@ -124,6 +125,7 @@ impl ListenerMessage {
 pub struct Propose {
     pub order_id: OrderId,
     pub timestamp: Timestamp,
+    pub from_commit_txid: Txid,
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize)]

--- a/daemon/src/rollover/protocol.rs
+++ b/daemon/src/rollover/protocol.rs
@@ -147,7 +147,6 @@ pub(crate) enum RolloverMsg {
     Msg0(RolloverMsg0),
     Msg1(RolloverMsg1),
     Msg2(RolloverMsg2),
-    Msg3(RolloverMsg3),
 }
 
 impl RolloverMsg {
@@ -172,14 +171,6 @@ impl RolloverMsg {
             Ok(v)
         } else {
             bail!("Not Msg2")
-        }
-    }
-
-    pub fn try_into_msg3(self) -> Result<RolloverMsg3> {
-        if let Self::Msg3(v) = self {
-            Ok(v)
-        } else {
-            bail!("Not Msg3")
         }
     }
 }
@@ -604,6 +595,7 @@ pub(crate) fn finalize_revoked_commits(
         publication_pk_theirs: dlc.publish_pk_counterparty,
         txid: transaction.txid(),
         script_pubkey: dlc.commit.2.script_pubkey(),
+        event_id: dlc.settlement_event_id,
     });
 
     Ok(revoked_commit)

--- a/daemon/src/rollover/protocol.rs
+++ b/daemon/src/rollover/protocol.rs
@@ -595,7 +595,7 @@ pub(crate) fn finalize_revoked_commits(
         publication_pk_theirs: dlc.publish_pk_counterparty,
         txid: transaction.txid(),
         script_pubkey: dlc.commit.2.script_pubkey(),
-        event_id: dlc.settlement_event_id,
+        settlement_event_id: Some(dlc.settlement_event_id),
     });
 
     Ok(revoked_commit)

--- a/daemon/src/rollover/taker.rs
+++ b/daemon/src/rollover/taker.rs
@@ -269,24 +269,6 @@ impl Actor {
                             let revoked_commit =
                                 finalize_revoked_commits(&dlc, own_cfd_txs.commit.1, msg2)?;
 
-                            framed
-                                .send(DialerMessage::RolloverMsg(Box::new(RolloverMsg::Msg3(
-                                    RolloverMsg3,
-                                ))))
-                                .await
-                                .context("Failed to send Msg3")?;
-                            let _msg3 = framed
-                                .next()
-                                .timeout(ROLLOVER_MSG_TIMEOUT)
-                                .await
-                                .with_context(|| {
-                                    format_expect_msg_within("Msg3", ROLLOVER_MSG_TIMEOUT)
-                                })?
-                                .context("Empty stream instead of Msg3")?
-                                .context("Unable to decode listener Msg3")?
-                                .into_rollover_msg()?
-                                .try_into_msg3()?;
-
                             let dlc = Dlc {
                                 identity: dlc.identity,
                                 identity_counterparty: dlc.identity_counterparty,

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -38,8 +38,8 @@ use maia_core::PunishParams;
 use model::calculate_payouts;
 use model::olivia;
 use model::Cet;
+use model::CompleteFee;
 use model::Dlc;
-use model::FeeFlow;
 use model::Position;
 use model::Role;
 use model::RolloverParams;
@@ -375,7 +375,7 @@ pub async fn roll_over(
     our_position: Position,
     dlc: Dlc,
     n_payouts: usize,
-    complete_fee: FeeFlow,
+    complete_fee: CompleteFee,
 ) -> Result<Dlc> {
     let (rev_sk, rev_pk) = keypair::new(&mut rand::thread_rng());
     let (publish_sk, publish_pk) = keypair::new(&mut rand::thread_rng());
@@ -459,7 +459,12 @@ pub async fn roll_over(
         .context("Empty stream instead of Msg2")?
         .try_into_msg2()?;
 
-    let revoked_commit = finalize_revoked_commits(&dlc, own_cfd_txs.commit.1, msg2.into())?;
+    let revoked_commit = finalize_revoked_commits(
+        &dlc,
+        own_cfd_txs.commit.1,
+        msg2.into(),
+        rollover_params.complete_fee_before_rollover(),
+    )?;
 
     // TODO: Remove send- and receiving ACK messages once we are able to handle incomplete DLC
     // monitoring

--- a/daemon/src/setup_contract_deprecated.rs
+++ b/daemon/src/setup_contract_deprecated.rs
@@ -41,8 +41,8 @@ use maia_deprecated::spending_tx_sighash;
 use model::calculate_payouts;
 use model::olivia;
 use model::Cet;
+use model::CompleteFee;
 use model::Dlc;
-use model::FeeFlow;
 use model::Position;
 use model::RevokedCommit;
 use model::Role;
@@ -376,7 +376,7 @@ pub async fn roll_over(
     our_position: Position,
     dlc: Dlc,
     n_payouts: usize,
-    complete_fee: FeeFlow,
+    complete_fee: CompleteFee,
 ) -> Result<Dlc> {
     let sk = dlc.identity;
     let pk =
@@ -647,8 +647,10 @@ pub async fn roll_over(
         publication_pk_theirs: dlc.publish_pk_counterparty,
         txid: transaction.txid(),
         script_pubkey: dlc.commit.2.script_pubkey(),
-        // We don't allow the taker to rollover from a specific commit-tx in the deprecated version because we cannot be sure this works side effect free.
+        // We don't allow the taker to rollover from a specific commit-tx in the deprecated version
+        // because we cannot be sure this works side effect free.
         settlement_event_id: None,
+        complete_fee: None,
     });
 
     // TODO: Remove send- and receiving ACK messages once we are able to handle incomplete DLC

--- a/daemon/src/setup_contract_deprecated.rs
+++ b/daemon/src/setup_contract_deprecated.rs
@@ -647,6 +647,8 @@ pub async fn roll_over(
         publication_pk_theirs: dlc.publish_pk_counterparty,
         txid: transaction.txid(),
         script_pubkey: dlc.commit.2.script_pubkey(),
+        // We don't allow the taker to rollover from a specific commit-tx in the deprecated version because we cannot be sure this works side effect free.
+        settlement_event_id: None,
     });
 
     // TODO: Remove send- and receiving ACK messages once we are able to handle incomplete DLC

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -17,7 +17,6 @@ use maia_core::CfdTransactions;
 use maia_core::PartyParams;
 use maia_core::PunishParams;
 use model::libp2p::PeerId;
-use model::FeeFlow;
 use model::FundingRate;
 use model::Leverage;
 use model::MakerOffers;
@@ -243,22 +242,22 @@ pub enum CompleteFee {
     Nein,
 }
 
-impl From<FeeFlow> for CompleteFee {
-    fn from(fee_flow: FeeFlow) -> Self {
-        match fee_flow {
-            FeeFlow::LongPaysShort(a) => CompleteFee::LongPaysShort(a),
-            FeeFlow::ShortPaysLong(a) => CompleteFee::ShortPaysLong(a),
-            FeeFlow::Nein => CompleteFee::Nein,
+impl From<model::CompleteFee> for CompleteFee {
+    fn from(complete_fee: model::CompleteFee) -> Self {
+        match complete_fee {
+            model::CompleteFee::LongPaysShort(a) => CompleteFee::LongPaysShort(a),
+            model::CompleteFee::ShortPaysLong(a) => CompleteFee::ShortPaysLong(a),
+            model::CompleteFee::None => CompleteFee::Nein,
         }
     }
 }
 
-impl From<CompleteFee> for FeeFlow {
-    fn from(fee_flow: CompleteFee) -> Self {
-        match fee_flow {
-            CompleteFee::LongPaysShort(a) => FeeFlow::LongPaysShort(a),
-            CompleteFee::ShortPaysLong(a) => FeeFlow::ShortPaysLong(a),
-            CompleteFee::Nein => FeeFlow::Nein,
+impl From<CompleteFee> for model::CompleteFee {
+    fn from(complete_fee: CompleteFee) -> Self {
+        match complete_fee {
+            CompleteFee::LongPaysShort(a) => model::CompleteFee::LongPaysShort(a),
+            CompleteFee::ShortPaysLong(a) => model::CompleteFee::ShortPaysLong(a),
+            CompleteFee::Nein => model::CompleteFee::None,
         }
     }
 }

--- a/maker/src/rollover.rs
+++ b/maker/src/rollover.rs
@@ -105,7 +105,7 @@ impl Actor {
         if let Err(e) = self
             .executor
             .execute(self.order_id, |cfd| {
-                Ok(cfd.complete_rollover(dlc, funding_fee))
+                Ok(cfd.complete_rollover(dlc, funding_fee, None))
             })
             .await
         {

--- a/maker/src/rollover.rs
+++ b/maker/src/rollover.rs
@@ -165,7 +165,7 @@ impl Actor {
                 };
 
                 let (event, params, dlc, position, event_id) =
-                    cfd.accept_rollover_proposal(tx_fee_rate, funding_rate, self.version)?;
+                    cfd.accept_rollover_proposal(tx_fee_rate, funding_rate, None, self.version)?;
                 Ok((event, params, dlc, position, event_id, funding_rate))
             })
             .await?;
@@ -304,7 +304,7 @@ impl xtra::Actor for Actor {
                 .await?;
 
             self.executor
-                .execute(self.order_id, |cfd| cfd.start_rollover())
+                .execute(self.order_id, |cfd| cfd.start_rollover_deprecated())
                 .await?;
 
             anyhow::Ok(())

--- a/model/proptest-regressions/cfd.txt
+++ b/model/proptest-regressions/cfd.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc c6ade7dfb7c844fb65bd2b8870ec8c904397d39d4ada695e17d2066f11368f50 # shrinks to minutes = 0
+cc 078abb474922d9c786b4b66265660a121142c317cadeacd135bc2badce171749 # shrinks to minutes = 60

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -2216,6 +2216,7 @@ pub struct RevokedCommit {
     // To monitor revoked commit transaction
     pub txid: Txid,
     pub script_pubkey: Script,
+    pub settlement_event_id: Option<BitMexPriceEventId>,
 }
 
 /// Used when transactions (e.g. collaborative close) are recorded as a part of

--- a/model/src/rollover.rs
+++ b/model/src/rollover.rs
@@ -1,3 +1,4 @@
+use crate::CompleteFee;
 use crate::FeeAccount;
 use crate::FundingFee;
 use crate::Leverage;
@@ -77,5 +78,9 @@ impl RolloverParams {
 
     pub fn funding_fee(&self) -> &FundingFee {
         &self.current_fee
+    }
+
+    pub fn complete_fee_before_rollover(&self) -> CompleteFee {
+        self.fee_account.settle()
     }
 }

--- a/sqlite-db/migrations/20220622041906_add_settlement_event_id_to_revoke_commit_transactions.sql
+++ b/sqlite-db/migrations/20220622041906_add_settlement_event_id_to_revoke_commit_transactions.sql
@@ -1,0 +1,5 @@
+ALTER TABLE
+    revoked_commit_transactions
+ADD
+    -- We allow NULL values to ensure backwards compatibility (we cannot chose a default value for this easily)
+    COLUMN settlement_event_id text NULL;

--- a/sqlite-db/migrations/20220622055305_add_complete_fee_to_rollover_tables.sql
+++ b/sqlite-db/migrations/20220622055305_add_complete_fee_to_rollover_tables.sql
@@ -1,0 +1,19 @@
+ALTER TABLE
+    rollover_completed_event_data
+ADD
+    -- The complete fee including this rollover (contrary to the funding_fee this field contains the accumulated fees until now).
+    COLUMN complete_fee INTEGER NULL;
+ALTER TABLE
+    rollover_completed_event_data
+ADD
+    COLUMN complete_fee_flow text NULL;
+ALTER TABLE
+    revoked_commit_transactions
+ADD
+    -- We add this as metadata to the revoked_commit_transactions so we are able to handle rollovers from a previous commit-tx-id.
+    -- This fields allows the maker to know what the complete fee was at a previous point in time.
+    COLUMN complete_fee INTEGER NULL;
+ALTER TABLE
+    revoked_commit_transactions
+ADD
+    COLUMN complete_fee_flow text NULL;

--- a/sqlite-db/sqlx-data.json
+++ b/sqlite-db/sqlx-data.json
@@ -1,5 +1,53 @@
 {
   "db": "SQLite",
+  "030ed8e5bcfb9b96de7d38135cd35ffd4ecbec84ed06aefe86660f4991808510": {
+    "query": "\n            SELECT\n                encsig_ours as \"encsig_ours: models::AdaptorSignature\",\n                publication_pk_theirs as \"publication_pk_theirs: models::PublicKey\",\n                revocation_sk_theirs as \"revocation_sk_theirs: models::SecretKey\",\n                script_pubkey,\n                settlement_event_id as \"settlement_event_id: models::BitMexPriceEventId\",\n                txid as \"txid: models::Txid\"\n            FROM\n                revoked_commit_transactions\n            WHERE\n                cfd_id = $1\n            ",
+    "describe": {
+      "columns": [
+        {
+          "name": "encsig_ours: models::AdaptorSignature",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "publication_pk_theirs: models::PublicKey",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "revocation_sk_theirs: models::SecretKey",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "script_pubkey",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "settlement_event_id: models::BitMexPriceEventId",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "txid: models::Txid",
+          "ordinal": 5,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        true,
+        false
+      ]
+    }
+  },
   "060f5ccae5e675d3118ae357eb225c7fa37d54802a24e328db1dc84e547d4d9d": {
     "query": "\n            delete from open_cets where cfd_id = (select id from cfds where cfds.uuid = $1)\n        ",
     "describe": {
@@ -388,48 +436,6 @@
         "Right": 1
       },
       "nullable": []
-    }
-  },
-  "6792c293c2931ae9575cfc840b32d212729a409630ff1a3d452d54ee5072267d": {
-    "query": "\n            SELECT\n                encsig_ours as \"encsig_ours: models::AdaptorSignature\",\n                publication_pk_theirs as \"publication_pk_theirs: models::PublicKey\",\n                revocation_sk_theirs as \"revocation_sk_theirs: models::SecretKey\",\n                script_pubkey,\n                txid as \"txid: models::Txid\"\n            FROM\n                revoked_commit_transactions\n            WHERE\n                cfd_id = $1\n            ",
-    "describe": {
-      "columns": [
-        {
-          "name": "encsig_ours: models::AdaptorSignature",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "publication_pk_theirs: models::PublicKey",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "revocation_sk_theirs: models::SecretKey",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "script_pubkey",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "txid: models::Txid",
-          "ordinal": 4,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
     }
   },
   "7a2f760e4af1661f6df85ba6ce17ea746723f6b2d28f933aa8692c63e9c904be": {
@@ -874,16 +880,6 @@
       "nullable": []
     }
   },
-  "d8d9d380f3847552a7060c0cdde8f1ade3ed0d4a260bc07137a6c274d556a927": {
-    "query": "\n                insert into revoked_commit_transactions (\n                    cfd_id,\n                    encsig_ours,\n                    publication_pk_theirs,\n                    revocation_sk_theirs,\n                    script_pubkey,\n                    txid\n                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6 )\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 6
-      },
-      "nullable": []
-    }
-  },
   "dff18431c5abb3a65efde6fda9e48658f4533c9726bbc993f4b99e0d1924dac5": {
     "query": "\n        SELECT\n            collaborative_settlement_txs.txid as \"txid: models::Txid\",\n            collaborative_settlement_txs.vout as \"vout: models::Vout\",\n            collaborative_settlement_txs.payout as \"payout: models::Payout\",\n            collaborative_settlement_txs.price as \"price: models::Price\"\n        FROM\n            collaborative_settlement_txs\n        JOIN\n            closed_cfds on closed_cfds.id = collaborative_settlement_txs.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        ",
     "describe": {
@@ -1032,6 +1028,16 @@
       "nullable": [
         false
       ]
+    }
+  },
+  "f7b758f27f6bc3ae68ce5b42d1b5ac093691f1a8bcf90712a69a78426f5c2c77": {
+    "query": "\n                insert into revoked_commit_transactions (\n                    cfd_id,\n                    encsig_ours,\n                    publication_pk_theirs,\n                    revocation_sk_theirs,\n                    script_pubkey,\n                    txid,\n                    settlement_event_id\n                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6, $7 )\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 7
+      },
+      "nullable": []
     }
   },
   "fc7e8992943cd5c64d307272eb1951e4c7c645308b20245d5f2818aaaf3b265b": {

--- a/sqlite-db/sqlx-data.json
+++ b/sqlite-db/sqlx-data.json
@@ -1,7 +1,17 @@
 {
   "db": "SQLite",
-  "030ed8e5bcfb9b96de7d38135cd35ffd4ecbec84ed06aefe86660f4991808510": {
-    "query": "\n            SELECT\n                encsig_ours as \"encsig_ours: models::AdaptorSignature\",\n                publication_pk_theirs as \"publication_pk_theirs: models::PublicKey\",\n                revocation_sk_theirs as \"revocation_sk_theirs: models::SecretKey\",\n                script_pubkey,\n                settlement_event_id as \"settlement_event_id: models::BitMexPriceEventId\",\n                txid as \"txid: models::Txid\"\n            FROM\n                revoked_commit_transactions\n            WHERE\n                cfd_id = $1\n            ",
+  "060f5ccae5e675d3118ae357eb225c7fa37d54802a24e328db1dc84e547d4d9d": {
+    "query": "\n            delete from open_cets where cfd_id = (select id from cfds where cfds.uuid = $1)\n        ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": []
+    }
+  },
+  "1007a8cb0d30734c34794cf7c076d4cf2757bd7e270d7429220b12fae60d0b3f": {
+    "query": "\n            SELECT\n                encsig_ours as \"encsig_ours: models::AdaptorSignature\",\n                publication_pk_theirs as \"publication_pk_theirs: models::PublicKey\",\n                revocation_sk_theirs as \"revocation_sk_theirs: models::SecretKey\",\n                script_pubkey,\n                settlement_event_id as \"settlement_event_id: models::BitMexPriceEventId\",\n                txid as \"txid: models::Txid\",\n                complete_fee as \"complete_fee: i64\",\n                complete_fee_flow as \"complete_fee_flow: models::FeeFlow\"\n            FROM\n                revoked_commit_transactions\n            WHERE\n                cfd_id = $1\n            ",
     "describe": {
       "columns": [
         {
@@ -33,6 +43,16 @@
           "name": "txid: models::Txid",
           "ordinal": 5,
           "type_info": "Text"
+        },
+        {
+          "name": "complete_fee: i64",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "complete_fee_flow: models::FeeFlow",
+          "ordinal": 7,
+          "type_info": "Text"
         }
       ],
       "parameters": {
@@ -44,155 +64,9 @@
         false,
         false,
         true,
-        false
-      ]
-    }
-  },
-  "060f5ccae5e675d3118ae357eb225c7fa37d54802a24e328db1dc84e547d4d9d": {
-    "query": "\n            delete from open_cets where cfd_id = (select id from cfds where cfds.uuid = $1)\n        ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": []
-    }
-  },
-  "107d46c4610fd22c505da985eac6deb5e134f622f8957776bc87b6fdf66bad46": {
-    "query": "\n            SELECT\n                settlement_event_id as \"settlement_event_id: models::BitMexPriceEventId\",\n                refund_timelock as \"refund_timelock: i64\",\n                funding_fee as \"funding_fee: i64\",\n                rate as \"rate: models::FundingRate\",\n                identity as \"identity: models::SecretKey\",\n                identity_counterparty as \"identity_counterparty: models::PublicKey\",\n                maker_address,\n                taker_address,\n                maker_lock_amount as \"maker_lock_amount: i64\",\n                taker_lock_amount as \"taker_lock_amount: i64\",\n                publish_sk as \"publish_sk: models::SecretKey\",\n                publish_pk_counterparty as \"publish_pk_counterparty: models::PublicKey\",\n                revocation_secret as \"revocation_secret: models::SecretKey\",\n                revocation_pk_counterparty as \"revocation_pk_counterparty: models::PublicKey\",\n                lock_tx as \"lock_tx: models::Transaction\",\n                lock_tx_descriptor,\n                commit_tx as \"commit_tx: models::Transaction\",\n                commit_adaptor_signature as \"commit_adaptor_signature: models::AdaptorSignature\",\n                commit_descriptor,\n                refund_tx as \"refund_tx: models::Transaction\",\n                refund_signature\n            FROM\n                rollover_completed_event_data\n            WHERE \n                cfd_id = $1 and \n                event_id = $2\n            ",
-    "describe": {
-      "columns": [
-        {
-          "name": "settlement_event_id: models::BitMexPriceEventId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "refund_timelock: i64",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "funding_fee: i64",
-          "ordinal": 2,
-          "type_info": "Null"
-        },
-        {
-          "name": "rate: models::FundingRate",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "identity: models::SecretKey",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "identity_counterparty: models::PublicKey",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "maker_address",
-          "ordinal": 6,
-          "type_info": "Text"
-        },
-        {
-          "name": "taker_address",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "maker_lock_amount: i64",
-          "ordinal": 8,
-          "type_info": "Null"
-        },
-        {
-          "name": "taker_lock_amount: i64",
-          "ordinal": 9,
-          "type_info": "Null"
-        },
-        {
-          "name": "publish_sk: models::SecretKey",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "publish_pk_counterparty: models::PublicKey",
-          "ordinal": 11,
-          "type_info": "Text"
-        },
-        {
-          "name": "revocation_secret: models::SecretKey",
-          "ordinal": 12,
-          "type_info": "Text"
-        },
-        {
-          "name": "revocation_pk_counterparty: models::PublicKey",
-          "ordinal": 13,
-          "type_info": "Text"
-        },
-        {
-          "name": "lock_tx: models::Transaction",
-          "ordinal": 14,
-          "type_info": "Text"
-        },
-        {
-          "name": "lock_tx_descriptor",
-          "ordinal": 15,
-          "type_info": "Text"
-        },
-        {
-          "name": "commit_tx: models::Transaction",
-          "ordinal": 16,
-          "type_info": "Text"
-        },
-        {
-          "name": "commit_adaptor_signature: models::AdaptorSignature",
-          "ordinal": 17,
-          "type_info": "Text"
-        },
-        {
-          "name": "commit_descriptor",
-          "ordinal": 18,
-          "type_info": "Text"
-        },
-        {
-          "name": "refund_tx: models::Transaction",
-          "ordinal": 19,
-          "type_info": "Text"
-        },
-        {
-          "name": "refund_signature",
-          "ordinal": 20,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 2
-      },
-      "nullable": [
         false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
+        true,
+        true
       ]
     }
   },
@@ -418,22 +292,22 @@
       "nullable": []
     }
   },
-  "63c18f39f0262c9178094ef11bb29bf64559611425ef5dca51ecc925cd1ce596": {
-    "query": "\n            insert into rollover_completed_event_data (\n                cfd_id,\n                event_id,\n                settlement_event_id,\n                refund_timelock,\n                funding_fee,\n                rate,\n                identity,\n                identity_counterparty,\n                maker_address,\n                taker_address,\n                maker_lock_amount,\n                taker_lock_amount,\n                publish_sk,\n                publish_pk_counterparty,\n                revocation_secret,\n                revocation_pk_counterparty,\n                lock_tx,\n                lock_tx_descriptor,\n                commit_tx,\n                commit_adaptor_signature,\n                commit_descriptor,\n                refund_tx,\n                refund_signature\n            ) values ( \n            (select id from cfds where cfds.uuid = $1),\n            $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23\n            )\n        ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 23
-      },
-      "nullable": []
-    }
-  },
   "6705894784db563cfc16ca0ac9c2a4eb152fe6f9111c068c4c077e7de930e0a0": {
     "query": "\n        DELETE FROM\n            cfds\n        WHERE\n            cfds.uuid = $1\n        ",
     "describe": {
       "columns": [],
       "parameters": {
         "Right": 1
+      },
+      "nullable": []
+    }
+  },
+  "6a0e947eb3254ed994e44b0018ca9232d37bc405b37856b15be5a0ef81757af1": {
+    "query": "\n            insert into rollover_completed_event_data (\n                cfd_id,\n                event_id,\n                settlement_event_id,\n                refund_timelock,\n                funding_fee,\n                rate,\n                identity,\n                identity_counterparty,\n                maker_address,\n                taker_address,\n                maker_lock_amount,\n                taker_lock_amount,\n                publish_sk,\n                publish_pk_counterparty,\n                revocation_secret,\n                revocation_pk_counterparty,\n                lock_tx,\n                lock_tx_descriptor,\n                commit_tx,\n                commit_adaptor_signature,\n                commit_descriptor,\n                refund_tx,\n                refund_signature,\n                complete_fee,\n                complete_fee_flow\n            ) values ( \n            (select id from cfds where cfds.uuid = $1),\n            $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25\n            )\n        ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 25
       },
       "nullable": []
     }
@@ -662,6 +536,156 @@
       "nullable": []
     }
   },
+  "b15920dbf09664b23c4bf64bf552b865a3280e186d3bd9ac424dc2e46493b6ea": {
+    "query": "\n            SELECT\n                settlement_event_id as \"settlement_event_id: models::BitMexPriceEventId\",\n                refund_timelock as \"refund_timelock: i64\",\n                funding_fee as \"funding_fee: i64\",\n                rate as \"rate: models::FundingRate\",\n                identity as \"identity: models::SecretKey\",\n                identity_counterparty as \"identity_counterparty: models::PublicKey\",\n                maker_address,\n                taker_address,\n                maker_lock_amount as \"maker_lock_amount: i64\",\n                taker_lock_amount as \"taker_lock_amount: i64\",\n                publish_sk as \"publish_sk: models::SecretKey\",\n                publish_pk_counterparty as \"publish_pk_counterparty: models::PublicKey\",\n                revocation_secret as \"revocation_secret: models::SecretKey\",\n                revocation_pk_counterparty as \"revocation_pk_counterparty: models::PublicKey\",\n                lock_tx as \"lock_tx: models::Transaction\",\n                lock_tx_descriptor,\n                commit_tx as \"commit_tx: models::Transaction\",\n                commit_adaptor_signature as \"commit_adaptor_signature: models::AdaptorSignature\",\n                commit_descriptor,\n                refund_tx as \"refund_tx: models::Transaction\",\n                refund_signature,\n                complete_fee as \"complete_fee: i64\",\n                complete_fee_flow as \"complete_fee_flow: models::FeeFlow\"\n            FROM\n                rollover_completed_event_data\n            WHERE \n                cfd_id = $1 and \n                event_id = $2\n            ",
+    "describe": {
+      "columns": [
+        {
+          "name": "settlement_event_id: models::BitMexPriceEventId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "refund_timelock: i64",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "funding_fee: i64",
+          "ordinal": 2,
+          "type_info": "Null"
+        },
+        {
+          "name": "rate: models::FundingRate",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "identity: models::SecretKey",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "identity_counterparty: models::PublicKey",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "maker_address",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "taker_address",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "maker_lock_amount: i64",
+          "ordinal": 8,
+          "type_info": "Null"
+        },
+        {
+          "name": "taker_lock_amount: i64",
+          "ordinal": 9,
+          "type_info": "Null"
+        },
+        {
+          "name": "publish_sk: models::SecretKey",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "publish_pk_counterparty: models::PublicKey",
+          "ordinal": 11,
+          "type_info": "Text"
+        },
+        {
+          "name": "revocation_secret: models::SecretKey",
+          "ordinal": 12,
+          "type_info": "Text"
+        },
+        {
+          "name": "revocation_pk_counterparty: models::PublicKey",
+          "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "lock_tx: models::Transaction",
+          "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "lock_tx_descriptor",
+          "ordinal": 15,
+          "type_info": "Text"
+        },
+        {
+          "name": "commit_tx: models::Transaction",
+          "ordinal": 16,
+          "type_info": "Text"
+        },
+        {
+          "name": "commit_adaptor_signature: models::AdaptorSignature",
+          "ordinal": 17,
+          "type_info": "Text"
+        },
+        {
+          "name": "commit_descriptor",
+          "ordinal": 18,
+          "type_info": "Text"
+        },
+        {
+          "name": "refund_tx: models::Transaction",
+          "ordinal": 19,
+          "type_info": "Text"
+        },
+        {
+          "name": "refund_signature",
+          "ordinal": 20,
+          "type_info": "Text"
+        },
+        {
+          "name": "complete_fee: i64",
+          "ordinal": 21,
+          "type_info": "Int64"
+        },
+        {
+          "name": "complete_fee_flow: models::FeeFlow",
+          "ordinal": 22,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 2
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true
+      ]
+    }
+  },
   "bfccb1d1578875f599f2553fc4902b4344edecf08ea954dd6810e4a9c53e76af": {
     "query": "\n            SELECT\n                uuid as \"id: models::OrderId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                taker_leverage as \"taker_leverage: models::Leverage\",\n                n_contracts as \"n_contracts: models::Contracts\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                fees as \"fees: models::Fees\",\n                kind as \"kind: models::FailedKind\"\n            FROM\n                failed_cfds\n            WHERE\n                failed_cfds.uuid = $1\n            ",
     "describe": {
@@ -880,6 +904,16 @@
       "nullable": []
     }
   },
+  "d976d272379c97848872132ea551766bf822f81d078cd2ffd097da42d11aed8b": {
+    "query": "\n                insert into revoked_commit_transactions (\n                    cfd_id,\n                    encsig_ours,\n                    publication_pk_theirs,\n                    revocation_sk_theirs,\n                    script_pubkey,\n                    txid,\n                    settlement_event_id,\n                    complete_fee,\n                    complete_fee_flow\n                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6, $7, $8, $9 )\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 9
+      },
+      "nullable": []
+    }
+  },
   "dff18431c5abb3a65efde6fda9e48658f4533c9726bbc993f4b99e0d1924dac5": {
     "query": "\n        SELECT\n            collaborative_settlement_txs.txid as \"txid: models::Txid\",\n            collaborative_settlement_txs.vout as \"vout: models::Vout\",\n            collaborative_settlement_txs.payout as \"payout: models::Payout\",\n            collaborative_settlement_txs.price as \"price: models::Price\"\n        FROM\n            collaborative_settlement_txs\n        JOIN\n            closed_cfds on closed_cfds.id = collaborative_settlement_txs.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        ",
     "describe": {
@@ -1028,16 +1062,6 @@
       "nullable": [
         false
       ]
-    }
-  },
-  "f7b758f27f6bc3ae68ce5b42d1b5ac093691f1a8bcf90712a69a78426f5c2c77": {
-    "query": "\n                insert into revoked_commit_transactions (\n                    cfd_id,\n                    encsig_ours,\n                    publication_pk_theirs,\n                    revocation_sk_theirs,\n                    script_pubkey,\n                    txid,\n                    settlement_event_id\n                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6, $7 )\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 7
-      },
-      "nullable": []
     }
   },
   "fc7e8992943cd5c64d307272eb1951e4c7c645308b20245d5f2818aaaf3b265b": {

--- a/sqlite-db/src/closed.rs
+++ b/sqlite-db/src/closed.rs
@@ -297,8 +297,15 @@ impl ClosedCfdInputAggregate {
             RolloverStarted => {}
             RolloverAccepted => {}
             RolloverRejected => {}
-            RolloverCompleted { dlc, funding_fee } => {
-                self.fee_account = self.fee_account.add_funding_fee(funding_fee);
+            RolloverCompleted {
+                dlc,
+                funding_fee,
+                complete_fee,
+            } => {
+                self.fee_account = match complete_fee {
+                    None => self.fee_account.add_funding_fee(funding_fee),
+                    Some(complete_fee) => self.fee_account.from_complete_fee(complete_fee),
+                };
                 self.latest_dlc = dlc;
             }
             RolloverFailed => {}

--- a/sqlite-db/src/lib.rs
+++ b/sqlite-db/src/lib.rs
@@ -658,12 +658,13 @@ async fn load_cfd_events(
 
     for (cfd_row_id, event_row_id, event) in events.iter_mut() {
         if let RolloverCompleted { .. } = event.event {
-            if let Some((dlc, funding_fee)) =
+            if let Some((dlc, funding_fee, complete_fee)) =
                 rollover::load(conn, *cfd_row_id, *event_row_id).await?
             {
                 event.event = RolloverCompleted {
                     dlc: Some(dlc),
                     funding_fee,
+                    complete_fee,
                 }
             }
         }

--- a/sqlite-db/src/rollover/insert.rs
+++ b/sqlite-db/src/rollover/insert.rs
@@ -183,6 +183,9 @@ async fn insert_revoked_commit_transaction(
     let publication_pk_theirs = models::PublicKey::from(revoked.publication_pk_theirs);
     let encsig_ours = models::AdaptorSignature::from(revoked.encsig_ours);
     let txid = models::Txid::from(revoked.txid);
+    let settlement_event_id = revoked
+        .settlement_event_id
+        .map(models::BitMexPriceEventId::from);
     let query_result = sqlx::query!(
         r#"
                 insert into revoked_commit_transactions (
@@ -191,15 +194,17 @@ async fn insert_revoked_commit_transaction(
                     publication_pk_theirs,
                     revocation_sk_theirs,
                     script_pubkey,
-                    txid
-                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6 )
+                    txid,
+                    settlement_event_id
+                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6, $7 )
             "#,
         offer_id,
         encsig_ours,
         publication_pk_theirs,
         revocation_secret,
         revoked_tx_script_pubkey,
-        txid
+        txid,
+        settlement_event_id
     )
     .execute(&mut *inner_transaction)
     .await?;

--- a/sqlite-db/src/rollover/insert.rs
+++ b/sqlite-db/src/rollover/insert.rs
@@ -1,8 +1,10 @@
 use crate::models;
+use crate::models::into_complete_fee_and_flow;
 use anyhow::Result;
 use bdk::bitcoin::hashes::hex::ToHex;
 use model::Cet;
 use model::CfdEvent;
+use model::CompleteFee;
 use model::Dlc;
 use model::EventKind;
 use model::FundingFee;
@@ -23,6 +25,7 @@ pub async fn insert(
         EventKind::RolloverCompleted {
             dlc: Some(dlc),
             funding_fee,
+            complete_fee,
         } => {
             let mut inner_transaction = connection.begin().await?;
 
@@ -33,6 +36,7 @@ pub async fn insert(
                 event_id,
                 &dlc,
                 funding_fee,
+                complete_fee,
                 event.id.into(),
             )
             .await?;
@@ -75,6 +79,7 @@ async fn insert_rollover_completed_event_data(
     event_id: i64,
     dlc: &Dlc,
     funding_fee: FundingFee,
+    complete_fee: Option<CompleteFee>,
     offer_id: models::OrderId,
 ) -> Result<()> {
     let (lock_tx, lock_tx_descriptor) = dlc.lock.clone();
@@ -109,6 +114,8 @@ async fn insert_rollover_completed_event_data(
     let rate = models::FundingRate::from(funding_fee.rate);
     let settlement_event_id = models::BitMexPriceEventId::from(dlc.settlement_event_id);
 
+    let (complete_fee, complete_fee_flow) = into_complete_fee_and_flow(complete_fee);
+
     let query_result = sqlx::query!(
         r#"
             insert into rollover_completed_event_data (
@@ -134,10 +141,12 @@ async fn insert_rollover_completed_event_data(
                 commit_adaptor_signature,
                 commit_descriptor,
                 refund_tx,
-                refund_signature
+                refund_signature,
+                complete_fee,
+                complete_fee_flow
             ) values ( 
             (select id from cfds where cfds.uuid = $1),
-            $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23
+            $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25
             )
         "#,
         offer_id,
@@ -163,6 +172,8 @@ async fn insert_rollover_completed_event_data(
         commit_tx_descriptor,
         refund_tx,
         refund_signature,
+        complete_fee,
+        complete_fee_flow,
     )
     .execute(&mut *inner_transaction)
     .await?;
@@ -186,6 +197,9 @@ async fn insert_revoked_commit_transaction(
     let settlement_event_id = revoked
         .settlement_event_id
         .map(models::BitMexPriceEventId::from);
+
+    let (complete_fee, complete_fee_flow) = into_complete_fee_and_flow(revoked.complete_fee);
+
     let query_result = sqlx::query!(
         r#"
                 insert into revoked_commit_transactions (
@@ -195,8 +209,10 @@ async fn insert_revoked_commit_transaction(
                     revocation_sk_theirs,
                     script_pubkey,
                     txid,
-                    settlement_event_id
-                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6, $7 )
+                    settlement_event_id,
+                    complete_fee,
+                    complete_fee_flow
+                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6, $7, $8, $9 )
             "#,
         offer_id,
         encsig_ours,
@@ -204,7 +220,9 @@ async fn insert_revoked_commit_transaction(
         revocation_secret,
         revoked_tx_script_pubkey,
         txid,
-        settlement_event_id
+        settlement_event_id,
+        complete_fee,
+        complete_fee_flow,
     )
     .execute(&mut *inner_transaction)
     .await?;

--- a/sqlite-db/src/rollover/load.rs
+++ b/sqlite-db/src/rollover/load.rs
@@ -118,6 +118,7 @@ async fn load_revoked_commit_transactions(
                 publication_pk_theirs as "publication_pk_theirs: models::PublicKey",
                 revocation_sk_theirs as "revocation_sk_theirs: models::SecretKey",
                 script_pubkey,
+                settlement_event_id as "settlement_event_id: models::BitMexPriceEventId",
                 txid as "txid: models::Txid"
             FROM
                 revoked_commit_transactions
@@ -136,6 +137,9 @@ async fn load_revoked_commit_transactions(
             publication_pk_theirs: row.publication_pk_theirs.into(),
             script_pubkey: Script::from_hex(row.script_pubkey.as_str())?,
             txid: row.txid.into(),
+            settlement_event_id: row
+                .settlement_event_id
+                .map(|settlement_event_id| settlement_event_id.into()),
         })
     })
     .collect::<Result<Vec<_>>>()?;

--- a/sqlite-db/src/test_events/rollover_completed.json
+++ b/sqlite-db/src/test_events/rollover_completed.json
@@ -584,7 +584,8 @@
           "publication_pk_theirs": "0365b5818a889a2d6756db89c723631b9add9ea1911d1ad7c7184477fe41f46424",
           "revocation_sk_theirs": "e4f2652ba41bedf0271e85ccd2ffb6f972bb4b67591dda43979c638b1187fba6",
           "script_pubkey": "0020de27d4eeaa1bcec849f007bb55ccb1adc638484caf1e67f503dfbdda751edd10",
-          "txid": "53f58ce696b0f732ae5a637741b0bd23d69e313848183fd4b32d1a98a9143299"
+          "txid": "53f58ce696b0f732ae5a637741b0bd23d69e313848183fd4b32d1a98a9143299",
+          "settlement_event_id": "/x/BitMEX/BXBT/2022-04-15T00:00:00.price?n=20"
         }
       ],
       "settlement_event_id": "/x/BitMEX/BXBT/2022-04-15T01:00:00.price?n=20",

--- a/sqlite-db/src/test_events/rollover_completed.json
+++ b/sqlite-db/src/test_events/rollover_completed.json
@@ -585,12 +585,14 @@
           "revocation_sk_theirs": "e4f2652ba41bedf0271e85ccd2ffb6f972bb4b67591dda43979c638b1187fba6",
           "script_pubkey": "0020de27d4eeaa1bcec849f007bb55ccb1adc638484caf1e67f503dfbdda751edd10",
           "txid": "53f58ce696b0f732ae5a637741b0bd23d69e313848183fd4b32d1a98a9143299",
-          "settlement_event_id": "/x/BitMEX/BXBT/2022-04-15T00:00:00.price?n=20"
+          "settlement_event_id": "/x/BitMEX/BXBT/2022-04-15T00:00:00.price?n=20",
+          "complete_fee": { "LongPaysShort": 1000 }
         }
       ],
       "settlement_event_id": "/x/BitMEX/BXBT/2022-04-15T01:00:00.price?n=20",
       "taker_address": "tb1q7ysq6mc5qavt5ppps0mkcqwf6fm4zamc7zhpqn",
-      "taker_lock_amount": 119695
+      "taker_lock_amount": 119695,
+      "complete_fee": { "LongPaysShort": 1000 }
     }
   }
 }


### PR DESCRIPTION
This implements a more resilient rollover protocol where the taker proposes a `commit_txid` from which to roll over from to the maker. Protocol details can be found here: https://github.com/itchysats/itchysats/issues/1775

TODO:

- [x] Assert on the exact fees at the end of the rollover tests, make sure that the fees did not change compared to the code on master.
- [x] Add actor tests where we rollover twice and on the second rollover the taker uses the same `event_id`. (This might be a bit tricky)

Resolves [#1622](https://github.com/itchysats/itchysats/issues/1622), https://github.com/itchysats/itchysats/issues/1775

--- 

Implications when merging this PR and rolling it into production:

Previous ItchySats version that included the `libp2p` `rollover` protocol will not be compatible because the protocol contains breaking changes. Since we did *not* roll any version that included `libp2p` `rollover` out on Umbrel there should not be any users affected. 
The legacy rollover should not be affected by the breaking changes. The feature was implemented in a way that is backwards compatible (to the legacy version). This has to be tested on `testnet`.