### PR TITLE
Change log level

### DIFF
--- a/xtra-libp2p-ping/src/ping.rs
+++ b/xtra-libp2p-ping/src/ping.rs
@@ -128,7 +128,7 @@ impl Actor {
             };
 
             let err_handler = move |e| async move {
-                tracing::debug!(%peer, "Outbound ping protocol failed: {e:#}")
+                tracing::warn!(%peer, "Outbound ping protocol failed: {e:#}")
             };
 
             if let Err(e) = self


### PR DESCRIPTION
Debugs are normally not shown, meaning we would not see this log level. Hence, I propose to change it to warn.
