### PR TITLE
Avoid endlessly re-connecting in case a connection was already estalished

### DIFF
--- a/xtra-libp2p/src/dialer.rs
+++ b/xtra-libp2p/src/dialer.rs
@@ -96,10 +96,10 @@ impl Actor {
     }
 
     async fn dial(&self) -> Result<()> {
-        anyhow::ensure!(
-            !self.is_connection_established().await?,
-            "Connection should not be active when dialing"
-        );
+        if self.is_connection_established().await? {
+            tracing::info!("Connection is already established, no need to connect");
+            return Ok(());
+        }
 
         if let Err(e) = self.connect().await {
             tracing::warn!("Failed to request connection from endpoint: {e:#}");


### PR DESCRIPTION
This can happen in scenarios where the connection is still being established, but the dialer ran into a timeout already.
The dialer then restarts, but when asking the endpoint for connection information it is connected at that point - it then stops and restarts endlessly (until we lose connection which could be never).

resolves https://github.com/itchysats/itchysats/issues/2316