### PR TITLE
Introduce /itchysats/order protocol over libp2p

### DIFF
--- a/daemon-tests/src/flow.rs
+++ b/daemon-tests/src/flow.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use daemon::projection::Cfd;
 use daemon::projection::CfdState;
 use daemon::projection::MakerOffers;
+use model::OrderId;
 use std::time::Duration;
 use tokio::sync::watch;
 
@@ -79,5 +80,16 @@ pub fn one_cfd_with_state(expected_state: CfdState) -> impl Fn(Vec<Cfd>) -> Opti
         [_one_that_doesnt_match_state] => None,
         [] => None,
         _more_than_one => panic!("More than one CFD in feed!"),
+    }
+}
+
+pub fn cfd_with_state(
+    order_id: OrderId,
+    expected_state: CfdState,
+) -> impl Fn(Vec<Cfd>) -> Option<Cfd> {
+    move |cfds: Vec<Cfd>| match cfds.iter().find(|cfd| cfd.order_id == order_id) {
+        Some(cfd) if cfd.state == expected_state => Some(cfd.clone()),
+        Some(_cfd_that_does_not_match_state) => None,
+        None => None,
     }
 }

--- a/daemon-tests/src/maia.rs
+++ b/daemon-tests/src/maia.rs
@@ -92,6 +92,10 @@ impl OliviaData {
             .collect()
     }
 
+    pub fn settlement_attestation(&self) -> oracle::Attestation {
+        self.attestations().last().unwrap().clone()
+    }
+
     const OLIVIA_PK: &'static str =
         "ddd4636845a90185991826be5a494cde9f4a6947b1727217afedc6292fa4caf7";
 

