### PR TITLE
Use macos 12 in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -100,7 +100,7 @@ jobs:
   smoke_test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -112,13 +112,13 @@ jobs:
         shell: bash
         run: |
           cargo dev-maker &
-          sleep 10s # Wait for binaries to start
+          sleep 10 # Wait for binaries to start
           curl --fail http://localhost:8001/api/alive
       - name: Smoke testing taker for ${{ matrix.os }} binary
         shell: bash
         run: |
           cargo dev-taker &
-          sleep 10s # Wait for binaries to start
+          sleep 10 # Wait for binaries to start
           curl --fail http://localhost:8000/api/alive
 
   daemons_arm_build:

--- a/bors.toml
+++ b/bors.toml
@@ -22,8 +22,8 @@ status = [
   "frontend (maker)",
   "frontend (taker)",
   "test (ubuntu-latest)",
-  "test (macos-latest)",
+  "test (macos-12)",
   "smoke_test (ubuntu-latest)",
-  "smoke_test (macos-latest)",
+  "smoke_test (macos-12)",
   "daemons_arm_build",
 ]


### PR DESCRIPTION
For some reason, macos-latest still points to Big Sur (11).

Check whether the CI situation (a lot of failures on macos jobs) will improve
with the latest macos version.