### PR TITLE
Pin time to `0.3.9` because of debug assert panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,7 +839,7 @@ dependencies = [
  "statrs",
  "test-case",
  "thiserror",
- "time 0.3.10",
+ "time 0.3.9",
  "tokio",
  "tokio-tasks",
  "tokio-util 0.7.2",
@@ -873,7 +873,7 @@ dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
  "sqlite-db",
- "time 0.3.10",
+ "time 0.3.9",
  "tokio",
  "tokio-tasks",
  "tracing",
@@ -1923,7 +1923,7 @@ dependencies = [
  "shared-bin",
  "sqlite-db",
  "thiserror",
- "time 0.3.10",
+ "time 0.3.9",
  "tokio",
  "tokio-tasks",
  "tokio-util 0.7.2",
@@ -2077,7 +2077,7 @@ dependencies = [
  "serde_test",
  "serde_with",
  "thiserror",
- "time 0.3.10",
+ "time 0.3.9",
  "tracing",
  "url",
  "uuid",
@@ -3819,7 +3819,7 @@ dependencies = [
  "rocket",
  "rocket-basicauth",
  "serde",
- "time 0.3.10",
+ "time 0.3.9",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4007,7 +4007,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror",
- "time 0.3.10",
+ "time 0.3.9",
  "tokio",
  "tracing",
  "x25519-dalek",
@@ -4307,7 +4307,7 @@ dependencies = [
  "serde_test",
  "shared-bin",
  "sqlite-db",
- "time 0.3.10",
+ "time 0.3.9",
  "tokio",
  "tokio-tasks",
  "tracing",
@@ -4422,9 +4422,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.10"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82501a4c1c0330d640a6e176a3d6a204f5ec5237aca029029d21864a902e27b0"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
  "itoa 1.0.1",
  "libc",
@@ -4679,7 +4679,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.10",
+ "time 0.3.9",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -4871,7 +4871,7 @@ dependencies = [
  "rustversion",
  "sysinfo",
  "thiserror",
- "time 0.3.10",
+ "time 0.3.9",
 ]
 
 [[package]]
@@ -5234,7 +5234,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.10",
+ "time 0.3.9",
  "tokio",
  "tokio-tasks",
  "tracing",
@@ -5284,7 +5284,7 @@ dependencies = [
  "rust_decimal_macros",
  "sluice",
  "thiserror",
- "time 0.3.10",
+ "time 0.3.9",
  "tokio",
  "tokio-tasks",
  "tracing",

--- a/daemon-tests/Cargo.toml
+++ b/daemon-tests/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.6"
 rust_decimal = "1.25"
 rust_decimal_macros = "1.25"
 sqlite-db = { path = "../sqlite-db" }
-time = "0.3"
+time = "=0.3.9"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
 tokio-tasks = { path = "../tokio-tasks", features = ["xtra"] }
 tracing = { version = "0.1" }

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -43,7 +43,7 @@ sqlite-db = { path = "../sqlite-db" }
 sqlx = { version = "0.5.13", features = ["offline", "sqlite", "uuid", "runtime-tokio-rustls"] }
 statrs = "0.15"
 thiserror = "1"
-time = { version = "0.3", features = ["serde", "macros", "parsing", "formatting", "serde-well-known"] }
+time = { version = "=0.3.9", features = ["serde", "macros", "parsing", "formatting", "serde-well-known"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
 tokio-tasks = { path = "../tokio-tasks", features = ["xtra"] }
 tokio-util = { version = "0.7", features = ["codec"] }
@@ -62,7 +62,7 @@ xtras = { path = "../xtras" }
 pretty_assertions = "1"
 serde_test = "1"
 test-case = "2"
-time = { version = "0.3", features = ["std"] }
+time = { version = "=0.3.9", features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "tracing-log"] }
 
 [build-dependencies]

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1", features = ["derive"] }
 shared-bin = { path = "../shared-bin" }
 sqlite-db = { path = "../sqlite-db" }
 thiserror = "1"
-time = { version = "0.3", features = ["serde", "macros", "parsing", "formatting", "serde-well-known"] }
+time = { version = "=0.3.9", features = ["serde", "macros", "parsing", "formatting", "serde-well-known"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
 tokio-tasks = { path = "../tokio-tasks", features = ["xtra"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = { version = "1", features = ["macros"] }
 thiserror = "1"
-time = { version = "0.3", features = ["macros", "formatting", "parsing", "serde"] }
+time = { version = "=0.3.9", features = ["macros", "formatting", "parsing", "serde"] }
 tracing = "0.1"
 url = { version = "2", default-features = false }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/shared-bin/Cargo.toml
+++ b/shared-bin/Cargo.toml
@@ -16,6 +16,6 @@ model = { path = "../model" }
 rocket = { version = "0.5.0-rc.1", features = ["json"] }
 rocket-basicauth = { path = "../rocket-basicauth" }
 serde = { version = "1", features = ["derive"] }
-time = "0.3"
+time = "=0.3.9"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter", "local-time", "tracing-log", "json"] }

--- a/sqlite-db/Cargo.toml
+++ b/sqlite-db/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.5.13", features = ["offline", "sqlite", "uuid", "runtime-tokio-rustls"] }
 thiserror = "1"
-time = { version = "0.3", features = [] }
+time = { version = "=0.3.9", features = [] }
 tokio = { version = "1" }
 tracing = "0.1"
 x25519-dalek = "1.1"

--- a/taker/Cargo.toml
+++ b/taker/Cargo.toml
@@ -23,7 +23,7 @@ rust-embed-rocket = { path = "../rust-embed-rocket" }
 serde = { version = "1", features = ["derive"] }
 shared-bin = { path = "../shared-bin" }
 sqlite-db = { path = "../sqlite-db" }
-time = "0.3"
+time = "=0.3.9"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
 tokio-tasks = { path = "../tokio-tasks", features = ["xtra"] }
 tracing = { version = "0.1" }

--- a/xtra-bitmex-price-feed/Cargo.toml
+++ b/xtra-bitmex-price-feed/Cargo.toml
@@ -14,7 +14,7 @@ rust_decimal = { version = "1", features = ["serde-with-float"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
-time = { version = "0.3", features = ["serde-well-known"] }
+time = { version = "=0.3.9", features = ["serde-well-known"] }
 tokio = "1"
 tokio-tasks = { path = "../tokio-tasks" }
 tracing = "0.1"

--- a/xtra-libp2p-offer/Cargo.toml
+++ b/xtra-libp2p-offer/Cargo.toml
@@ -23,6 +23,6 @@ xtras = { path = "../xtras" }
 rust_decimal = "1.25"
 rust_decimal_macros = "1.25"
 sluice = "0.5"
-time = { version = "0.3", features = ["macros"] }
+time = { version = "=0.3.9", features = ["macros"] }
 tokio = { version = "1", features = ["macros"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }


### PR DESCRIPTION
Otherwise the rollover tests (may) panic.
We can bump the version once https://github.com/time-rs/time/issues/481 is resolved.

--- 

I am still surprised that the tests did not fail when we merged the bump. This would mean this is only a problem *sometimes*, which is not good. I wonder if there is a bigger problem in `time` that may cause issues. (@klochowicz mentioned this in https://github.com/itchysats/itchysats/issues/2274 as well).

Resolves #2274