--- a/daemon-tests/src/mocks/oracle.rs
+++ b/daemon-tests/src/mocks/oracle.rs
@@ -34,16 +34,21 @@ impl xtra::Actor for OracleActor {
 
 #[xtra_productivity]
 impl OracleActor {
+    /// Handle a request to get `Announcement`s.
+    ///
+    /// We _ignore_ the message that is supposed to indicate which `Announcement`s the sender is
+    /// requesting. Instead, we return whatever `Announcement`s we have mocked beforehand.
     async fn handle(
         &mut self,
-        msg: oracle::GetAnnouncements,
+        _: oracle::GetAnnouncements,
     ) -> Result<Vec<olivia::Announcement>, oracle::NoAnnouncement> {
-        self.mock
+        Ok(self
+            .mock
             .lock()
             .await
             .announcements
             .clone()
-            .ok_or(oracle::NoAnnouncement(msg.0[0]))
+            .expect("To have mocked announcements"))
     }
 
     async fn handle(&mut self, _msg: oracle::MonitorAttestations) {}
@@ -52,6 +57,7 @@ impl OracleActor {
 
     async fn handle(&mut self, _msg: oracle::SyncAttestations) {}
 }
+
 pub struct MockOracle {
     executor: command::Executor,
     announcements: Option<Vec<olivia::Announcement>>,

--- a/daemon-tests/tests/non_collaborative_settlement.rs
+++ b/daemon-tests/tests/non_collaborative_settlement.rs
@@ -44,12 +44,7 @@ async fn force_close_open_cfd(maker_position: Position) {
     wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
 
     // Delivering correct attestation moves the state `PendingCet`
-    simulate_attestation!(
-        taker,
-        maker,
-        order_id,
-        oracle_data.attestations()[0].clone()
-    );
+    simulate_attestation!(taker, maker, order_id, oracle_data.settlement_attestation());
 
     sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     wait_next_state!(order_id, maker, taker, CfdState::PendingCet);

--- a/daemon-tests/tests/offer.rs
+++ b/daemon-tests/tests/offer.rs
@@ -1,25 +1,16 @@
 use daemon::bdk::bitcoin::Amount;
-use daemon::projection::CfdOrder;
-use daemon::projection::CfdState;
+use daemon::projection::CfdOffer;
 use daemon::projection::MakerOffers;
-use daemon_tests::confirm;
 use daemon_tests::dummy_offer_params;
 use daemon_tests::flow::is_next_offers_none;
 use daemon_tests::flow::next_maker_offers;
-use daemon_tests::flow::next_with;
-use daemon_tests::flow::one_cfd_with_state;
 use daemon_tests::start_both;
-use daemon_tests::wait_next_state;
 use model::Leverage;
 use model::Position;
-use model::Usd;
 use otel_tests::otel_test;
-use rust_decimal_macros::dec;
-use std::time::Duration;
-use tokio_extras::time::sleep;
 
 #[otel_test]
-async fn taker_receives_order_from_maker_on_publication() {
+async fn taker_receives_offer_from_maker_on_publication() {
     let (mut maker, mut taker) = start_both().await;
 
     assert!(is_next_offers_none(taker.offers_feed()).await.unwrap());
@@ -35,146 +26,23 @@ async fn taker_receives_order_from_maker_on_publication() {
     assert_eq_offers(published, received);
 }
 
-#[otel_test]
-async fn taker_takes_order_and_maker_rejects() {
-    let (mut maker, mut taker) = start_both().await;
-
-    is_next_offers_none(taker.offers_feed()).await.unwrap();
-
-    maker
-        .set_offer_params(dummy_offer_params(Position::Short))
-        .await;
-
-    let (_, received) = next_maker_offers(maker.offers_feed(), taker.offers_feed())
-        .await
-        .unwrap();
-
-    let order_id = received.short.unwrap().id;
-
-    taker.mocks.mock_oracle_announcement().await;
-    maker.mocks.mock_oracle_announcement().await;
-    taker
-        .system
-        .take_offer(order_id, Usd::new(dec!(100)), Leverage::TWO)
-        .await
-        .unwrap();
-
-    wait_next_state!(order_id, maker, taker, CfdState::PendingSetup);
-
-    maker.system.reject_order(order_id).await.unwrap();
-
-    wait_next_state!(order_id, maker, taker, CfdState::Rejected);
-}
-
-#[otel_test]
-async fn another_offer_is_automatically_created_after_taker_takes_order() {
-    let (mut maker, mut taker) = start_both().await;
-
-    is_next_offers_none(taker.offers_feed()).await.unwrap();
-
-    maker
-        .set_offer_params(dummy_offer_params(Position::Short))
-        .await;
-
-    let (_, received) = next_maker_offers(maker.offers_feed(), taker.offers_feed())
-        .await
-        .unwrap();
-
-    let order_id_take = received.short.unwrap().id;
-
-    taker.mocks.mock_oracle_announcement().await;
-    maker.mocks.mock_oracle_announcement().await;
-    taker
-        .system
-        .take_offer(order_id_take, Usd::new(dec!(10)), Leverage::TWO)
-        .await
-        .unwrap();
-
-    // For the taker the offer is reset after taking it, so we can't take the same one twice
-    is_next_offers_none(taker.offers_feed()).await.unwrap();
-
-    let (maker_update, taker_update) = next_maker_offers(maker.offers_feed(), taker.offers_feed())
-        .await
-        .unwrap();
-
-    let new_order_id_maker = maker_update.short.unwrap().id;
-    let new_order_id_taker = taker_update.short.unwrap().id;
-
-    assert_ne!(
-        new_order_id_taker, order_id_take,
-        "Another offer should be available, and it should have a different id than first one"
-    );
-
-    assert_ne!(
-        new_order_id_maker, order_id_take,
-        "Another offer should be available, and it should have a different id than first one"
-    );
-
-    assert_eq!(
-        new_order_id_taker, new_order_id_maker,
-        "Both parties have the same new id"
-    )
-}
-
-#[otel_test]
-async fn taker_takes_order_and_maker_accepts_and_contract_setup() {
-    let (mut maker, mut taker) = start_both().await;
-
-    is_next_offers_none(taker.offers_feed()).await.unwrap();
-
-    maker
-        .set_offer_params(dummy_offer_params(Position::Short))
-        .await;
-
-    let (_, received) = next_maker_offers(maker.offers_feed(), taker.offers_feed())
-        .await
-        .unwrap();
-
-    let order_id = received.short.unwrap().id;
-
-    taker.mocks.mock_oracle_announcement().await;
-    maker.mocks.mock_oracle_announcement().await;
-
-    taker
-        .system
-        .take_offer(order_id, Usd::new(dec!(100)), Leverage::TWO)
-        .await
-        .unwrap();
-    wait_next_state!(order_id, maker, taker, CfdState::PendingSetup);
-
-    maker.mocks.mock_party_params().await;
-    taker.mocks.mock_party_params().await;
-
-    maker.mocks.mock_wallet_sign_and_broadcast().await;
-    taker.mocks.mock_wallet_sign_and_broadcast().await;
-
-    maker.system.accept_order(order_id).await.unwrap();
-    wait_next_state!(order_id, maker, taker, CfdState::ContractSetup);
-
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
-    wait_next_state!(order_id, maker, taker, CfdState::PendingOpen);
-
-    confirm!(lock transaction, order_id, maker, taker);
-    wait_next_state!(order_id, maker, taker, CfdState::Open);
-}
-
 fn assert_eq_offers(published: MakerOffers, received: MakerOffers) {
     match (published.long, received.long) {
         (None, None) => (),
-        (Some(published), Some(received)) => assert_eq_orders(published, received),
-        (None, Some(_)) => panic!("Long orders did not match: Published None, received Some "),
-        (Some(_), None) => panic!("Long orders did not match: Published Some, received None "),
+        (Some(published), Some(received)) => assert_eq_offer(published, received),
+        (None, Some(_)) => panic!("Long offers did not match: Published None, received Some "),
+        (Some(_), None) => panic!("Long offers did not match: Published Some, received None "),
     }
 
     match (published.short, received.short) {
         (None, None) => (),
-        (Some(published), Some(received)) => assert_eq_orders(published, received),
-        (None, Some(_)) => panic!("Short orders did not match: Published None, received Some "),
-        (Some(_), None) => panic!("Short orders did not match: Published Some, received None "),
+        (Some(published), Some(received)) => assert_eq_offer(published, received),
+        (None, Some(_)) => panic!("Short offers did not match: Published None, received Some "),
+        (Some(_), None) => panic!("Short offers did not match: Published Some, received None "),
     }
 }
 
-fn assert_eq_orders(mut published: CfdOrder, received: CfdOrder) {
+fn assert_eq_offer(mut published: CfdOffer, received: CfdOffer) {
     // we fix the leverage to TWO for our test
     let fixed_leverage = Leverage::TWO;
 
@@ -197,12 +65,12 @@ fn assert_eq_orders(mut published: CfdOrder, received: CfdOrder) {
             .initial_funding_fee_per_lot
             * -1
     );
-    // align leverage details so we can assert on the order
+    // align leverage details so we can assert on the offer
     published.leverage_details = received.leverage_details.clone();
 
     assert_eq!(published, received);
 
-    // Hard-coded to match the dummy_new_order()
+    // Hard-coded to match the dummy_new_offer()
     assert_eq!(received.opening_fee.unwrap(), Amount::from_sat(2));
     assert_eq!(received.funding_rate_hourly_percent, "0.00100");
 }

--- a/daemon-tests/tests/order.rs
+++ b/daemon-tests/tests/order.rs
@@ -1,0 +1,223 @@
+use daemon::projection::CfdState;
+use daemon_tests::confirm;
+use daemon_tests::dummy_offer_params;
+use daemon_tests::flow::cfd_with_state;
+use daemon_tests::flow::is_next_offers_none;
+use daemon_tests::flow::next_maker_offers;
+use daemon_tests::flow::next_with;
+use daemon_tests::flow::one_cfd_with_state;
+use daemon_tests::start_both;
+use daemon_tests::wait_next_state;
+use daemon_tests::wait_next_state_multi_cfd;
+use daemon_tests::Maker;
+use daemon_tests::Taker;
+use model::Leverage;
+use model::OrderId;
+use model::Position;
+use model::Usd;
+use otel_tests::otel_test;
+use rust_decimal_macros::dec;
+use std::time::Duration;
+use tokio_extras::time::sleep;
+
+#[otel_test]
+async fn taker_places_order_and_maker_rejects() {
+    let (mut maker, mut taker) = start_both().await;
+
+    is_next_offers_none(taker.offers_feed()).await.unwrap();
+
+    maker
+        .set_offer_params(dummy_offer_params(Position::Short))
+        .await;
+
+    let (_, received) = next_maker_offers(maker.offers_feed(), taker.offers_feed())
+        .await
+        .unwrap();
+
+    let offer_id = received.short.unwrap().id;
+
+    taker.mocks.mock_oracle_announcement().await;
+    maker.mocks.mock_oracle_announcement().await;
+    let order_id = taker
+        .system
+        .place_order(offer_id, Usd::new(dec!(100)), Leverage::TWO)
+        .await
+        .unwrap();
+
+    wait_next_state!(order_id, maker, taker, CfdState::PendingSetup);
+
+    maker.system.reject_order(order_id).await.unwrap();
+
+    wait_next_state!(order_id, maker, taker, CfdState::Rejected);
+}
+
+#[otel_test]
+async fn taker_places_order_and_maker_accepts_and_contract_setup() {
+    let (mut maker, mut taker) = start_both().await;
+
+    is_next_offers_none(taker.offers_feed()).await.unwrap();
+
+    maker
+        .set_offer_params(dummy_offer_params(Position::Short))
+        .await;
+
+    let (_, received) = next_maker_offers(maker.offers_feed(), taker.offers_feed())
+        .await
+        .unwrap();
+
+    let offer_id = received.short.unwrap().id;
+
+    taker.mocks.mock_oracle_announcement().await;
+    maker.mocks.mock_oracle_announcement().await;
+
+    let order_id = taker
+        .system
+        .place_order(offer_id, Usd::new(dec!(100)), Leverage::TWO)
+        .await
+        .unwrap();
+
+    first_contract_setup(&mut maker, &mut taker, order_id).await;
+}
+
+#[otel_test]
+async fn taker_places_order_for_same_offer_twice_results_in_two_cfds() {
+    let (mut maker, mut taker) = start_both().await;
+
+    is_next_offers_none(taker.offers_feed()).await.unwrap();
+
+    maker
+        .set_offer_params(dummy_offer_params(Position::Short))
+        .await;
+
+    let (_, received) = next_maker_offers(maker.offers_feed(), taker.offers_feed())
+        .await
+        .unwrap();
+
+    let offer_id = received.short.unwrap().id;
+
+    taker.mocks.mock_oracle_announcement().await;
+    maker.mocks.mock_oracle_announcement().await;
+    let first_order_id = taker
+        .system
+        .place_order(offer_id, Usd::new(dec!(10)), Leverage::TWO)
+        .await
+        .unwrap();
+
+    first_contract_setup(&mut maker, &mut taker, first_order_id).await;
+
+    let second_order_id = taker
+        .system
+        .place_order(offer_id, Usd::new(dec!(10)), Leverage::TWO)
+        .await
+        .unwrap();
+
+    additional_contract_setup(&mut maker, &mut taker, second_order_id).await;
+
+    let taker_cfds = taker.cfds();
+    assert_eq!(
+        taker_cfds.len(),
+        2,
+        "taker should have two Cfd after two orders were filled"
+    );
+
+    let first_cfd = taker_cfds
+        .iter()
+        .find(|cfd| cfd.order_id == first_order_id)
+        .unwrap();
+    let second_cfd = taker_cfds
+        .iter()
+        .find(|cfd| cfd.order_id == second_order_id)
+        .unwrap();
+
+    assert_eq!(
+        first_order_id, first_cfd.order_id,
+        "First taker cfd's order_id id does not match order_id"
+    );
+    assert_eq!(
+        offer_id, first_cfd.offer_id,
+        "First taker cfd's offer_id does not match offer_id"
+    );
+    assert_eq!(
+        second_order_id, second_cfd.order_id,
+        "Second taker cfd's order_id id does not match order_id"
+    );
+    assert_eq!(
+        offer_id, second_cfd.offer_id,
+        "Second taker cfd's offer_id does not match offer_id"
+    );
+
+    let maker_cfds = maker.cfds();
+    assert_eq!(
+        maker_cfds.len(),
+        2,
+        "maker should have two Cfd after two orders were filled"
+    );
+
+    let first_cfd = maker_cfds
+        .iter()
+        .find(|cfd| cfd.order_id == first_order_id)
+        .unwrap();
+    let second_cfd = maker_cfds
+        .iter()
+        .find(|cfd| cfd.order_id == second_order_id)
+        .unwrap();
+
+    assert_eq!(
+        first_order_id, first_cfd.order_id,
+        "First maker cfd's order_id id does not match order_id"
+    );
+    assert_eq!(
+        offer_id, first_cfd.offer_id,
+        "First maker cfd's offer_id does not match offer_id"
+    );
+    assert_eq!(
+        second_order_id, second_cfd.order_id,
+        "Second maker cfd's order_id id does not match order_id"
+    );
+    assert_eq!(
+        offer_id, second_cfd.offer_id,
+        "Second maker cfd's offer_id does not match offer_id"
+    );
+}
+
+/// To be used for the first contract setup
+async fn first_contract_setup(maker: &mut Maker, taker: &mut Taker, order_id: OrderId) {
+    wait_next_state!(order_id, maker, taker, CfdState::PendingSetup);
+
+    maker.mocks.mock_party_params().await;
+    taker.mocks.mock_party_params().await;
+
+    maker.mocks.mock_wallet_sign_and_broadcast().await;
+    taker.mocks.mock_wallet_sign_and_broadcast().await;
+
+    maker.system.accept_order(order_id).await.unwrap();
+    wait_next_state!(order_id, maker, taker, CfdState::ContractSetup);
+
+    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
+    wait_next_state!(order_id, maker, taker, CfdState::PendingOpen);
+
+    confirm!(lock transaction, order_id, maker, taker);
+    wait_next_state!(order_id, maker, taker, CfdState::Open);
+}
+
+/// To be used for any additional contract setup
+///
+/// Note that we don't assert on the number of cfds, but just try to find the cfd with the given id.
+async fn additional_contract_setup(maker: &mut Maker, taker: &mut Taker, order_id: OrderId) {
+    wait_next_state_multi_cfd!(order_id, maker, taker, CfdState::PendingSetup);
+
+    maker.mocks.mock_party_params().await;
+    taker.mocks.mock_party_params().await;
+
+    maker.mocks.mock_wallet_sign_and_broadcast().await;
+    taker.mocks.mock_wallet_sign_and_broadcast().await;
+
+    maker.system.accept_order(order_id).await.unwrap();
+    wait_next_state_multi_cfd!(order_id, maker, taker, CfdState::ContractSetup);
+
+    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
+    wait_next_state_multi_cfd!(order_id, maker, taker, CfdState::PendingOpen);
+
+    confirm!(lock transaction, order_id, maker, taker);
+    wait_next_state_multi_cfd!(order_id, maker, taker, CfdState::Open);
+}

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -16,7 +16,8 @@ use model::libp2p::PeerId;
 use model::olivia;
 use model::Identity;
 use model::Leverage;
-use model::Order;
+use model::Offer;
+use model::OfferId;
 use model::OrderId;
 use model::Price;
 use model::Role;
@@ -56,6 +57,7 @@ pub mod monitor;
 pub mod noise;
 mod online_status;
 pub mod oracle;
+pub mod order;
 pub mod position_metrics;
 pub mod process_manager;
 pub mod projection;
@@ -82,9 +84,10 @@ pub const PING_INTERVAL: Duration = Duration::from_secs(30);
 pub const N_PAYOUTS: usize = 200;
 
 pub struct TakerActorSystem<O, W, P> {
-    pub cfd_actor: Address<taker_cfd::Actor<O, W>>,
+    pub cfd_actor: Address<taker_cfd::Actor>,
     pub connection_actor: Address<connection::Actor>,
     wallet_actor: Address<W>,
+    _oracle_actor: Address<O>,
     pub auto_rollover_actor: Address<auto_rollover::Actor>,
     pub price_feed_actor: Address<P>,
     executor: command::Executor,
@@ -176,6 +179,27 @@ where
 
         let (endpoint_addr, endpoint_context) = Context::new(None);
 
+        let (order_supervisor, order) = Supervisor::new({
+            let oracle = oracle_addr.clone();
+            let db = db.clone();
+            let process_manager = process_manager_addr;
+            let wallet = wallet_actor_addr.clone();
+            let projection = projection_actor.clone();
+            let endpoint = endpoint_addr.clone();
+            move || {
+                order::taker::Actor::new(
+                    n_payouts,
+                    oracle_pk,
+                    oracle.clone().into(),
+                    (db.clone(), process_manager.clone()),
+                    (wallet.clone().into(), wallet.clone().into()),
+                    projection.clone(),
+                    endpoint.clone(),
+                )
+            }
+        });
+        tasks.add(order_supervisor.run_log_summary());
+
         let (collab_settlement_supervisor, libp2p_collab_settlement_addr) = Supervisor::new({
             let endpoint_addr = endpoint_addr.clone();
             let executor = executor.clone();
@@ -192,14 +216,9 @@ where
         let (connection_actor_addr, connection_actor_ctx) = Context::new(None);
         let cfd_actor_addr = taker_cfd::Actor::new(
             db.clone(),
-            wallet_actor_addr.clone(),
-            oracle_pk,
             projection_actor,
-            process_manager_addr,
-            connection_actor_addr.clone(),
-            oracle_addr.clone(),
             libp2p_collab_settlement_addr,
-            n_payouts,
+            order,
             maker_identity,
             PeerId::from(
                 maker_multiaddr
@@ -214,6 +233,7 @@ where
         let (rollover_supervisor, libp2p_rollover_addr) = Supervisor::new({
             let endpoint_addr = endpoint_addr.clone();
             let executor = executor.clone();
+            let oracle_addr = oracle_addr.clone();
             move || {
                 rollover::v_2_0_0::taker::Actor::new(
                     endpoint_addr.clone(),
@@ -324,6 +344,7 @@ where
             cfd_actor: cfd_actor_addr,
             connection_actor: connection_actor_addr,
             wallet_actor: wallet_actor_addr,
+            _oracle_actor: oracle_addr,
             auto_rollover_actor: auto_rollover_addr,
             price_feed_actor,
             executor,
@@ -337,20 +358,22 @@ where
     }
 
     #[instrument(skip(self), err)]
-    pub async fn take_offer(
+    pub async fn place_order(
         &self,
-        order_id: OrderId,
+        offer_id: OfferId,
         quantity: Usd,
         leverage: Leverage,
-    ) -> Result<()> {
-        self.cfd_actor
-            .send(taker_cfd::TakeOffer {
-                order_id,
+    ) -> Result<OrderId> {
+        let order_id = self
+            .cfd_actor
+            .send(taker_cfd::PlaceOrder {
+                offer_id,
                 quantity,
                 leverage,
             })
             .await??;
-        Ok(())
+
+        Ok(order_id)
     }
 
     #[instrument(skip(self), err)]

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -20,7 +20,7 @@ use xtra::prelude::MessageChannel;
 use xtra_productivity::xtra_productivity;
 use xtras::SendInterval;
 
-/// Timout to be passed into the reqwest client for doing http requests against the oracle.
+/// Timeout to be passed into the reqwest client for doing http requests against the oracle.
 ///
 /// 10 seconds was chosen arbitrarily. It should be plenty to fetch from the oracle and does not let
 /// us wait forever.

--- a/daemon/src/order.rs
+++ b/daemon/src/order.rs
@@ -1,0 +1,5 @@
+pub const PROTOCOL_NAME: &str = "/itchysats/order/1.0.0";
+
+pub mod maker;
+mod protocol;
+pub mod taker;

--- a/daemon/src/order/maker.rs
+++ b/daemon/src/order/maker.rs
@@ -1,0 +1,372 @@
+use crate::command;
+use crate::oracle;
+use crate::oracle::NoAnnouncement;
+use crate::order::protocol;
+use crate::order::protocol::MakerMessage;
+use crate::order::protocol::TakerMessage;
+use crate::process_manager;
+use crate::projection;
+use crate::setup_contract;
+use crate::wallet;
+use crate::wire::SetupMsg;
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use async_trait::async_trait;
+use asynchronous_codec::Framed;
+use asynchronous_codec::JsonCodec;
+use bdk::bitcoin::psbt::PartiallySignedTransaction;
+use bdk::bitcoin::XOnlyPublicKey;
+use futures::channel::oneshot;
+use futures::future;
+use futures::SinkExt;
+use futures::StreamExt;
+use maia_core::PartyParams;
+use model::olivia;
+use model::Cfd;
+use model::Identity;
+use model::MakerOffers;
+use model::Offer;
+use model::OfferId;
+use model::OrderId;
+use model::Role;
+use std::collections::HashMap;
+use std::fmt;
+use std::time::Duration;
+use tokio_extras::FutureExt;
+use tracing::instrument;
+use xtra::prelude::MessageChannel;
+use xtra_libp2p::NewInboundSubstream;
+use xtra_libp2p::Substream;
+use xtra_productivity::xtra_productivity;
+use xtras::SendAsyncSafe;
+
+const ORDER_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct Actor {
+    executor: command::Executor,
+    oracle_pk: XOnlyPublicKey,
+    get_announcement:
+        MessageChannel<oracle::GetAnnouncements, Result<Vec<olivia::Announcement>, NoAnnouncement>>,
+    build_party_params: MessageChannel<wallet::BuildPartyParams, Result<PartyParams>>,
+    sign: MessageChannel<wallet::Sign, Result<PartiallySignedTransaction>>,
+    projection: xtra::Address<projection::Actor>,
+    n_payouts: usize,
+    decision_senders: HashMap<OrderId, oneshot::Sender<protocol::Decision>>,
+    db: sqlite_db::Connection,
+    latest_offers: MessageChannel<xtra_libp2p_offer::maker::GetLatestOffers, Option<MakerOffers>>,
+}
+
+impl Actor {
+    pub fn new(
+        n_payouts: usize,
+        oracle_pk: XOnlyPublicKey,
+        get_announcement: MessageChannel<
+            oracle::GetAnnouncements,
+            Result<Vec<olivia::Announcement>, NoAnnouncement>,
+        >,
+        (db, process_manager): (sqlite_db::Connection, xtra::Address<process_manager::Actor>),
+        (build_party_params, sign): (
+            MessageChannel<wallet::BuildPartyParams, Result<PartyParams>>,
+            MessageChannel<wallet::Sign, Result<PartiallySignedTransaction>>,
+        ),
+        projection: xtra::Address<projection::Actor>,
+        latest_offers: MessageChannel<
+            xtra_libp2p_offer::maker::GetLatestOffers,
+            Option<MakerOffers>,
+        >,
+    ) -> Self {
+        Self {
+            executor: command::Executor::new(db.clone(), process_manager),
+            oracle_pk,
+            get_announcement,
+            build_party_params,
+            sign,
+            projection,
+            n_payouts,
+            decision_senders: HashMap::default(),
+            db,
+            latest_offers,
+        }
+    }
+
+    #[instrument(skip(self), err)]
+    async fn receive_order(
+        &mut self,
+        framed: &mut Framed<Substream, JsonCodec<MakerMessage, TakerMessage>>,
+    ) -> Result<TakerMessage> {
+        let order = framed
+            .next()
+            .timeout(ORDER_TIMEOUT, || tracing::debug_span!("receive order"))
+            .await
+            .context("Timeout when waiting for order")?
+            .context("Stream terminated")?
+            .context("Unable to decode order")?;
+
+        Ok(order)
+    }
+
+    #[instrument(skip(self), err)]
+    async fn pick_offer(&self, offer_id: OfferId) -> Result<Offer> {
+        let latest_offers = self
+            .latest_offers
+            .send(xtra_libp2p_offer::maker::GetLatestOffers)
+            .await
+            .context("Failed to retrieve latest offer from offers actor")?
+            .context("No latest offers available")?;
+
+        let offer = latest_offers
+            .pick_offer_to_take(offer_id)
+            .with_context(|| format!("Offer with id {offer_id} not found in current offers"))?;
+
+        Ok(offer)
+    }
+}
+
+#[xtra_productivity]
+impl Actor {
+    async fn handle(&mut self, msg: NewInboundSubstream, ctx: &mut xtra::Context<Self>) {
+        let NewInboundSubstream { peer, stream } = msg;
+
+        let mut framed = Framed::new(stream, JsonCodec::<MakerMessage, TakerMessage>::new());
+
+        let order = match self.receive_order(&mut framed).await {
+            Ok(order) => order,
+            Err(e) => {
+                tracing::error!("Failed to receive order from taker: {e:#}");
+                return;
+            }
+        };
+
+        let (id, offer, quantity, leverage) = match order {
+            TakerMessage::PlaceOrder {
+                id,
+                offer: offer_id,
+                quantity,
+                leverage,
+            } => (id, offer_id, quantity, leverage),
+            TakerMessage::ContractSetupMsg(_) => {
+                tracing::error!("Unexpected message");
+                return;
+            }
+        };
+
+        tracing::info!(taker = %peer, %quantity, order_id = %id, "Taker wants to place an order");
+
+        // Reject the order if the offer cannot be found in the latest offers
+        let offer = match self.pick_offer(offer.id).await {
+            Ok(offer) => offer,
+            Err(e) => {
+                tracing::warn!("Rejecting taker order because unable to pick offer: {e:#}");
+
+                let future = async move {
+                    framed
+                        .send(MakerMessage::Decision(protocol::Decision::Reject))
+                        .await?;
+
+                    anyhow::Ok(())
+                };
+
+                tokio_extras::spawn_fallible(
+                    &ctx.address().expect("self to be alive"),
+                    future,
+                    move |e| async move {
+                        tracing::debug!(%peer, "Failed to send reject order message: {e}");
+                    },
+                );
+
+                return;
+            }
+        };
+
+        let oracle_event_id = offer.oracle_event_id;
+
+        let cfd = Cfd::from_order(
+            id,
+            &offer,
+            quantity,
+            Identity::new(x25519_dalek::PublicKey::from(
+                *b"hello world, oh what a beautiful",
+            )),
+            Some(peer.into()),
+            Role::Maker,
+            leverage,
+        );
+
+        // If this fails we shouldn't try to append
+        // `ContractSetupFailed` to the nonexistent CFD
+        if let Err(e) = self.db.insert_cfd(&cfd).await {
+            tracing::error!("Inserting new cfd failed: {e:#}");
+            return;
+        }
+
+        if let Err(e) = self
+            .projection
+            .send_async_safe(projection::CfdChanged(cfd.id()))
+            .await
+        {
+            tracing::error!(%id, "Failed to update projection with new cfd when handling order: {e:#}");
+            return;
+        }
+
+        let (sender, receiver) = oneshot::channel();
+        self.decision_senders.insert(id, sender);
+
+        let task = {
+            let build_party_params = self.build_party_params.clone();
+            let sign = self.sign.clone();
+            let get_announcement = self.get_announcement.clone();
+            let executor = self.executor.clone();
+            let oracle_pk = self.oracle_pk;
+            let n_payouts = self.n_payouts;
+            async move {
+                match receiver.await? {
+                    protocol::Decision::Accept => {
+                        framed
+                            .send(MakerMessage::Decision(protocol::Decision::Accept))
+                            .await?;
+
+                        tracing::info!(taker = %peer, %quantity, order_id = %id, "Order accepted");
+                    }
+                    protocol::Decision::Reject => {
+                        framed
+                            .send(MakerMessage::Decision(protocol::Decision::Reject))
+                            .await?;
+
+                        tracing::info!(taker = %peer, %quantity, order_id = %id, "Order rejected");
+
+                        executor
+                            .execute(id, |cfd| {
+                                cfd.reject_contract_setup(anyhow::anyhow!("Unknown"))
+                            })
+                            .await?;
+
+                        return anyhow::Ok(());
+                    }
+                }
+
+                let (setup_params, position) = executor
+                    .execute(id, |cfd| cfd.start_contract_setup())
+                    .await?;
+
+                let (sink, stream) = framed.split();
+
+                let announcement = get_announcement
+                    .send(oracle::GetAnnouncements(vec![oracle_event_id]))
+                    .await??;
+
+                let dlc = setup_contract::new(
+                    sink.with(|msg| future::ok(MakerMessage::ContractSetupMsg(Box::new(msg)))),
+                    Box::pin(stream.filter_map(|msg| async move {
+                        let msg = match msg {
+                            Ok(msg) => msg,
+                            Err(e) => {
+                                tracing::error!("Failed to deserialize MakerMessage: {e:#}");
+                                return None;
+                            }
+                        };
+
+                        match SetupMsg::try_from(msg) {
+                            Ok(msg) => Some(msg),
+                            Err(e) => {
+                                tracing::error!("Failed to convert to SetupMsg: {e:#}");
+                                None
+                            }
+                        }
+                    }))
+                    .fuse(),
+                    (oracle_pk, announcement),
+                    setup_params,
+                    build_party_params,
+                    sign,
+                    Role::Maker,
+                    position,
+                    n_payouts,
+                )
+                .await?;
+
+                if let Err(e) = executor
+                    .execute(id, |cfd| cfd.complete_contract_setup(dlc))
+                    .await
+                {
+                    tracing::error!(%id, "Failed to execute contract_setup_completed: {e:#}");
+                }
+
+                anyhow::Ok(())
+            }
+        };
+
+        let err_handler = {
+            let executor = self.executor.clone();
+            move |e| async move {
+                if let Err(e) = executor
+                    .execute(id, |cfd| Ok(cfd.fail_contract_setup(e)))
+                    .await
+                {
+                    tracing::error!(%id, "Failed to execute fail_contract_setup: {e:#}");
+                }
+            }
+        };
+
+        let address = ctx.address().expect("we are alive");
+        tokio_extras::spawn_fallible(&address, task, err_handler);
+    }
+
+    async fn handle(&mut self, msg: Decision) -> Result<()> {
+        let id = msg.id();
+
+        tracing::debug!("Instructed to {msg} order {id}");
+
+        let sender = self
+            .decision_senders
+            .remove(&id)
+            .context("Can't make decision on nonexistent order {id}")?;
+
+        sender
+            .send(msg.into())
+            .map_err(|_| anyhow!("Can't deliver decision on taking order {id}"))?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum Decision {
+    Accept(OrderId),
+    Reject(OrderId),
+}
+
+impl Decision {
+    fn id(&self) -> OrderId {
+        match self {
+            Decision::Accept(id) | Decision::Reject(id) => *id,
+        }
+    }
+}
+
+impl From<Decision> for protocol::Decision {
+    fn from(decision: Decision) -> Self {
+        match decision {
+            Decision::Accept(_) => protocol::Decision::Accept,
+            Decision::Reject(_) => protocol::Decision::Reject,
+        }
+    }
+}
+
+impl fmt::Display for Decision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Decision::Accept(_) => "Accept",
+            Decision::Reject(_) => "Reject",
+        };
+
+        s.fmt(f)
+    }
+}
+
+#[async_trait]
+impl xtra::Actor for Actor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}

--- a/daemon/src/order/protocol.rs
+++ b/daemon/src/order/protocol.rs
@@ -1,0 +1,54 @@
+use crate::wire::SetupMsg;
+use anyhow::bail;
+use anyhow::Result;
+use model::Leverage;
+use model::Offer;
+use model::OrderId;
+use model::Usd;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum TakerMessage {
+    PlaceOrder {
+        id: OrderId,
+        offer: Offer,
+        quantity: Usd,
+        leverage: Leverage,
+    },
+    ContractSetupMsg(Box<SetupMsg>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum MakerMessage {
+    Decision(Decision),
+    ContractSetupMsg(Box<SetupMsg>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum Decision {
+    Accept,
+    Reject,
+}
+
+impl TryFrom<MakerMessage> for SetupMsg {
+    type Error = anyhow::Error;
+
+    fn try_from(value: MakerMessage) -> Result<Self> {
+        match value {
+            MakerMessage::Decision(_) => bail!("Expected SetupMsg, got decision"),
+            MakerMessage::ContractSetupMsg(msg) => Ok(*msg),
+        }
+    }
+}
+
+impl TryFrom<TakerMessage> for SetupMsg {
+    type Error = anyhow::Error;
+
+    fn try_from(value: TakerMessage) -> Result<Self> {
+        match value {
+            TakerMessage::PlaceOrder { .. } => bail!("Expected SetupMsg, got order placement"),
+            TakerMessage::ContractSetupMsg(msg) => Ok(*msg),
+        }
+    }
+}

--- a/daemon/src/order/taker.rs
+++ b/daemon/src/order/taker.rs
@@ -1,0 +1,269 @@
+use crate::command;
+use crate::oracle;
+use crate::oracle::NoAnnouncement;
+use crate::order::protocol::Decision;
+use crate::order::protocol::MakerMessage;
+use crate::order::protocol::TakerMessage;
+use crate::order::PROTOCOL_NAME;
+use crate::process_manager;
+use crate::projection;
+use crate::setup_contract;
+use crate::wallet;
+use crate::wire::SetupMsg;
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
+use async_trait::async_trait;
+use asynchronous_codec::Framed;
+use asynchronous_codec::JsonCodec;
+use bdk::bitcoin::psbt::PartiallySignedTransaction;
+use bdk::bitcoin::XOnlyPublicKey;
+use futures::future;
+use futures::SinkExt;
+use futures::StreamExt;
+use libp2p_core::PeerId;
+use maia_core::PartyParams;
+use model::olivia;
+use model::Cfd;
+use model::Identity;
+use model::Leverage;
+use model::Offer;
+use model::OrderId;
+use model::Role;
+use model::Usd;
+use xtra::prelude::MessageChannel;
+use xtra_libp2p::Endpoint;
+use xtra_libp2p::OpenSubstream;
+use xtra_productivity::xtra_productivity;
+
+pub struct Actor {
+    endpoint: xtra::Address<Endpoint>,
+    executor: command::Executor,
+    oracle_pk: XOnlyPublicKey,
+    get_announcement:
+        MessageChannel<oracle::GetAnnouncements, Result<Vec<olivia::Announcement>, NoAnnouncement>>,
+    build_party_params: MessageChannel<wallet::BuildPartyParams, Result<PartyParams>>,
+    sign: MessageChannel<wallet::Sign, Result<PartiallySignedTransaction>>,
+    projection: xtra::Address<projection::Actor>,
+    n_payouts: usize,
+    db: sqlite_db::Connection,
+}
+
+impl Actor {
+    pub fn new(
+        n_payouts: usize,
+        oracle_pk: XOnlyPublicKey,
+        get_announcement: MessageChannel<
+            oracle::GetAnnouncements,
+            Result<Vec<olivia::Announcement>, NoAnnouncement>,
+        >,
+        (db, process_manager): (sqlite_db::Connection, xtra::Address<process_manager::Actor>),
+        (build_party_params, sign): (
+            MessageChannel<wallet::BuildPartyParams, Result<PartyParams>>,
+            MessageChannel<wallet::Sign, Result<PartiallySignedTransaction>>,
+        ),
+        projection: xtra::Address<projection::Actor>,
+        endpoint: xtra::Address<Endpoint>,
+    ) -> Self {
+        Self {
+            endpoint,
+            executor: command::Executor::new(db.clone(), process_manager),
+            oracle_pk,
+            get_announcement,
+            build_party_params,
+            sign,
+            projection,
+            n_payouts,
+            db,
+        }
+    }
+}
+
+#[xtra_productivity]
+impl Actor {
+    pub async fn handle(&mut self, msg: PlaceOrder, ctx: &mut xtra::Context<Self>) {
+        let id = msg.id;
+
+        let task = {
+            let build_party_params = self.build_party_params.clone();
+            let sign = self.sign.clone();
+            let get_announcement = self.get_announcement.clone();
+            let endpoint = self.endpoint.clone();
+            let executor = self.executor.clone();
+            let db = self.db.clone();
+            let oracle_pk = self.oracle_pk;
+            let n_payouts = self.n_payouts;
+            let projection = self.projection.clone();
+            async move {
+                tracing::info!(order = ?msg, "Placing order");
+
+                let PlaceOrder {
+                    id,
+                    quantity,
+                    leverage,
+                    offer,
+                    maker_identity,
+                    maker_peer_id,
+                } = msg;
+
+                let oracle_event_id = offer.oracle_event_id;
+                let cfd = Cfd::from_order(
+                    id,
+                    &offer,
+                    quantity,
+                    maker_identity,
+                    Some(maker_peer_id.into()),
+                    Role::Taker,
+                    leverage,
+                );
+
+                // If this fails we shouldn't try to append
+                // `ContractSetupFailed` to the nonexistent CFD
+                if let Err(e) = db.insert_cfd(&cfd).await {
+                    tracing::error!("Inserting new cfd failed: {e:#}");
+                    return anyhow::Ok(());
+                };
+
+                projection.send(projection::CfdChanged(cfd.id())).await?;
+
+                let stream = endpoint
+                    .send(OpenSubstream::single_protocol(maker_peer_id, PROTOCOL_NAME))
+                    .await
+                    .context("Endpoint is disconnected")?
+                    .context("No connection to peer")?
+                    .await
+                    .context("Failed to open substream")?;
+
+                let mut framed =
+                    Framed::new(stream, JsonCodec::<TakerMessage, MakerMessage>::new());
+
+                framed
+                    .send(TakerMessage::PlaceOrder {
+                        id,
+                        offer,
+                        quantity,
+                        leverage,
+                    })
+                    .await?;
+
+                match framed.next().await.context("Stream terminated")?? {
+                    MakerMessage::Decision(Decision::Accept) => {
+                        tracing::info!(order_id = %msg.id, %maker_peer_id, "Order accepted");
+                    }
+                    MakerMessage::Decision(Decision::Reject) => {
+                        tracing::info!(order_id = %msg.id, %maker_peer_id, "Order rejected");
+
+                        executor
+                            .execute(id, |cfd| {
+                                cfd.reject_contract_setup(anyhow::anyhow!("Unknown"))
+                            })
+                            .await?;
+
+                        return anyhow::Ok(());
+                    }
+                    MakerMessage::ContractSetupMsg(_) => bail!("Unexpected message"),
+                };
+
+                let (setup_params, position) = executor
+                    .execute(id, |cfd| cfd.start_contract_setup())
+                    .await?;
+
+                let (sink, stream) = framed.split();
+
+                let announcement = get_announcement
+                    .send(oracle::GetAnnouncements(vec![oracle_event_id]))
+                    .await??;
+
+                let dlc = setup_contract::new(
+                    sink.with(|msg| future::ok(TakerMessage::ContractSetupMsg(Box::new(msg)))),
+                    Box::pin(stream.filter_map(|msg| async move {
+                        let msg = match msg {
+                            Ok(msg) => msg,
+                            Err(e) => {
+                                tracing::error!("Failed to deserialize MakerMessage: {e:#}");
+                                return None;
+                            }
+                        };
+
+                        match SetupMsg::try_from(msg) {
+                            Ok(msg) => Some(msg),
+                            Err(e) => {
+                                tracing::error!("Failed to convert to SetupMsg: {e:#}");
+                                None
+                            }
+                        }
+                    }))
+                    .fuse(),
+                    (oracle_pk, announcement),
+                    setup_params,
+                    build_party_params,
+                    sign,
+                    Role::Taker,
+                    position,
+                    n_payouts,
+                )
+                .await?;
+
+                if let Err(e) = executor
+                    .execute(id, |cfd| cfd.complete_contract_setup(dlc))
+                    .await
+                {
+                    tracing::error!(%id, "Failed to execute contract_setup_completed: {e:#}");
+                }
+
+                anyhow::Ok(())
+            }
+        };
+
+        let err_handler = {
+            let executor = self.executor.clone();
+            move |e| async move {
+                if let Err(e) = executor
+                    .execute(id, |cfd| Ok(cfd.fail_contract_setup(e)))
+                    .await
+                {
+                    tracing::error!(%id, "Failed to execute fail_contract_setup: {e:#}");
+                }
+            }
+        };
+
+        let address = ctx.address().expect("we are alive");
+        tokio_extras::spawn_fallible(&address, task, err_handler);
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PlaceOrder {
+    id: OrderId,
+    offer: Offer,
+    quantity: Usd,
+    leverage: Leverage,
+    maker_peer_id: PeerId,
+    maker_identity: Identity,
+}
+
+impl PlaceOrder {
+    pub(crate) fn new(
+        id: OrderId,
+        offer: Offer,
+        (quantity, leverage): (Usd, Leverage),
+        maker_peer_id: PeerId,
+        maker_identity: Identity,
+    ) -> Self {
+        Self {
+            id,
+            offer,
+            quantity,
+            leverage,
+            maker_peer_id,
+            maker_identity,
+        }
+    }
+}
+
+#[async_trait]
+impl xtra::Actor for Actor {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -1,25 +1,18 @@
-use crate::bitcoin::util::psbt::PartiallySignedTransaction;
 use crate::collab_settlement;
 use crate::collab_settlement::taker::Settle;
-use crate::connection;
-use crate::oracle;
-use crate::process_manager;
+use crate::order;
 use crate::projection;
-use crate::setup_taker;
-use crate::wallet;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use async_trait::async_trait;
-use maia_core::secp256k1_zkp::XOnlyPublicKey;
-use maia_core::PartyParams;
 use model::libp2p::PeerId;
 use model::market_closing_price;
-use model::olivia;
 use model::Cfd;
 use model::Identity;
 use model::Leverage;
 use model::MakerOffers;
+use model::OfferId;
 use model::OrderId;
 use model::Origin;
 use model::Price;
@@ -27,16 +20,15 @@ use model::Role;
 use model::Usd;
 use sqlite_db;
 use time::OffsetDateTime;
-use xtra::Actor as _;
 use xtra_productivity::xtra_productivity;
-use xtras::AddressMap;
+use xtras::SendAsyncSafe;
 
 #[derive(Clone)]
 pub struct CurrentMakerOffers(pub Option<MakerOffers>);
 
 #[derive(Clone, Copy)]
-pub struct TakeOffer {
-    pub order_id: OrderId,
+pub struct PlaceOrder {
+    pub offer_id: OfferId,
     pub quantity: Usd,
     pub leverage: Leverage,
 }
@@ -49,51 +41,31 @@ pub struct ProposeSettlement {
     pub quote_timestamp: String,
 }
 
-pub struct Actor<O, W> {
+pub struct Actor {
     db: sqlite_db::Connection,
-    wallet: xtra::Address<W>,
-    oracle_pk: XOnlyPublicKey,
     projection_actor: xtra::Address<projection::Actor>,
-    process_manager_actor: xtra::Address<process_manager::Actor>,
-    conn_actor: xtra::Address<connection::Actor>,
-    setup_actors: AddressMap<OrderId, setup_taker::Actor>,
     libp2p_collab_settlement_actor: xtra::Address<collab_settlement::taker::Actor>,
-    oracle_actor: xtra::Address<O>,
-    n_payouts: usize,
+    order_actor: xtra::Address<order::taker::Actor>,
     current_maker_offers: Option<MakerOffers>,
     maker_identity: Identity,
     maker_peer_id: PeerId,
 }
 
-impl<O, W> Actor<O, W>
-where
-    W: xtra::Handler<wallet::Sign> + xtra::Handler<wallet::BuildPartyParams>,
-{
+impl Actor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         db: sqlite_db::Connection,
-        wallet: xtra::Address<W>,
-        oracle_pk: XOnlyPublicKey,
         projection_actor: xtra::Address<projection::Actor>,
-        process_manager_actor: xtra::Address<process_manager::Actor>,
-        conn_actor: xtra::Address<connection::Actor>,
-        oracle_actor: xtra::Address<O>,
         libp2p_collab_settlement_actor: xtra::Address<collab_settlement::taker::Actor>,
-        n_payouts: usize,
+        order_actor: xtra::Address<order::taker::Actor>,
         maker_identity: Identity,
         maker_peer_id: PeerId,
     ) -> Self {
         Self {
             db,
-            wallet,
-            oracle_pk,
             projection_actor,
-            process_manager_actor,
-            conn_actor,
-            oracle_actor,
             libp2p_collab_settlement_actor,
-            n_payouts,
-            setup_actors: AddressMap::default(),
+            order_actor,
             current_maker_offers: None,
             maker_identity,
             maker_peer_id,
@@ -102,7 +74,7 @@ where
 }
 
 #[xtra_productivity]
-impl<O, W> Actor<O, W> {
+impl Actor {
     async fn handle_current_offers(&mut self, msg: xtra_libp2p_offer::taker::LatestMakerOffers) {
         let takers_perspective_of_maker_offers = msg.0.map(|mut maker_offers| {
             maker_offers.long = maker_offers.long.map(|mut long| {
@@ -130,10 +102,7 @@ impl<O, W> Actor<O, W> {
             tracing::warn!("Failed to send current offers to projection actor: {e:#}");
         };
     }
-}
 
-#[xtra_productivity]
-impl<O, W> Actor<O, W> {
     async fn handle_propose_settlement(&mut self, msg: ProposeSettlement) -> Result<()> {
         let ProposeSettlement {
             order_id,
@@ -161,111 +130,45 @@ impl<O, W> Actor<O, W> {
 
         Ok(())
     }
-}
 
-#[xtra_productivity]
-impl<O, W> Actor<O, W>
-where
-    O: xtra::Handler<
-            oracle::GetAnnouncements,
-            Return = Result<Vec<olivia::Announcement>, oracle::NoAnnouncement>,
-        > + xtra::Handler<oracle::MonitorAttestations>,
-    W: xtra::Handler<wallet::BuildPartyParams, Return = Result<PartyParams>>
-        + xtra::Handler<wallet::Sign, Return = Result<PartiallySignedTransaction>>,
-{
-    async fn handle_take_offer(
-        &mut self,
-        msg: TakeOffer,
-        ctx: &mut xtra::Context<Self>,
-    ) -> Result<()> {
-        let TakeOffer {
-            order_id,
+    async fn handle(&mut self, msg: PlaceOrder) -> Result<OrderId> {
+        let PlaceOrder {
+            offer_id,
             quantity,
             leverage,
         } = msg;
 
-        let disconnected = self
-            .setup_actors
-            .get_disconnected(order_id)
-            .with_context(|| {
-                format!("Contract setup for order {order_id} is already in progress")
-            })?;
-
-        let (order_to_take, maker_offers) = self
+        let offer = self
             .current_maker_offers
             .clone()
             .context("No maker offers available to take")?
-            .take_order(order_id);
+            .pick_offer_to_take(offer_id)
+            .context("Offer to take could not be found in current maker offers, you might have an outdated offer")?;
 
-        let order_to_take = order_to_take.context("Order to take could not be found in current maker offers, you might have an outdated offer")?;
-
-        // The offer we are instructed to take is removed from the
-        // set of available offers immediately so that we don't attempt
-        // to take it more than once
-        {
-            self.current_maker_offers.replace(maker_offers);
-            self.projection_actor
-                .send(projection::Update(self.current_maker_offers.clone()))
-                .await?;
+        if !offer.is_safe_to_take(OffsetDateTime::now_utc()) {
+            bail!("The maker's offer appears to be outdated, refusing to place order");
         }
 
-        if !order_to_take.is_safe_to_take(OffsetDateTime::now_utc()) {
-            bail!("The maker's offer appears to be outdated, refusing to take offer",);
-        }
-
-        tracing::info!("Taking current order: {:?}", &order_to_take);
-
-        // We create the cfd here without any events yet, only static data
-        // Once the contract setup completes (rejected / accepted / failed) the first event will be
-        // recorded
-        let cfd = Cfd::from_order(
-            &order_to_take,
-            quantity,
+        let order_id = OrderId::default();
+        let place_order = order::taker::PlaceOrder::new(
+            order_id,
+            offer,
+            (quantity, leverage),
+            self.maker_peer_id.inner(),
             self.maker_identity,
-            Some(self.maker_peer_id),
-            Role::Taker,
-            leverage,
         );
 
-        self.db.insert_cfd(&cfd).await?;
-        self.projection_actor
-            .send(projection::CfdChanged(cfd.id()))
-            .await?;
+        self.order_actor
+            .send_async_safe(place_order)
+            .await
+            .context("Failed to place order")?;
 
-        let price_event_id = order_to_take.oracle_event_id;
-        let announcement = self
-            .oracle_actor
-            .send(oracle::GetAnnouncements(vec![price_event_id]))
-            .await?
-            .with_context(|| format!("Announcement {price_event_id} not found"))?;
-
-        let (addr, fut) = setup_taker::Actor::new(
-            self.db.clone(),
-            self.process_manager_actor.clone(),
-            (
-                cfd.id(),
-                cfd.quantity(),
-                cfd.taker_leverage(),
-                self.n_payouts,
-            ),
-            (self.oracle_pk, announcement[0].clone()),
-            self.wallet.clone().into(),
-            self.wallet.clone().into(),
-            self.conn_actor.clone(),
-        )
-        .create(None)
-        .run();
-
-        tokio_extras::spawn(&ctx.address().expect("self to be alive"), fut);
-        tracing::info!("Spawned taker setup actor");
-        disconnected.insert(addr);
-
-        Ok(())
+        Ok(order_id)
     }
 }
 
 #[async_trait]
-impl<O: 'static, W: 'static> xtra::Actor for Actor<O, W> {
+impl xtra::Actor for Actor {
     type Stop = ();
 
     async fn stopped(self) -> Self::Stop {}

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -419,7 +419,7 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload")]
 pub enum SetupMsg {
     /// Message enabling setting up lock and based on that commit, refund and cets

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1060,6 +1060,7 @@ impl From<&Payout> for i64 {
 #[derive(Debug, Clone, Copy)]
 pub struct FailedCfd {
     pub id: OrderId,
+    pub offer_id: OfferId,
     pub position: Position,
     pub initial_price: Price,
     pub taker_leverage: Leverage,
@@ -1111,6 +1112,7 @@ pub enum Settlement {
 #[derive(Debug, Clone, Copy)]
 pub struct ClosedCfd {
     pub id: OrderId,
+    pub offer_id: OfferId,
     pub position: Position,
     pub initial_price: Price,
     pub taker_leverage: Leverage,

--- a/sqlite-db/migrations/20220725144854_add_offer_id_columns.sql
+++ b/sqlite-db/migrations/20220725144854_add_offer_id_columns.sql
@@ -1,0 +1,37 @@
+-- Introduce offer_id field for all cfd tables.
+-- We can opt to move offer related parameters to a separate table for normalization in a separate iteration if needed.
+--
+-- Steps:
+-- 1. Rename `uuid` to `order_id` so the column makes more sense
+-- 2. Add column `offer_id` with a dummy default value
+-- 3. Set `offer_id` value to `order_id` value because prior to this change offer=order
+ALTER TABLE
+    cfds RENAME COLUMN uuid TO order_id;
+ALTER TABLE
+    cfds
+ADD
+    COLUMN offer_id text NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000';
+UPDATE
+    cfds
+SET
+    offer_id = order_id;
+ALTER TABLE
+    main.closed_cfds RENAME COLUMN uuid TO order_id;
+ALTER TABLE
+    closed_cfds
+ADD
+    COLUMN offer_id text NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000';
+UPDATE
+    closed_cfds
+SET
+    offer_id = order_id;
+ALTER TABLE
+    main.failed_cfds RENAME COLUMN uuid TO order_id;
+ALTER TABLE
+    failed_cfds
+ADD
+    COLUMN offer_id text NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000';
+UPDATE
+    failed_cfds
+SET
+    offer_id = order_id;

--- a/sqlite-db/sqlx-data.json
+++ b/sqlite-db/sqlx-data.json
@@ -1,14 +1,56 @@
 {
   "db": "SQLite",
-  "060f5ccae5e675d3118ae357eb225c7fa37d54802a24e328db1dc84e547d4d9d": {
+  "01338142381cbcdab61aca1aef1640f52cf100ef6d8852e8a95bec69f78a50cb": {
+    "describe": {
+      "columns": [
+        {
+          "name": "order_id: models::OrderId",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            SELECT\n                order_id as \"order_id: models::OrderId\"\n            FROM\n                failed_cfds\n            "
+  },
+  "0315a501b111ee6c2d297e57ae0a020d68fedfaf3a9432e6bdc20eb52ef5a6ae": {
     "describe": {
       "columns": [],
       "nullable": [],
       "parameters": {
-        "Right": 1
+        "Right": 9
       }
     },
-    "query": "\n            delete from open_cets where cfd_id = (select id from cfds where cfds.uuid = $1)\n        "
+    "query": "\n                insert into open_cets (\n                    cfd_id,\n                    oracle_event_id,\n                    adaptor_sig,\n                    maker_amount,\n                    taker_amount,\n                    n_bits,\n                    range_start,\n                    range_end,\n                    txid\n                ) values ( (select id from cfds where cfds.order_id = $1), $2, $3, $4, $5, $6, $7, $8, $9 )\n            "
+  },
+  "0669f88eaef74a15ce31885089773e44b6c296e0e0d2b5ef6c1fbe09bf318a54": {
+    "describe": {
+      "columns": [
+        {
+          "name": "cfd_id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "order_id: models::OrderId",
+          "ordinal": 1,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        true,
+        false
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "\n            select\n                id as cfd_id,\n                order_id as \"order_id: models::OrderId\"\n            from\n                cfds\n            where exists (\n                select id from EVENTS as events\n                where events.cfd_id = cfds.id and\n                (\n                    events.name = $1 or\n                    events.name = $2\n                )\n            )\n            "
   },
   "138cd0bf1974ccc90c52024796a8e81e5d61413261d4bba6073504379e67cdeb": {
     "describe": {
@@ -76,85 +118,31 @@
     },
     "query": "\n            SELECT\n                encsig_ours as \"encsig_ours: models::AdaptorSignature\",\n                publication_pk_theirs as \"publication_pk_theirs: models::PublicKey\",\n                revocation_sk_theirs as \"revocation_sk_theirs: models::SecretKey\",\n                revocation_sk_ours as \"revocation_sk_ours: models::SecretKey\",\n                script_pubkey,\n                settlement_event_id as \"settlement_event_id: models::BitMexPriceEventId\",\n                txid as \"txid: models::Txid\",\n                complete_fee as \"complete_fee: i64\",\n                complete_fee_flow as \"complete_fee_flow: models::FeeFlow\"\n            FROM\n                revoked_commit_transactions\n            WHERE\n                cfd_id = $1\n            ORDER BY id\n            "
   },
-  "1b0a898c7975e9d9eb313fe900b15c4672f11ff110e0ae16560d7f3d7b4fddc4": {
+  "1af14106d15834986495c94a54c8a209e2f94909e8bb5f4a4a11b3e2df3102e1": {
     "describe": {
       "columns": [
         {
-          "name": "cfd_id",
+          "name": "txid: models::Txid",
           "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "vout: models::Vout",
+          "ordinal": 1,
           "type_info": "Int64"
         },
         {
-          "name": "uuid: models::OrderId",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "position: models::Position",
+          "name": "payout: models::Payout",
           "ordinal": 2,
-          "type_info": "Text"
+          "type_info": "Int64"
         },
         {
-          "name": "initial_price: models::Price",
+          "name": "price: models::Price",
           "ordinal": 3,
           "type_info": "Text"
-        },
-        {
-          "name": "leverage: models::Leverage",
-          "ordinal": 4,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_hours",
-          "ordinal": 5,
-          "type_info": "Int64"
-        },
-        {
-          "name": "quantity_usd: models::Usd",
-          "ordinal": 6,
-          "type_info": "Text"
-        },
-        {
-          "name": "counterparty_network_identity: models::Identity",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "counterparty_peer_id: models::PeerId",
-          "ordinal": 8,
-          "type_info": "Text"
-        },
-        {
-          "name": "role: models::Role",
-          "ordinal": 9,
-          "type_info": "Text"
-        },
-        {
-          "name": "opening_fee: models::OpeningFee",
-          "ordinal": 10,
-          "type_info": "Null"
-        },
-        {
-          "name": "initial_funding_rate: models::FundingRate",
-          "ordinal": 11,
-          "type_info": "Null"
-        },
-        {
-          "name": "initial_tx_fee_rate: models::TxFeeRate",
-          "ordinal": 12,
-          "type_info": "Null"
         }
       ],
       "nullable": [
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
         false,
         false,
         false,
@@ -164,7 +152,27 @@
         "Right": 1
       }
     },
-    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: models::OrderId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                leverage as \"leverage: models::Leverage\",\n                settlement_time_interval_hours,\n                quantity_usd as \"quantity_usd: models::Usd\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                opening_fee as \"opening_fee: models::OpeningFee\",\n                initial_funding_rate as \"initial_funding_rate: models::FundingRate\",\n                initial_tx_fee_rate as \"initial_tx_fee_rate: models::TxFeeRate\"\n            from\n                cfds\n            where\n                cfds.uuid = $1\n            "
+    "query": "\n        SELECT\n            collaborative_settlement_txs.txid as \"txid: models::Txid\",\n            collaborative_settlement_txs.vout as \"vout: models::Vout\",\n            collaborative_settlement_txs.payout as \"payout: models::Payout\",\n            collaborative_settlement_txs.price as \"price: models::Price\"\n        FROM\n            collaborative_settlement_txs\n        JOIN\n            closed_cfds on closed_cfds.id = collaborative_settlement_txs.cfd_id\n        WHERE\n            closed_cfds.order_id = $1\n        "
+  },
+  "1c2f1bf7f8b76e1e8ae0ee66080e8986a50226141291b4e1d695e30d0b9c7ea9": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "\n            delete from open_cets where cfd_id = (select id from cfds where cfds.order_id = $1)\n        "
+  },
+  "1f2ef1ab518a808f2680ae74e1a817790904012e268f90f0a6e8c7b53ab0d45b": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 5
+      }
+    },
+    "query": "\n        INSERT INTO collaborative_settlement_txs\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout,\n            price\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.order_id = $1),\n            $2, $3, $4, $5\n        )\n        "
   },
   "20dcbd828efa787dbff1d26cabc1a5ac81acacad6536a27c51aab3b02c0efd58": {
     "describe": {
@@ -184,33 +192,57 @@
     },
     "query": "\n            SELECT\n                first_seen_timestamp\n            FROM\n                time_to_first_position\n            WHERE\n                taker_id = $1\n            "
   },
-  "2bc999ce15bafc204ee01ed09cb6fa139fc709e35ba441634f7b8c080ca41d83": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 25
-      }
-    },
-    "query": "\n            insert into rollover_completed_event_data (\n                cfd_id,\n                event_id,\n                settlement_event_id,\n                refund_timelock,\n                funding_fee,\n                rate,\n                identity,\n                identity_counterparty,\n                maker_address,\n                taker_address,\n                maker_lock_amount,\n                taker_lock_amount,\n                publish_sk,\n                publish_pk_counterparty,\n                revocation_secret,\n                revocation_pk_counterparty,\n                lock_tx,\n                lock_tx_descriptor,\n                commit_tx,\n                commit_adaptor_signature,\n                commit_descriptor,\n                refund_tx,\n                refund_signature,\n                complete_fee,\n                complete_fee_flow\n            ) values (\n            (select id from cfds where cfds.uuid = $1),\n            $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25\n            )\n        "
-  },
-  "2fa4050fc45976c626a21f0de7468a9c2e9eaf6caf6797b5623e663d0c190366": {
+  "2b17856ca53345e31205aa2b48b01659f8d17bec28cb2935d54cb49bacc188ba": {
     "describe": {
       "columns": [
         {
-          "name": "uuid: models::OrderId",
+          "name": "cfd_row_id",
           "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "event_row_id",
+          "ordinal": 1,
+          "type_info": "Int64"
+        },
+        {
+          "name": "name",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "data",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at: models::Timestamp",
+          "ordinal": 4,
           "type_info": "Text"
         }
       ],
       "nullable": [
+        true,
+        false,
+        false,
+        false,
         false
       ],
       "parameters": {
-        "Right": 0
+        "Right": 2
       }
     },
-    "query": "\n            SELECT\n                uuid as \"uuid: models::OrderId\"\n            FROM\n                closed_cfds\n            "
+    "query": "\n\n        select\n            c.id as cfd_row_id,\n            events.id as event_row_id,\n            events.name,\n            events.data,\n            events.created_at as \"created_at: models::Timestamp\"\n        from\n            events\n        join\n            cfds c on c.id = events.cfd_id\n        where\n            order_id = $1\n        order by\n            events.id\n        limit $2,-1\n            "
+  },
+  "2ecfb19c21f666c4f73744f01354de511e463e5867a13fa5f6d8519327684aa9": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 5
+      }
+    },
+    "query": "\n        INSERT INTO closed_cets\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout,\n            price\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.order_id = $1),\n            $2, $3, $4, $5\n        )\n        "
   },
   "375bcb24b5a899520f76cd2f07ed5f14d4e862ef76a680de4d43350866260baa": {
     "describe": {
@@ -242,83 +274,31 @@
     },
     "query": "\n            SELECT \n                COUNT(DISTINCT rollover_completed_event_data.id) as rollovers, \n                COUNT(DISTINCT revoked_commit_transactions.id) as revokes, \n                COUNT(DISTINCT open_cets.id) as cets\n            FROM \n                rollover_completed_event_data, \n                revoked_commit_transactions, \n                open_cets;\n            "
   },
-  "3b946031bc9598649255793e28a2c34538daec61b075f890757967eef04ff1af": {
+  "496c2ab5814811e176bff90b7129179c7946d106d47bebf6baa78ee3b35268a7": {
     "describe": {
       "columns": [
         {
-          "name": "created_at!: i64",
+          "name": "cfd_id",
           "ordinal": 0,
           "type_info": "Int64"
-        }
-      ],
-      "nullable": [
-        true
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n        SELECT\n            event_log.created_at as \"created_at!: i64\"\n        FROM\n            event_log\n        JOIN\n            closed_cfds on closed_cfds.id = event_log.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        ORDER BY event_log.created_at ASC\n        LIMIT 1\n        "
-  },
-  "450bfcea8dcac5288b69187eb4ae5aec72012d7320e1d4d2602c448671512295": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n            delete from rollover_completed_event_data where cfd_id = (select id from cfds where cfds.uuid = $1)\n        "
-  },
-  "51dfaedacea8acc8fde5353d67061df2537941a992ca436bb908d9237414e23c": {
-    "describe": {
-      "columns": [
+        },
         {
-          "name": "uuid: models::OrderId",
-          "ordinal": 0,
+          "name": "order_id: models::OrderId",
+          "ordinal": 1,
           "type_info": "Text"
         }
       ],
       "nullable": [
+        true,
         false
       ],
       "parameters": {
-        "Right": 0
+        "Right": 3
       }
     },
-    "query": "\n            SELECT\n                uuid as \"uuid: models::OrderId\"\n            FROM\n                cfds\n            "
+    "query": "\n            select\n                id as cfd_id,\n                order_id as \"order_id: models::OrderId\"\n            from\n                cfds\n            where exists (\n                select id from EVENTS as events\n                where events.cfd_id = cfds.id and\n                (\n                    events.name = $1 or\n                    events.name = $2 or\n                    events.name= $3\n                )\n            )\n            "
   },
-  "58e3d05c44b0ddc2d4713e292fffef23b078e042810a411ea22fcf7bfe6c84fd": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 9
-      }
-    },
-    "query": "\n                insert into open_cets (\n                    cfd_id,\n                    oracle_event_id,\n                    adaptor_sig,\n                    maker_amount,\n                    taker_amount,\n                    n_bits,\n                    range_start,\n                    range_end,\n                    txid\n                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6, $7, $8, $9 )\n            "
-  },
-  "58f901862d163e620ae414a67b3dc0d26014993568727ae974b937cf82f42c84": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 2
-      }
-    },
-    "query": "\n        INSERT INTO closed_commit_txs\n        (\n            cfd_id,\n            txid\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2\n        )\n        "
-  },
-  "5bb1bc88b8fd2fe70fc2852aca4c40630458d4d9bc363771e099fa6f27bb6ff2": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 10
-      }
-    },
-    "query": "\n                insert into revoked_commit_transactions (\n                    cfd_id,\n                    encsig_ours,\n                    publication_pk_theirs,\n                    revocation_sk_theirs,\n                    script_pubkey,\n                    txid,\n                    settlement_event_id,\n                    complete_fee,\n                    complete_fee_flow,\n                    revocation_sk_ours\n                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6, $7, $8, $9, $10 )\n            "
-  },
-  "6705894784db563cfc16ca0ac9c2a4eb152fe6f9111c068c4c077e7de930e0a0": {
+  "4a47f065ae19becd62b696f3b6f83ca138bbd719903ae93375942888c9f4c5aa": {
     "describe": {
       "columns": [],
       "nullable": [],
@@ -326,27 +306,39 @@
         "Right": 1
       }
     },
-    "query": "\n        DELETE FROM\n            cfds\n        WHERE\n            cfds.uuid = $1\n        "
+    "query": "\n            delete from rollover_completed_event_data where cfd_id = (select id from cfds where cfds.order_id = $1)\n        "
   },
-  "697d9ca427dd0d3d8b3a21640bb2f309d30fb34b8d57bf663fe282892b21dd5d": {
+  "4cd8f8d0b36f353b61783243db9f888bf1ba698c1d2a1c53aeeb573ce7b1eab8": {
     "describe": {
-      "columns": [
-        {
-          "name": "created_at!: i64",
-          "ordinal": 0,
-          "type_info": "Int64"
-        }
-      ],
-      "nullable": [
-        true
-      ],
+      "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 1
       }
     },
-    "query": "\n        SELECT\n            event_log_failed.created_at as \"created_at!: i64\"\n        FROM\n            event_log_failed\n        JOIN\n            failed_cfds on failed_cfds.id = event_log_failed.cfd_id\n        WHERE\n            failed_cfds.uuid = $1\n        ORDER BY event_log_failed.created_at ASC\n        LIMIT 1\n        "
+    "query": "\n        DELETE FROM\n            events\n        WHERE events.cfd_id IN\n            (SELECT id FROM cfds WHERE cfds.order_id = $1)\n        "
   },
-  "7a2f760e4af1661f6df85ba6ce17ea746723f6b2d28f933aa8692c63e9c904be": {
+  "53ffb8aafd4978ad1ddb5d7b3ef18f1e1938f37af6bae7d41f9371c68b2e76d4": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 3
+      }
+    },
+    "query": "\n            INSERT INTO event_log_failed (\n                cfd_id,\n                name,\n                created_at\n            )\n            VALUES\n            (\n                (SELECT id FROM failed_cfds WHERE failed_cfds.order_id = $1),\n                $2, $3\n            )\n            "
+  },
+  "54a137ff1c5d3b785023c9382662730fbc161ee4290777e9754a8313887f8ca1": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 11
+      }
+    },
+    "query": "\n        INSERT INTO failed_cfds\n        (\n            order_id,\n            offer_id,\n            position,\n            initial_price,\n            taker_leverage,\n            n_contracts,\n            counterparty_network_identity,\n            counterparty_peer_id,\n            role,\n            fees,\n            kind\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n        "
+  },
+  "56e8ce89f0072ac7c451c2a6314f4c22664ccd48e345255ca61319a8040f7626": {
     "describe": {
       "columns": [
         {
@@ -362,49 +354,259 @@
         "Right": 1
       }
     },
-    "query": "select id from cfds where uuid = $1"
+    "query": "select id from cfds where order_id = $1"
   },
-  "7a7a9cc00acb13e8aab74b57a9ced6e6ef490780956e659e090a15833ceee571": {
+  "702549323c4c22903b4e030456ce5214611521dbf7560e0900fda9a06ca554a4": {
+    "describe": {
+      "columns": [
+        {
+          "name": "cfd_id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "order_id: models::OrderId",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "offer_id: models::OfferId",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: models::Position",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price: models::Price",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "leverage: models::Leverage",
+          "ordinal": 5,
+          "type_info": "Int64"
+        },
+        {
+          "name": "settlement_time_interval_hours",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "quantity_usd: models::Usd",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "counterparty_network_identity: models::Identity",
+          "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "counterparty_peer_id: models::PeerId",
+          "ordinal": 9,
+          "type_info": "Text"
+        },
+        {
+          "name": "role: models::Role",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "opening_fee: models::OpeningFee",
+          "ordinal": 11,
+          "type_info": "Null"
+        },
+        {
+          "name": "initial_funding_rate: models::FundingRate",
+          "ordinal": 12,
+          "type_info": "Null"
+        },
+        {
+          "name": "initial_tx_fee_rate: models::TxFeeRate",
+          "ordinal": 13,
+          "type_info": "Null"
+        }
+      ],
+      "nullable": [
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "\n            select\n                id as cfd_id,\n                order_id as \"order_id: models::OrderId\",\n                offer_id as \"offer_id: models::OfferId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                leverage as \"leverage: models::Leverage\",\n                settlement_time_interval_hours,\n                quantity_usd as \"quantity_usd: models::Usd\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                opening_fee as \"opening_fee: models::OpeningFee\",\n                initial_funding_rate as \"initial_funding_rate: models::FundingRate\",\n                initial_tx_fee_rate as \"initial_tx_fee_rate: models::TxFeeRate\"\n            from\n                cfds\n            where\n                cfds.order_id = $1\n            "
+  },
+  "76e71ec93cb68fc2a917844dd8ea20d307326f215d0a4b0356393b0d2f5067bc": {
+    "describe": {
+      "columns": [
+        {
+          "name": "commit_txid!: models::Txid",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "txid: models::Txid",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "vout: models::Vout",
+          "ordinal": 2,
+          "type_info": "Int64"
+        },
+        {
+          "name": "payout: models::Payout",
+          "ordinal": 3,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        true,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "\n        SELECT\n            closed_commit_txs.txid as \"commit_txid!: models::Txid\",\n            closed_refund_txs.txid as \"txid: models::Txid\",\n            closed_refund_txs.vout as \"vout: models::Vout\",\n            closed_refund_txs.payout as \"payout: models::Payout\"\n        FROM\n            closed_refund_txs\n        JOIN\n            closed_commit_txs on closed_commit_txs.cfd_id = closed_refund_txs.cfd_id\n        JOIN\n            closed_cfds on closed_cfds.id = closed_refund_txs.cfd_id\n        WHERE\n            closed_cfds.order_id = $1\n        "
+  },
+  "779a2aa25040b646788075c279cb97e26f3eb233f25f426642ed32d423008f96": {
     "describe": {
       "columns": [],
       "nullable": [],
       "parameters": {
-        "Right": 3
+        "Right": 13
       }
     },
-    "query": "\n            INSERT INTO event_log_failed (\n                cfd_id,\n                name,\n                created_at\n            )\n            VALUES\n            (\n                (SELECT id FROM failed_cfds WHERE failed_cfds.uuid = $1),\n                $2, $3\n            )\n            "
+    "query": "\n        INSERT INTO closed_cfds\n        (\n            order_id,\n            offer_id,\n            position,\n            initial_price,\n            taker_leverage,\n            n_contracts,\n            counterparty_network_identity,\n            counterparty_peer_id,\n            role,\n            fees,\n            expiry_timestamp,\n            lock_txid,\n            lock_dlc_vout\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)\n        "
   },
-  "7b72ad9417037bdb34fdd53091329bd85718d79a640eabc533652379fb548512": {
+  "83e000677e6f83472de94228165ca54819d4c55bd16d89e9efa270b3f24b8ac6": {
     "describe": {
-      "columns": [],
-      "nullable": [],
+      "columns": [
+        {
+          "name": "order_id: models::OrderId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "offer_id: models::OfferId",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: models::Position",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price: models::Price",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "taker_leverage: models::Leverage",
+          "ordinal": 4,
+          "type_info": "Int64"
+        },
+        {
+          "name": "n_contracts: models::Contracts",
+          "ordinal": 5,
+          "type_info": "Int64"
+        },
+        {
+          "name": "counterparty_network_identity: models::Identity",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "counterparty_peer_id: models::PeerId",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "role: models::Role",
+          "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "fees: models::Fees",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "expiry_timestamp",
+          "ordinal": 10,
+          "type_info": "Int64"
+        },
+        {
+          "name": "lock_txid: models::Txid",
+          "ordinal": 11,
+          "type_info": "Text"
+        },
+        {
+          "name": "lock_dlc_vout: models::Vout",
+          "ordinal": 12,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
       "parameters": {
-        "Right": 4
+        "Right": 1
       }
     },
-    "query": "\n        INSERT INTO closed_refund_txs\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2, $3, $4\n        )\n        "
+    "query": "\n            SELECT\n                order_id as \"order_id: models::OrderId\",\n                offer_id as \"offer_id: models::OfferId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                taker_leverage as \"taker_leverage: models::Leverage\",\n                n_contracts as \"n_contracts: models::Contracts\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                fees as \"fees: models::Fees\",\n                expiry_timestamp,\n                lock_txid as \"lock_txid: models::Txid\",\n                lock_dlc_vout as \"lock_dlc_vout: models::Vout\"\n            FROM\n                closed_cfds\n            WHERE\n                closed_cfds.order_id = $1\n            "
   },
-  "8175b7702d6a0b28843f03a9b6f507a64a703ae2ff649b3a28f339f3abb70fce": {
+  "89c4ffc05a97ee61f28ecb36e6e488991e24f72f58b161f624a2da08f9399c0a": {
     "describe": {
-      "columns": [],
-      "nullable": [],
+      "columns": [
+        {
+          "name": "created_at!: i64",
+          "ordinal": 0,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        true
+      ],
       "parameters": {
-        "Right": 5
+        "Right": 1
       }
     },
-    "query": "\n        INSERT INTO closed_cets\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout,\n            price\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2, $3, $4, $5\n        )\n        "
+    "query": "\n        SELECT\n            event_log_failed.created_at as \"created_at!: i64\"\n        FROM\n            event_log_failed\n        JOIN\n            failed_cfds on failed_cfds.id = event_log_failed.cfd_id\n        WHERE\n            failed_cfds.order_id = $1\n        ORDER BY event_log_failed.created_at ASC\n        LIMIT 1\n        "
   },
-  "8192c50dcb3342b01b9ab39daadcbc73f75d3b7f48ae18dfe4d936ebf8725fb4": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 3
-      }
-    },
-    "query": "\n            INSERT INTO event_log (\n                cfd_id,\n                name,\n                created_at\n            )\n            VALUES\n            (\n                (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n                $2, $3\n            )\n            "
-  },
-  "8376057fa3aeb05be23c79c288b929b9b6a8590b410f2496ab2c52dba24b5e8c": {
+  "8d90494f380b2f67fa27e38dd0940f53ad261f9a8653cb1151e29df5c7527758": {
     "describe": {
       "columns": [
         {
@@ -444,47 +646,51 @@
         "Right": 1
       }
     },
-    "query": "\n        SELECT\n            closed_commit_txs.txid as \"commit_txid!: models::Txid\",\n            closed_cets.txid as \"txid: models::Txid\",\n            closed_cets.vout as \"vout: models::Vout\",\n            closed_cets.payout as \"payout: models::Payout\",\n            closed_cets.price as \"price: models::Price\"\n        FROM\n            closed_cets\n        JOIN\n            closed_commit_txs on closed_commit_txs.cfd_id = closed_cets.cfd_id\n        JOIN\n            closed_cfds on closed_cfds.id = closed_cets.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        "
+    "query": "\n        SELECT\n            closed_commit_txs.txid as \"commit_txid!: models::Txid\",\n            closed_cets.txid as \"txid: models::Txid\",\n            closed_cets.vout as \"vout: models::Vout\",\n            closed_cets.payout as \"payout: models::Payout\",\n            closed_cets.price as \"price: models::Price\"\n        FROM\n            closed_cets\n        JOIN\n            closed_commit_txs on closed_commit_txs.cfd_id = closed_cets.cfd_id\n        JOIN\n            closed_cfds on closed_cfds.id = closed_cets.cfd_id\n        WHERE\n            closed_cfds.order_id = $1\n        "
   },
-  "8556fa5ffa07322e35a16add4e40fa35bd543f7a1cb6d81b046ded4ec7bbb0be": {
+  "8ece00728af7cc64aba25240bb9554ebc1e359aa1fa59aa1237c1db2248bd37f": {
+    "describe": {
+      "columns": [
+        {
+          "name": "created_at!: i64",
+          "ordinal": 0,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "\n        SELECT\n            event_log.created_at as \"created_at!: i64\"\n        FROM\n            event_log\n        JOIN\n            closed_cfds on closed_cfds.id = event_log.cfd_id\n        WHERE\n            closed_cfds.order_id = $1\n        ORDER BY event_log.created_at ASC\n        LIMIT 1\n        "
+  },
+  "92f8ec42a06c2b6afb8d40ee842c62885b68becaa797f1317194a012c6721915": {
     "describe": {
       "columns": [],
       "nullable": [],
       "parameters": {
-        "Right": 12
+        "Right": 4
       }
     },
-    "query": "\n        INSERT INTO closed_cfds\n        (\n            uuid,\n            position,\n            initial_price,\n            taker_leverage,\n            n_contracts,\n            counterparty_network_identity,\n            counterparty_peer_id,\n            role,\n            fees,\n            expiry_timestamp,\n            lock_txid,\n            lock_dlc_vout\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)\n        "
+    "query": "\n        INSERT INTO closed_refund_txs\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.order_id = $1),\n            $2, $3, $4\n        )\n        "
   },
-  "86477acca532607d45b1c3dda0d5dce72e1e8808856e89352f74caecd6657636": {
+  "9421d26f739b3319751334a22a3bd1c8795357d948920dec4a3d567bb7f8d45e": {
     "describe": {
-      "columns": [
-        {
-          "name": "cfd_id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "uuid: models::OrderId",
-          "ordinal": 1,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        true,
-        false
-      ],
+      "columns": [],
+      "nullable": [],
       "parameters": {
-        "Right": 3
+        "Right": 2
       }
     },
-    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: models::OrderId\"\n            from\n                cfds\n            where exists (\n                select id from EVENTS as events\n                where events.cfd_id = cfds.id and\n                (\n                    events.name = $1 or\n                    events.name = $2 or\n                    events.name= $3\n                )\n            )\n            "
+    "query": "\n        INSERT INTO closed_commit_txs\n        (\n            cfd_id,\n            txid\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.order_id = $1),\n            $2\n        )\n        "
   },
-  "8874e29f69435343da92ab0dbd49a5b16ff556f9f2c2f32bb3809b730d65b74f": {
+  "978a67b4fbaab87b71155e52b5225bbc9fc7ab70573069bf6563afd4be5a8713": {
     "describe": {
       "columns": [
         {
-          "name": "uuid: models::OrderId",
+          "name": "order_id: models::OrderId",
           "ordinal": 0,
           "type_info": "Text"
         }
@@ -496,19 +702,9 @@
         "Right": 0
       }
     },
-    "query": "\n            SELECT\n                uuid as \"uuid: models::OrderId\"\n            FROM\n                failed_cfds\n            "
+    "query": "\n            SELECT\n                order_id as \"order_id: models::OrderId\"\n            FROM\n                closed_cfds\n            "
   },
-  "8be24a7ddeb039a60c0600232d742f9ba75c02cde7bf536bb190525be07f0d5b": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 5
-      }
-    },
-    "query": "\n        INSERT INTO collaborative_settlement_txs\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout,\n            price\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2, $3, $4, $5\n        )\n        "
-  },
-  "917676bc8f8daffc784657cd8a1f8552273fa63be601a0a9782b4073359abfff": {
+  "9af85916cc2b849cb51b78f35e2384a1ffeb9269b53952fd8220a77a4ccaba6f": {
     "describe": {
       "columns": [],
       "nullable": [],
@@ -516,31 +712,7 @@
         "Right": 1
       }
     },
-    "query": "\n            delete from revoked_commit_transactions where cfd_id = (select id from cfds where cfds.uuid = $1)\n        "
-  },
-  "9b6615bc3e46b09f11f53e3d817fc2516c4ca24f129157ef0e45a4d5b51fe6a7": {
-    "describe": {
-      "columns": [
-        {
-          "name": "cfd_id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "uuid: models::OrderId",
-          "ordinal": 1,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        true,
-        false
-      ],
-      "parameters": {
-        "Right": 2
-      }
-    },
-    "query": "\n            select\n                id as cfd_id,\n                uuid as \"uuid: models::OrderId\"\n            from\n                cfds\n            where exists (\n                select id from EVENTS as events\n                where events.cfd_id = cfds.id and\n                (\n                    events.name = $1 or\n                    events.name = $2\n                )\n            )\n            "
+    "query": "\n            delete from revoked_commit_transactions where cfd_id = (select id from cfds where cfds.order_id = $1)\n        "
   },
   "9ee7e0229619689eed2c5f2e834d9449a732824bbeffed628d01abc1d1839319": {
     "describe": {
@@ -560,6 +732,16 @@
     },
     "query": "\n            SELECT\n                first_position_timestamp\n            FROM\n                time_to_first_position\n            WHERE\n                taker_id = $1\n            "
   },
+  "a380f17ca61f675559fe2713b246cddf95b05c3f3bda938c13c756332296693c": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 25
+      }
+    },
+    "query": "\n            insert into rollover_completed_event_data (\n                cfd_id,\n                event_id,\n                settlement_event_id,\n                refund_timelock,\n                funding_fee,\n                rate,\n                identity,\n                identity_counterparty,\n                maker_address,\n                taker_address,\n                maker_lock_amount,\n                taker_lock_amount,\n                publish_sk,\n                publish_pk_counterparty,\n                revocation_secret,\n                revocation_pk_counterparty,\n                lock_tx,\n                lock_tx_descriptor,\n                commit_tx,\n                commit_adaptor_signature,\n                commit_descriptor,\n                refund_tx,\n                refund_signature,\n                complete_fee,\n                complete_fee_flow\n            ) values (\n            (select id from cfds where cfds.order_id = $1),\n            $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25\n            )\n        "
+  },
   "a8124175098e096f61da0874f7cd9f1ebfadde95fd2fc2cc478982be04d1e150": {
     "describe": {
       "columns": [],
@@ -570,207 +752,25 @@
     },
     "query": "\n            UPDATE time_to_first_position\n            SET first_position_timestamp = $2\n            WHERE taker_id = $1 and first_position_timestamp is NULL\n            "
   },
-  "aedd751cc7dcf48f77e8b00fba501ca65e0020dac15e6ba985bd61166c137531": {
-    "describe": {
-      "columns": [
-        {
-          "name": "commit_txid!: models::Txid",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "txid: models::Txid",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "vout: models::Vout",
-          "ordinal": 2,
-          "type_info": "Int64"
-        },
-        {
-          "name": "payout: models::Payout",
-          "ordinal": 3,
-          "type_info": "Int64"
-        }
-      ],
-      "nullable": [
-        true,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n        SELECT\n            closed_commit_txs.txid as \"commit_txid!: models::Txid\",\n            closed_refund_txs.txid as \"txid: models::Txid\",\n            closed_refund_txs.vout as \"vout: models::Vout\",\n            closed_refund_txs.payout as \"payout: models::Payout\"\n        FROM\n            closed_refund_txs\n        JOIN\n            closed_commit_txs on closed_commit_txs.cfd_id = closed_refund_txs.cfd_id\n        JOIN\n            closed_cfds on closed_cfds.id = closed_refund_txs.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        "
-  },
-  "bfccb1d1578875f599f2553fc4902b4344edecf08ea954dd6810e4a9c53e76af": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id: models::OrderId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "position: models::Position",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "initial_price: models::Price",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "taker_leverage: models::Leverage",
-          "ordinal": 3,
-          "type_info": "Int64"
-        },
-        {
-          "name": "n_contracts: models::Contracts",
-          "ordinal": 4,
-          "type_info": "Int64"
-        },
-        {
-          "name": "counterparty_network_identity: models::Identity",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "counterparty_peer_id: models::PeerId",
-          "ordinal": 6,
-          "type_info": "Text"
-        },
-        {
-          "name": "role: models::Role",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "fees: models::Fees",
-          "ordinal": 8,
-          "type_info": "Int64"
-        },
-        {
-          "name": "kind: models::FailedKind",
-          "ordinal": 9,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n            SELECT\n                uuid as \"id: models::OrderId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                taker_leverage as \"taker_leverage: models::Leverage\",\n                n_contracts as \"n_contracts: models::Contracts\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                fees as \"fees: models::Fees\",\n                kind as \"kind: models::FailedKind\"\n            FROM\n                failed_cfds\n            WHERE\n                failed_cfds.uuid = $1\n            "
-  },
-  "cd5327482f9f36bba240a2c75dcf05fa2747615843d916debd2ec993d098b0c1": {
-    "describe": {
-      "columns": [
-        {
-          "name": "uuid: models::OrderId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "position: models::Position",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "initial_price: models::Price",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "taker_leverage: models::Leverage",
-          "ordinal": 3,
-          "type_info": "Int64"
-        },
-        {
-          "name": "n_contracts: models::Contracts",
-          "ordinal": 4,
-          "type_info": "Int64"
-        },
-        {
-          "name": "counterparty_network_identity: models::Identity",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "counterparty_peer_id: models::PeerId",
-          "ordinal": 6,
-          "type_info": "Text"
-        },
-        {
-          "name": "role: models::Role",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "fees: models::Fees",
-          "ordinal": 8,
-          "type_info": "Int64"
-        },
-        {
-          "name": "expiry_timestamp",
-          "ordinal": 9,
-          "type_info": "Int64"
-        },
-        {
-          "name": "lock_txid: models::Txid",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "lock_dlc_vout: models::Vout",
-          "ordinal": 11,
-          "type_info": "Int64"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n            SELECT\n                uuid as \"uuid: models::OrderId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                taker_leverage as \"taker_leverage: models::Leverage\",\n                n_contracts as \"n_contracts: models::Contracts\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                fees as \"fees: models::Fees\",\n                expiry_timestamp,\n                lock_txid as \"lock_txid: models::Txid\",\n                lock_dlc_vout as \"lock_dlc_vout: models::Vout\"\n            FROM\n                closed_cfds\n            WHERE\n                closed_cfds.uuid = $1\n            "
-  },
-  "cd61f78c82124bdc7f5b97b7ff86b4608708463c25aca9b4de156ed0d837d535": {
+  "c73ad5e6953e1a587951b213cf07d4a98e08a25d774b693228c18113a832d72e": {
     "describe": {
       "columns": [],
       "nullable": [],
       "parameters": {
-        "Right": 10
+        "Right": 3
       }
     },
-    "query": "\n        INSERT INTO failed_cfds\n        (\n            uuid,\n            position,\n            initial_price,\n            taker_leverage,\n            n_contracts,\n            counterparty_network_identity,\n            counterparty_peer_id,\n            role,\n            fees,\n            kind\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)\n        "
+    "query": "\n            INSERT INTO event_log (\n                cfd_id,\n                name,\n                created_at\n            )\n            VALUES\n            (\n                (SELECT id FROM closed_cfds WHERE closed_cfds.order_id = $1),\n                $2, $3\n            )\n            "
+  },
+  "d2574386cb16c2ee01fded3c8d025e46a034efa3d5878e03879dc911bf61b749": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "\n        DELETE FROM\n            cfds\n        WHERE\n            cfds.order_id = $1\n        "
   },
   "d87c695f2f1f67e9acbc2ed4dac9a083738e82c52e419f5f025f8c4e327b4858": {
     "describe": {
@@ -782,31 +782,73 @@
     },
     "query": "\n            INSERT OR IGNORE INTO time_to_first_position\n            (\n                taker_id,\n                first_seen_timestamp\n            )\n            VALUES ($1, $2)\n            "
   },
-  "dff18431c5abb3a65efde6fda9e48658f4533c9726bbc993f4b99e0d1924dac5": {
+  "df128e7111bba8e0bdefc5b921da4cba171a0426ed121f30c1ec6b1084017226": {
     "describe": {
       "columns": [
         {
-          "name": "txid: models::Txid",
+          "name": "order_id: models::OrderId",
           "ordinal": 0,
           "type_info": "Text"
         },
         {
-          "name": "vout: models::Vout",
+          "name": "offer_id: models::OfferId",
           "ordinal": 1,
-          "type_info": "Int64"
+          "type_info": "Text"
         },
         {
-          "name": "payout: models::Payout",
+          "name": "position: models::Position",
           "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price: models::Price",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "taker_leverage: models::Leverage",
+          "ordinal": 4,
           "type_info": "Int64"
         },
         {
-          "name": "price: models::Price",
-          "ordinal": 3,
+          "name": "n_contracts: models::Contracts",
+          "ordinal": 5,
+          "type_info": "Int64"
+        },
+        {
+          "name": "counterparty_network_identity: models::Identity",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "counterparty_peer_id: models::PeerId",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "role: models::Role",
+          "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "fees: models::Fees",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "kind: models::FailedKind",
+          "ordinal": 10,
           "type_info": "Text"
         }
       ],
       "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
         false,
         false,
         false,
@@ -816,7 +858,17 @@
         "Right": 1
       }
     },
-    "query": "\n        SELECT\n            collaborative_settlement_txs.txid as \"txid: models::Txid\",\n            collaborative_settlement_txs.vout as \"vout: models::Vout\",\n            collaborative_settlement_txs.payout as \"payout: models::Payout\",\n            collaborative_settlement_txs.price as \"price: models::Price\"\n        FROM\n            collaborative_settlement_txs\n        JOIN\n            closed_cfds on closed_cfds.id = collaborative_settlement_txs.cfd_id\n        WHERE\n            closed_cfds.uuid = $1\n        "
+    "query": "\n            SELECT\n                order_id as \"order_id: models::OrderId\",\n                offer_id as \"offer_id: models::OfferId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                taker_leverage as \"taker_leverage: models::Leverage\",\n                n_contracts as \"n_contracts: models::Contracts\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                fees as \"fees: models::Fees\",\n                kind as \"kind: models::FailedKind\"\n            FROM\n                failed_cfds\n            WHERE\n                failed_cfds.order_id = $1\n            "
+  },
+  "e6fc0695967aae232e12dd135f89e021ccd46a79ab4d99265992ce8eddcc0d89": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 10
+      }
+    },
+    "query": "\n                insert into revoked_commit_transactions (\n                    cfd_id,\n                    encsig_ours,\n                    publication_pk_theirs,\n                    revocation_sk_theirs,\n                    script_pubkey,\n                    txid,\n                    settlement_event_id,\n                    complete_fee,\n                    complete_fee_flow,\n                    revocation_sk_ours\n                ) values ( (select id from cfds where cfds.order_id = $1), $2, $3, $4, $5, $6, $7, $8, $9, $10 )\n            "
   },
   "e95e6341d3b2d1bff0f6ea66b8cf2f939fef744d658fec70e4e2ffa8b365bd25": {
     "describe": {
@@ -1028,56 +1080,22 @@
     },
     "query": "\n            SELECT\n                settlement_event_id as \"settlement_event_id: models::BitMexPriceEventId\",\n                refund_timelock as \"refund_timelock: i64\",\n                funding_fee as \"funding_fee: i64\",\n                rate as \"rate: models::FundingRate\",\n                identity as \"identity: models::SecretKey\",\n                identity_counterparty as \"identity_counterparty: models::PublicKey\",\n                maker_address,\n                taker_address,\n                maker_lock_amount as \"maker_lock_amount: i64\",\n                taker_lock_amount as \"taker_lock_amount: i64\",\n                publish_sk as \"publish_sk: models::SecretKey\",\n                publish_pk_counterparty as \"publish_pk_counterparty: models::PublicKey\",\n                revocation_secret as \"revocation_secret: models::SecretKey\",\n                revocation_pk_counterparty as \"revocation_pk_counterparty: models::PublicKey\",\n                lock_tx as \"lock_tx: models::Transaction\",\n                lock_tx_descriptor,\n                commit_tx as \"commit_tx: models::Transaction\",\n                commit_adaptor_signature as \"commit_adaptor_signature: models::AdaptorSignature\",\n                commit_descriptor,\n                refund_tx as \"refund_tx: models::Transaction\",\n                refund_signature,\n                complete_fee as \"complete_fee: i64\",\n                complete_fee_flow as \"complete_fee_flow: models::FeeFlow\"\n            FROM\n                rollover_completed_event_data\n            WHERE\n                cfd_id = $1 and\n                event_id = $2\n            "
   },
-  "f72ab7ae71904c030803d1c014a94370192e3d1182827951592dd6bb3d5a6072": {
+  "fcb2b85f7bce805fb124368494bbd1038c01334c6087ced685ef02b4539bfc29": {
     "describe": {
       "columns": [
         {
-          "name": "cfd_row_id",
+          "name": "order_id: models::OrderId",
           "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "event_row_id",
-          "ordinal": 1,
-          "type_info": "Int64"
-        },
-        {
-          "name": "name",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "data",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "created_at: models::Timestamp",
-          "ordinal": 4,
           "type_info": "Text"
         }
       ],
       "nullable": [
-        true,
-        false,
-        false,
-        false,
         false
       ],
       "parameters": {
-        "Right": 2
+        "Right": 0
       }
     },
-    "query": "\n\n        select\n            c.id as cfd_row_id,\n            events.id as event_row_id,\n            events.name,\n            events.data,\n            events.created_at as \"created_at: models::Timestamp\"\n        from\n            events\n        join\n            cfds c on c.id = events.cfd_id\n        where\n            uuid = $1\n        order by\n            events.id\n        limit $2,-1\n            "
-  },
-  "fc7e8992943cd5c64d307272eb1951e4c7c645308b20245d5f2818aaaf3b265b": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n        DELETE FROM\n            events\n        WHERE events.cfd_id IN\n            (SELECT id FROM cfds WHERE cfds.uuid = $1)\n        "
+    "query": "\n            SELECT\n                order_id as \"order_id: models::OrderId\"\n            FROM\n                cfds\n            "
   }
 }

--- a/sqlite-db/src/impls.rs
+++ b/sqlite-db/src/impls.rs
@@ -7,6 +7,7 @@ impl crate::CfdAggregate for model::Cfd {
         _: Self::CtorArgs,
         crate::Cfd {
             id,
+            offer_id,
             position,
             initial_price,
             taker_leverage: leverage,
@@ -22,6 +23,7 @@ impl crate::CfdAggregate for model::Cfd {
     ) -> Self {
         model::Cfd::new(
             id,
+            offer_id,
             position,
             initial_price,
             leverage,

--- a/sqlite-db/src/models.rs
+++ b/sqlite-db/src/models.rs
@@ -22,6 +22,8 @@ use std::str::FromStr;
 use time::OffsetDateTime;
 use time::PrimitiveDateTime;
 
+pub type OfferId = OrderId;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, sqlx::Type)]
 #[sqlx(transparent)]
 pub struct OrderId(Hyphenated);
@@ -40,10 +42,10 @@ impl<'de> Deserialize<'de> for OrderId {
     where
         D: serde::Deserializer<'de>,
     {
-        let uuid = String::deserialize(deserializer)?;
-        let uuid = uuid.parse::<Uuid>().map_err(D::Error::custom)?;
+        let order_id = String::deserialize(deserializer)?;
+        let order_id = order_id.parse::<Uuid>().map_err(D::Error::custom)?;
 
-        Ok(Self(uuid.hyphenated()))
+        Ok(Self(order_id.hyphenated()))
     }
 }
 

--- a/sqlite-db/src/rollover/delete.rs
+++ b/sqlite-db/src/rollover/delete.rs
@@ -6,37 +6,37 @@ use sqlx::Transaction;
 
 pub(crate) async fn delete(
     inner_transaction: &mut Transaction<'_, Sqlite>,
-    offer_id: OrderId,
+    order_id: OrderId,
 ) -> Result<()> {
     sqlx::query!(
         r#"
-            delete from rollover_completed_event_data where cfd_id = (select id from cfds where cfds.uuid = $1)
+            delete from rollover_completed_event_data where cfd_id = (select id from cfds where cfds.order_id = $1)
         "#,
-        offer_id
+        order_id
     )
         .execute(&mut *inner_transaction)
         .await
-        .with_context(|| format!("Failed to delete from rollover_completed_event_data for {offer_id}"))?;
+        .with_context(|| format!("Failed to delete from rollover_completed_event_data for {order_id}"))?;
 
     sqlx::query!(
         r#"
-            delete from revoked_commit_transactions where cfd_id = (select id from cfds where cfds.uuid = $1)
+            delete from revoked_commit_transactions where cfd_id = (select id from cfds where cfds.order_id = $1)
         "#,
-        offer_id
+        order_id
     )
         .execute(&mut *inner_transaction)
         .await
-        .with_context(|| format!("Failed to delete from revoked_commit_transactions for {offer_id}"))?;
+        .with_context(|| format!("Failed to delete from revoked_commit_transactions for {order_id}"))?;
 
     sqlx::query!(
         r#"
-            delete from open_cets where cfd_id = (select id from cfds where cfds.uuid = $1)
+            delete from open_cets where cfd_id = (select id from cfds where cfds.order_id = $1)
         "#,
-        offer_id
+        order_id
     )
     .execute(&mut *inner_transaction)
     .await
-    .with_context(|| format!("Failed to delete from open_cets for {offer_id}"))?;
+    .with_context(|| format!("Failed to delete from open_cets for {order_id}"))?;
 
     Ok(())
 }

--- a/sqlite-db/src/rollover/insert.rs
+++ b/sqlite-db/src/rollover/insert.rs
@@ -81,7 +81,7 @@ async fn insert_rollover_completed_event_data(
     dlc: &Dlc,
     funding_fee: FundingFee,
     complete_fee: Option<CompleteFee>,
-    offer_id: models::OrderId,
+    order_id: models::OrderId,
 ) -> Result<()> {
     let (lock_tx, lock_tx_descriptor) = dlc.lock.clone();
     let (commit_tx, commit_adaptor_signature, commit_descriptor) = dlc.commit.clone();
@@ -146,11 +146,11 @@ async fn insert_rollover_completed_event_data(
                 complete_fee,
                 complete_fee_flow
             ) values (
-            (select id from cfds where cfds.uuid = $1),
+            (select id from cfds where cfds.order_id = $1),
             $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25
             )
         "#,
-        offer_id,
+        order_id,
         event_id,
         settlement_event_id,
         dlc.refund_timelock,
@@ -187,7 +187,7 @@ async fn insert_rollover_completed_event_data(
 
 async fn insert_revoked_commit_transaction(
     inner_transaction: &mut Transaction<'_, Sqlite>,
-    offer_id: models::OrderId,
+    order_id: models::OrderId,
     revoked: RevokedCommit,
 ) -> Result<()> {
     let revoked_tx_script_pubkey = revoked.script_pubkey.to_hex();
@@ -215,9 +215,9 @@ async fn insert_revoked_commit_transaction(
                     complete_fee,
                     complete_fee_flow,
                     revocation_sk_ours
-                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6, $7, $8, $9, $10 )
+                ) values ( (select id from cfds where cfds.order_id = $1), $2, $3, $4, $5, $6, $7, $8, $9, $10 )
             "#,
-        offer_id,
+        order_id,
         encsig_ours,
         publication_pk_theirs,
         revocation_sk_theirs,
@@ -240,7 +240,7 @@ async fn insert_revoked_commit_transaction(
 async fn insert_cet(
     db_transaction: &mut Transaction<'_, Sqlite>,
     event_id: BitMexPriceEventId,
-    offer_id: models::OrderId,
+    order_id: models::OrderId,
     cet: Cet,
 ) -> Result<()> {
     let maker_amount = cet.maker_amount.as_sat() as i64;
@@ -263,9 +263,9 @@ async fn insert_cet(
                     range_start,
                     range_end,
                     txid
-                ) values ( (select id from cfds where cfds.uuid = $1), $2, $3, $4, $5, $6, $7, $8, $9 )
+                ) values ( (select id from cfds where cfds.order_id = $1), $2, $3, $4, $5, $6, $7, $8, $9 )
             "#,
-        offer_id,
+        order_id,
         event_id,
         adaptor_sig,
         maker_amount,

--- a/sqlite-db/src/rollover/mod.rs
+++ b/sqlite-db/src/rollover/mod.rs
@@ -20,6 +20,7 @@ mod tests {
     use model::EventKind;
     use model::FundingRate;
     use model::Leverage;
+    use model::OfferId;
     use model::OpeningFee;
     use model::OrderId;
     use model::Position;
@@ -39,6 +40,7 @@ mod tests {
     pub fn dummy_cfd() -> Cfd {
         Cfd::new(
             OrderId::default(),
+            OfferId::default(),
             Position::Long,
             Price::new(dec!(60_000)).unwrap(),
             Leverage::TWO,
@@ -147,7 +149,7 @@ mod tests {
 
         let order_id = models::OrderId::from(cfd.id());
 
-        let cfd_row_id = sqlx::query!(r#"select id from cfds where uuid = $1"#, order_id)
+        let cfd_row_id = sqlx::query!(r#"select id from cfds where order_id = $1"#, order_id)
             .fetch_one(&mut connection)
             .await?
             .id
@@ -214,9 +216,9 @@ mod tests {
             .await
             .unwrap();
 
-        let offer_id = models::OrderId::from(cfd.id());
+        let order_id = models::OrderId::from(cfd.id());
 
-        let cfd_row_id = sqlx::query!(r#"select id from cfds where uuid = $1"#, offer_id)
+        let cfd_row_id = sqlx::query!(r#"select id from cfds where order_id = $1"#, order_id)
             .fetch_one(&mut connection)
             .await?
             .id

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -338,7 +338,7 @@ async fn main() -> Result<()> {
         N_PAYOUTS,
         Duration::from_secs(10),
         projection_actor.clone(),
-        Identity::new(maker_id),
+        maker_identity,
         maker_multiaddr,
         environment,
     )?;

--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -158,7 +158,7 @@ pub async fn post_order_request(
     _auth: Authenticated,
 ) -> Result<(), HttpApiProblem> {
     taker
-        .take_offer(
+        .place_order(
             cfd_order_request.order_id,
             cfd_order_request.quantity,
             cfd_order_request.leverage,

--- a/xtra-libp2p-offer/src/lib.rs
+++ b/xtra-libp2p-offer/src/lib.rs
@@ -15,8 +15,8 @@ mod tests {
     use model::FundingRate;
     use model::Leverage;
     use model::MakerOffers;
+    use model::Offer;
     use model::OpeningFee;
-    use model::Order;
     use model::Origin;
     use model::Position;
     use model::Price;
@@ -199,16 +199,16 @@ mod tests {
 
     pub fn dummy_maker_offers() -> Option<MakerOffers> {
         Some(MakerOffers {
-            long: Some(dummy_order(Position::Long)),
-            short: Some(dummy_order(Position::Short)),
+            long: Some(dummy_offer(Position::Long)),
+            short: Some(dummy_offer(Position::Short)),
             tx_fee_rate: TxFeeRate::default(),
             funding_rate_long: FundingRate::new(Decimal::ONE).unwrap(),
             funding_rate_short: FundingRate::new(Decimal::NEGATIVE_ONE).unwrap(),
         })
     }
 
-    fn dummy_order(position: Position) -> Order {
-        Order::new(
+    fn dummy_offer(position: Position) -> Offer {
+        Offer::new(
             position,
             Price::new(dec!(1000)).unwrap(),
             Usd::new(dec!(100)),

--- a/xtra-libp2p-offer/src/maker.rs
+++ b/xtra-libp2p-offer/src/maker.rs
@@ -66,6 +66,10 @@ impl Actor {
                 .await
         }
     }
+
+    async fn handle(&mut self, _: GetLatestOffers) -> Option<MakerOffers> {
+        self.latest_offers.clone()
+    }
 }
 
 #[xtra_productivity]
@@ -88,13 +92,16 @@ impl Actor {
 
 /// Instruct the `offer::maker::Actor` to broadcast to all
 /// connected peers an update to the current offers.
-pub struct NewOffers(Option<MakerOffers>);
+pub struct NewOffers(pub Option<MakerOffers>);
 
 impl NewOffers {
     pub fn new(offers: Option<MakerOffers>) -> Self {
         Self(offers)
     }
 }
+
+#[derive(Clone, Copy)]
+pub struct GetLatestOffers;
 
 #[async_trait]
 impl xtra::Actor for Actor {


### PR DESCRIPTION
Fix https://github.com/itchysats/itchysats/issues/1770.

The new design follows the proposal in #1770. This means that
the taker now generates an `OrderId` when _placing_ the order. We
currently reuse the same type for the offer (legacy) and the taker's
order, which is a bit confusing (but hard to avoid, because our model
wants an `OrderId`). With the new protocol the taker ignores the
`OrderId` associated with the offer, but we have to keep it around for
legacy connections.

One actor test got removed - with libp2p we're not changing the offers after
one was picked; the OrderId is generated on the taker side.

Co-authored-by: Lucas Soriano del Pino <l.soriano.del.pino@gmail.com>