### PR TITLE
Rollover asserts exact fees

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -505,8 +505,8 @@ pub fn dummy_offer_params(position_maker: Position) -> maker::cfd::OfferParams {
     maker::cfd::OfferParams {
         price_long,
         price_short,
-        min_quantity: Usd::new(dec!(5)),
-        max_quantity: Usd::new(dec!(100)),
+        min_quantity: Usd::new(dec!(100)),
+        max_quantity: Usd::new(dec!(1000)),
         tx_fee_rate: TxFeeRate::default(),
         // 8.76% annualized = rate of 0.0876 annualized = rate of 0.00024 daily
         funding_rate_long: FundingRate::new(dec!(0.00024)).unwrap(),

--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -204,7 +204,7 @@ async fn taker_takes_order_and_maker_rejects() {
     maker.mocks.mock_oracle_announcement().await;
     taker
         .system
-        .take_offer(order_id, Usd::new(dec!(10)), Leverage::TWO)
+        .take_offer(order_id, Usd::new(dec!(100)), Leverage::TWO)
         .await
         .unwrap();
 
@@ -288,7 +288,7 @@ async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
 
     taker
         .system
-        .take_offer(order_id, Usd::new(dec!(5)), Leverage::TWO)
+        .take_offer(order_id, Usd::new(dec!(100)), Leverage::TWO)
         .await
         .unwrap();
     wait_next_state!(order_id, maker, taker, CfdState::PendingSetup);
@@ -734,7 +734,7 @@ async fn start_from_open_cfd_state(
 
     taker
         .system
-        .take_offer(order_to_take.id, Usd::new(dec!(5)), Leverage::TWO)
+        .take_offer(order_to_take.id, Usd::new(dec!(100)), Leverage::TWO)
         .await
         .unwrap();
     wait_next_state!(order_to_take.id, maker, taker, CfdState::PendingSetup);


### PR DESCRIPTION
Note that initially I tried to accumulate the rollover fees which lead me to open https://github.com/itchysats/itchysats/pull/2284

I had to use `FundingFee::calculate` to make the test pass. I find that a bit odd, but it could be expected behavior.

---

I am planning to now add tests using different event IDs to create a failing test on master that should then pass on #2272  . This will be a bit tricky, because the fees are always `24h` at the moment given that we use events with outdated timestamps. I might touch on problems described in #2282 