### PR TITLE
Workaround to prevent overwriting RUST_LOG

### DIFF
--- a/shared-bin/src/logger.rs
+++ b/shared-bin/src/logger.rs
@@ -56,6 +56,7 @@ pub fn init(level: LevelFilter, json_format: bool) -> Result<()> {
 
 fn base_directives(env: EnvFilter) -> Result<EnvFilter> {
     let filter = env
+        .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
         .add_directive("sqlx=warn".parse()?) // sqlx logs all queries on INFO
         .add_directive("hyper=warn".parse()?)
         .add_directive("rustls=warn".parse()?)

--- a/shared-bin/src/logger.rs
+++ b/shared-bin/src/logger.rs
@@ -6,6 +6,9 @@ use tracing_subscriber::EnvFilter;
 
 pub use tracing_subscriber::filter::LevelFilter;
 
+const RUST_LOG_ENV: &str = "RUST_LOG";
+
+#[allow(clippy::print_stdout)] // because the logger is only initialized at the end of this function but we want to print a warning
 pub fn init(level: LevelFilter, json_format: bool) -> Result<()> {
     if level == LevelFilter::OFF {
         return Ok(());
@@ -13,28 +16,20 @@ pub fn init(level: LevelFilter, json_format: bool) -> Result<()> {
 
     let is_terminal = atty::is(atty::Stream::Stderr);
 
-    let filter = EnvFilter::from_default_env()
-        .add_directive(format!("{level}").parse()?)
-        .add_directive("sqlx=warn".parse()?) // sqlx logs all queries on INFO
-        .add_directive("hyper=warn".parse()?)
-        .add_directive("rustls=warn".parse()?)
-        .add_directive("reqwest=warn".parse()?)
-        .add_directive("tungstenite=warn".parse()?)
-        .add_directive("tokio_tungstenite=warn".parse()?)
-        .add_directive("electrum_client=warn".parse()?)
-        .add_directive("want=warn".parse()?)
-        .add_directive("mio=warn".parse()?)
-        .add_directive("tokio_util=warn".parse()?)
-        .add_directive("yamux=warn".parse()?)
-        .add_directive("multistream_select=warn".parse()?)
-        .add_directive("libp2p_noise=warn".parse()?)
-        .add_directive("xtra_libp2p_offer=debug".parse()?)
-        .add_directive("xtras=info".parse()?)
-        .add_directive("_=off".parse()?) // rocket logs headers on INFO and uses `_` as the log target for it?
-        .add_directive("rocket=off".parse()?) // disable rocket logs: we have our own
-        .add_directive("xtra=warn".parse()?)
-        .add_directive("sled=warn".parse()?) // downgrade sled log level: it is spamming too much on DEBUG
-        .add_directive("xtra_libp2p=info".parse()?);
+    let filter = match std::env::var_os(RUST_LOG_ENV).map(|s| s.into_string()) {
+        Some(Ok(env)) => {
+            let mut filter = base_directives(EnvFilter::new(""))?;
+            for directive in env.split(',') {
+                match directive.parse() {
+                    Ok(d) => filter = filter.add_directive(d),
+                    Err(e) => println!("WARN ignoring log directive: `{directive}`: {e}"),
+                };
+            }
+            filter
+        }
+        _ => base_directives(EnvFilter::from_env(RUST_LOG_ENV))?,
+    };
+    let filter = filter.add_directive(format!("{level}").parse()?);
 
     let builder = tracing_subscriber::fmt()
         .with_env_filter(filter)
@@ -57,4 +52,29 @@ pub fn init(level: LevelFilter, json_format: bool) -> Result<()> {
     tracing::info!("Initialized logger");
 
     Ok(())
+}
+
+fn base_directives(env: EnvFilter) -> Result<EnvFilter> {
+    let filter = env
+        .add_directive("sqlx=warn".parse()?) // sqlx logs all queries on INFO
+        .add_directive("hyper=warn".parse()?)
+        .add_directive("rustls=warn".parse()?)
+        .add_directive("reqwest=warn".parse()?)
+        .add_directive("tungstenite=warn".parse()?)
+        .add_directive("tokio_tungstenite=warn".parse()?)
+        .add_directive("electrum_client=warn".parse()?)
+        .add_directive("want=warn".parse()?)
+        .add_directive("mio=warn".parse()?)
+        .add_directive("tokio_util=warn".parse()?)
+        .add_directive("yamux=warn".parse()?)
+        .add_directive("multistream_select=warn".parse()?)
+        .add_directive("libp2p_noise=warn".parse()?)
+        .add_directive("xtra_libp2p_offer=debug".parse()?)
+        .add_directive("xtras=info".parse()?)
+        .add_directive("_=off".parse()?) // rocket logs headers on INFO and uses `_` as the log target for it?
+        .add_directive("rocket=off".parse()?) // disable rocket logs: we have our own
+        .add_directive("xtra=warn".parse()?)
+        .add_directive("sled=warn".parse()?) // downgrade sled log level: it is spamming too much on DEBUG
+        .add_directive("xtra_libp2p=info".parse()?);
+    Ok(filter)
 }


### PR DESCRIPTION
So far we overwrote RUST_LOG log settings using . This is annoying because hardcoded log levels can't be changed later on. With this workaround we can have smart defaults but allow the user to overwrite the log level using RUST_LOG

// edit// unfortunately tracing does not allow us to do this differently. There is an open ticket which inspired this solution: https://github.com/tokio-rs/tracing/issues/1466