### PR TITLE
Potential revoke commit fix

### DIFF
--- a/daemon/src/rollover/maker.rs
+++ b/daemon/src/rollover/maker.rs
@@ -312,9 +312,7 @@ impl Actor {
                         tracing::warn!(%order_id, "Failed to last rollover message to taker, this rollover will likely be retried by the taker: {e:#}");
                     }
 
-                    let revoked_commit = finalize_revoked_commits(
-                        &dlc,
-                        own_cfd_txs.commit.1,
+                    let revoked_commit = finalize_revoked_commits(&dlc, dlc.commit.1,
                         msg2,
                         rollover_params.complete_fee_before_rollover(),
                     )?;

--- a/daemon/src/rollover/taker.rs
+++ b/daemon/src/rollover/taker.rs
@@ -281,7 +281,7 @@ impl Actor {
 
                             let revoked_commit = finalize_revoked_commits(
                                 &dlc,
-                                own_cfd_txs.commit.1,
+                                dlc.commit.1,
                                 msg2,
                                 complete_fee_before_rollover,
                             )?;


### PR DESCRIPTION
When working on #2272 I noticed that using the adaptor sig of the newly created commit tx here might not be correct.

Note on the second commit https://github.com/itchysats/itchysats/commit/e251fdddceb437d3517ffda62c1731ef753fc7de - This might not be backwards compatible so we might drop it.

Note that I think this might also be a breaking change for existing positions once we rollout rollover over libp2p! This might mean that positions that were opened prior to a release might get force closed. 

Note: I did *not* adapt this code in `setup_contract_deprecated`.

---

Note on breaking protocol changes:

We are currently not capable to distinguish different rollover versions per `Cfd`. We might want to add this feature by saving what rollover protocol version was used upon saving a rollover. Otherwise we accept that upon breaking change in the protocol *existing* positions that were opened prior to the breaking change might get force closed. I documented this in https://github.com/itchysats/itchysats/issues/2279