### PR TITLE
Remove bdk log directive

### DIFF
--- a/shared-bin/src/logger.rs
+++ b/shared-bin/src/logger.rs
@@ -30,8 +30,6 @@ pub fn init(level: LevelFilter, json_format: bool) -> Result<()> {
         .add_directive("libp2p_noise=warn".parse()?)
         .add_directive("xtra_libp2p_offer=debug".parse()?)
         .add_directive("xtras=info".parse()?)
-        .add_directive("bdk::blockchain::script_sync=off".parse()?) // bdk logs duration of sync on INFO
-        .add_directive("bdk::wallet=off".parse()?) // bdk logs derivation of addresses on INFO
         .add_directive("_=off".parse()?) // rocket logs headers on INFO and uses `_` as the log target for it?
         .add_directive("rocket=off".parse()?) // disable rocket logs: we have our own
         .add_directive("xtra=warn".parse()?)


### PR DESCRIPTION
So that we can set it from the outside

I can't reproduce the wallet not ending to sync locally at the moment and this prevents us from enabling bdk logs. 