### PR TITLE
Re-structure rollovers test setup for configurability

### DIFF
--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -532,11 +532,21 @@ async fn rollover(
     // Ensure that the event ID of the latest dlc is the event ID used for rollover
     assert_eq!(
         oracle_data.announcement().id,
-        maker_cfd.aggregated.latest_dlc.unwrap().settlement_event_id
+        maker_cfd
+            .aggregated()
+            .latest_dlc()
+            .as_ref()
+            .unwrap()
+            .settlement_event_id
     );
     assert_eq!(
         oracle_data.announcement().id,
-        taker_cfd.aggregated.latest_dlc.unwrap().settlement_event_id
+        taker_cfd
+            .aggregated()
+            .latest_dlc()
+            .as_ref()
+            .unwrap()
+            .settlement_event_id
     );
 }
 

--- a/daemon-tests/tests/happy_path.rs
+++ b/daemon-tests/tests/happy_path.rs
@@ -402,13 +402,41 @@ async fn force_close_open_cfd(maker_position: Position) {
 #[tokio::test]
 async fn rollover_an_open_cfd_maker_going_short() {
     let _guard = init_tracing();
-    rollover_an_open_cfd(Position::Short, 1).await;
+    let (mut maker, mut taker, order_id, fee_structure) =
+        prepare_rollover(Position::Short, OliviaData::example_0()).await;
+
+    // We charge 24 times per rollover because that is the fallback strategy if the timestamp of
+    // the settlement-event is already expired
+    let (expected_maker_fee, expected_taker_fee) = fee_structure.predict_fees(24);
+    rollover(
+        &mut maker,
+        &mut taker,
+        order_id,
+        OliviaData::example_0(),
+        expected_maker_fee,
+        expected_taker_fee,
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn rollover_an_open_cfd_maker_going_long() {
     let _guard = init_tracing();
-    rollover_an_open_cfd(Position::Long, 1).await;
+    let (mut maker, mut taker, order_id, fee_structure) =
+        prepare_rollover(Position::Long, OliviaData::example_0()).await;
+
+    // We charge 24 times per rollover because that is the fallback strategy if the timestamp of
+    // the settlement-event is already expired
+    let (expected_maker_fee, expected_taker_fee) = fee_structure.predict_fees(24);
+    rollover(
+        &mut maker,
+        &mut taker,
+        order_id,
+        OliviaData::example_0(),
+        expected_maker_fee,
+        expected_taker_fee,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -416,11 +444,38 @@ async fn double_rollover_an_open_cfd() {
     // double rollover ensures that both parties properly succeeded and can do another rollover
 
     let _guard = init_tracing();
-    rollover_an_open_cfd(Position::Short, 2).await;
+    let (mut maker, mut taker, order_id, fee_structure) =
+        prepare_rollover(Position::Short, OliviaData::example_0()).await;
+
+    // We charge 24 times per rollover because that is the fallback strategy if the timestamp of
+    // the settlement-event is already expired
+    let (expected_maker_fee, expected_taker_fee) = fee_structure.predict_fees(24);
+    rollover(
+        &mut maker,
+        &mut taker,
+        order_id,
+        OliviaData::example_0(),
+        expected_maker_fee,
+        expected_taker_fee,
+    )
+    .await;
+
+    let (expected_maker_fee, expected_taker_fee) = fee_structure.predict_fees(48);
+    rollover(
+        &mut maker,
+        &mut taker,
+        order_id,
+        OliviaData::example_0(),
+        expected_maker_fee,
+        expected_taker_fee,
+    )
+    .await;
 }
 
-async fn rollover_an_open_cfd(maker_position: Position, nr_rollovers: u8) {
-    let oracle_data = OliviaData::example_0();
+async fn prepare_rollover(
+    maker_position: Position,
+    oracle_data: OliviaData,
+) -> (Maker, Taker, OrderId, FeeStructure) {
     let (mut maker, mut taker, order_id, fee_structure) =
         start_from_open_cfd_state(oracle_data.announcement(), maker_position).await;
 
@@ -429,41 +484,60 @@ async fn rollover_an_open_cfd(maker_position: Position, nr_rollovers: u8) {
         .set_offer_params(dummy_offer_params(maker_position))
         .await;
 
-    let maker_fees_before_rollover = maker.first_cfd().accumulated_fees;
-    let taker_fees_before_rollover = taker.first_cfd().accumulated_fees;
+    let maker_cfd = maker.first_cfd();
+    let taker_cfd = taker.first_cfd();
 
     let (expected_maker_fee, expected_taker_fee) = fee_structure.predict_fees(0);
-    assert_eq!(expected_maker_fee, maker_fees_before_rollover);
-    assert_eq!(expected_taker_fee, taker_fees_before_rollover);
+    assert_eq!(expected_maker_fee, maker_cfd.accumulated_fees);
+    assert_eq!(expected_taker_fee, taker_cfd.accumulated_fees);
 
-    for rollover_nr in 0..nr_rollovers {
-        taker.trigger_rollover(order_id).await;
+    (maker, taker, order_id, fee_structure)
+}
 
-        wait_next_state!(
-            order_id,
-            maker,
-            taker,
-            CfdState::IncomingRolloverProposal,
-            CfdState::OutgoingRolloverProposal
-        );
+async fn rollover(
+    maker: &mut Maker,
+    taker: &mut Taker,
+    order_id: OrderId,
+    oracle_data: OliviaData,
+    expected_fees_after_rollover_maker: SignedAmount,
+    expected_fees_after_rollover_taker: SignedAmount,
+) {
+    taker.trigger_rollover(order_id).await;
 
-        maker.system.accept_rollover(order_id).await.unwrap();
+    wait_next_state!(
+        order_id,
+        maker,
+        taker,
+        CfdState::IncomingRolloverProposal,
+        CfdState::OutgoingRolloverProposal
+    );
 
-        wait_next_state!(order_id, maker, taker, CfdState::RolloverSetup);
-        wait_next_state!(order_id, maker, taker, CfdState::Open);
+    maker.system.accept_rollover(order_id).await.unwrap();
 
-        let maker_fees_after_rollover = maker.first_cfd().accumulated_fees;
-        let taker_fees_after_rollover = taker.first_cfd().accumulated_fees;
+    wait_next_state!(order_id, maker, taker, CfdState::RolloverSetup);
+    wait_next_state!(order_id, maker, taker, CfdState::Open);
 
-        // predict fee after the rollover, i.e. rollover_nr + 1
-        // We charge 24 times per rollover because that is the fallback strategy if the timestamp of
-        // the settlement-event is already expired
-        let (expected_maker_fee, expected_taker_fee) =
-            fee_structure.predict_fees(((rollover_nr as i64) + 1) * 24);
+    let maker_cfd = maker.first_cfd();
+    let taker_cfd = taker.first_cfd();
 
-        assert_eq!(expected_maker_fee, maker_fees_after_rollover);
-        assert_eq!(expected_taker_fee, taker_fees_after_rollover);
-    }
+    assert_eq!(
+        expected_fees_after_rollover_maker,
+        maker_cfd.accumulated_fees
+    );
+    assert_eq!(
+        expected_fees_after_rollover_taker,
+        taker_cfd.accumulated_fees
+    );
+
+    // Ensure that the event ID of the latest dlc is the event ID used for rollover
+    assert_eq!(
+        oracle_data.announcement().id,
+        maker_cfd.aggregated.latest_dlc.unwrap().settlement_event_id
+    );
+    assert_eq!(
+        oracle_data.announcement().id,
+        taker_cfd.aggregated.latest_dlc.unwrap().settlement_event_id
+    );
 }
 
 #[tokio::test]

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -188,7 +188,7 @@ pub struct Cfd {
 
     #[serde(skip)]
     #[derivative(PartialEq = "ignore")]
-    aggregated: Aggregated,
+    pub aggregated: Aggregated,
 
     #[serde(skip)]
     network: Network,
@@ -203,11 +203,11 @@ pub struct Cfd {
 ///
 /// This dual-role motivates the existence of this struct.
 #[derive(Clone, Debug)]
-struct Aggregated {
+pub struct Aggregated {
     fee_account: FeeAccount,
 
     /// If this is present, we have an active DLC.
-    latest_dlc: Option<Dlc>,
+    pub latest_dlc: Option<Dlc>,
     /// If this is present, it should have been published.
     collab_settlement_tx: Option<(Transaction, Script)>,
     /// If this is present, it should have been published.

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -188,7 +188,7 @@ pub struct Cfd {
 
     #[serde(skip)]
     #[derivative(PartialEq = "ignore")]
-    pub aggregated: Aggregated,
+    aggregated: Aggregated,
 
     #[serde(skip)]
     network: Network,
@@ -207,7 +207,7 @@ pub struct Aggregated {
     fee_account: FeeAccount,
 
     /// If this is present, we have an active DLC.
-    pub latest_dlc: Option<Dlc>,
+    latest_dlc: Option<Dlc>,
     /// If this is present, it should have been published.
     collab_settlement_tx: Option<(Transaction, Script)>,
     /// If this is present, it should have been published.
@@ -291,6 +291,11 @@ impl Aggregated {
             };
         };
         self.state
+    }
+
+    // Only used in integration tests
+    pub fn latest_dlc(&self) -> &Option<Dlc> {
+        &self.latest_dlc
     }
 }
 
@@ -715,6 +720,11 @@ impl Cfd {
         let url = TxUrl::new(dlc.commit.0.txid(), network, TxLabel::Commit);
 
         Some(url)
+    }
+
+    // Only used in integration tests
+    pub fn aggregated(&self) -> &Aggregated {
+        &self.aggregated
     }
 
     fn collab_settlement_tx_url(&self, network: Network) -> Option<TxUrl> {


### PR DESCRIPTION
Split into `prepare_rollover` and `rollover`.
`prepare_rollover` prepares `maker`, `taker` and `fee_structure` to be used for the rollover; it prepares the open `cfd` and asserts on the initial fees.
`rollover` performs one rollover and can be parametrized.

--- 

One thing that is a bit unfortunate is that we now need access to the previously `private` `aggregated` in the `projection::Cfd` - but I think this is an acceptable change given that we can write better tests!
Potentially this could be configured with only being public in `cfg(test)` but I did not invest time into this.

---

This is for preparing more elaborate tests for #2272 
I thought it's better to keep the changeset smaller so I opened a separate PR with these improvements against master :)