### PR TITLE
Revert "Patch electrum client to ignore empty responses"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,7 +1043,8 @@ dependencies = [
 [[package]]
 name = "electrum-client"
 version = "0.8.0"
-source = "git+https://github.com/da-kami/rust-electrum-client/?branch=fix/ignore-empty-lines#44096f360192a2d2ecb6fff7cce0a07e24eb058c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd12f125852d77980725243b2a8b3bea73cd4c7a22c33bc52b08b664c561dc7"
 dependencies = [
  "bitcoin",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,3 @@ xtra = { git = "https://github.com/comit-network/xtra" } # We need to use unrele
 maia = { git = "https://github.com/comit-network/maia", rev = "a963084189e1598ca622abe206a78015ab6b8466" } # Unreleased
 maia-core = { git = "https://github.com/comit-network/maia", rev = "e419cb2cf19bed6ec53eaa3672408a6205a9b705", package = "maia-core" } # Unreleased version, pinned before maia's breaking change
 xtra_productivity = { git = "https://github.com/comit-network/xtra-productivity" } # Unreleased
-electrum-client = { git = "https://github.com/da-kami/rust-electrum-client/", branch = "fix/ignore-empty-lines" }


### PR DESCRIPTION
This reverts commit c7c285520567dc69c08a562a7a887f80125fca4e.

For some reason, we are experiencing 100% CPU load due to unfinished wallet
syncs on testnet. We suspect this might be reason.