### PR TITLE
Fetch announcements SETTLEMENT_INTERVAL + 2

### DIFF
--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -131,7 +131,7 @@ async fn main() -> Result<()> {
         db.clone(),
         wallet.clone(),
         *olivia::PUBLIC_KEY,
-        |executor| oracle::Actor::new(db.clone(), executor, SETTLEMENT_INTERVAL),
+        |executor| oracle::Actor::new(db.clone(), executor),
         {
             |executor| {
                 let electrum = opts.network.electrum().to_string();

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -369,7 +369,7 @@ async fn main() -> Result<()> {
         wallet.clone(),
         *olivia::PUBLIC_KEY,
         identities,
-        |executor| oracle::Actor::new(db.clone(), executor, SETTLEMENT_INTERVAL),
+        |executor| oracle::Actor::new(db.clone(), executor),
         {
             |executor| {
                 let electrum = network.electrum().to_string();


### PR DESCRIPTION
For a rollover to happen successfully we need to know the oracle announcement details.
Our actor is checking if a new announcement can be fetched every SYNC_ANNOUNCEMENTS_INTERVAL and
ANNOUNCEMENT_LOOKAHEAD hours into the future. Given we rollover every for
hour model::SETTLEMENT_INTERVAL into the future, we want to have at least model::SETTLEMENT_INTERVAL
announcements ready. Due to sync interval coincidence, it might happen that we do not have
synced for a specific announcement yet. Hence, we need to fetch more announcements.
We fetch model::SETTLEMENT_INTERVAL + 2 announcement into the future because of this example:

Assume the last fetch was at 01.01.2022 00:59:55, i.e. 5 seconds before midnight and we would
have synced for model::SETTLEMENT_INTERVAL+1 we would have synced announcements until 02.01.2022
01:00:00. A rollover request happening exactly at 01.01.2022 01:00:00 would ask for the
announcement at 02.01.2022 02:00:00 because of how olivia::next_announcement_after works. Note:
even if the underlying logic of olivia::next_announcement_after changes, fetching model::
SETTLEMENT_INTERVAL + 2 won't hurt.


resolves #2264 