### PR TITLE
Add metric for unique takers

### DIFF
--- a/daemon/src/position_metrics.rs
+++ b/daemon/src/position_metrics.rs
@@ -353,7 +353,7 @@ mod metrics {
             .unwrap()
         });
 
-    static POSITION_AMOUNT_GAUGE: conquer_once::Lazy<prometheus::IntGaugeVec> =
+    static POSITION_NUMBER_GAUGE: conquer_once::Lazy<prometheus::IntGaugeVec> =
         conquer_once::Lazy::new(|| {
             prometheus::register_int_gauge_vec!(
                 "positions_number_total",
@@ -427,7 +427,7 @@ mod metrics {
                     .to_f64()
                     .unwrap_or_default(),
             );
-        POSITION_AMOUNT_GAUGE
+        POSITION_NUMBER_GAUGE
             .with(&HashMap::from([
                 (POSITION_LABEL, position_label),
                 (STATUS_LABEL, status),


### PR DESCRIPTION
I'd like to push this intro production asap so that we start collecting metrics. 

This metric shows us the unique takers with open/closed/.. positions.
We need the additional `all` position because some takers might have long AND short positions. If this is the case we would count them twice, i.e. `long` + `short` != `all`

It looks like this:

```
# HELP counterparty_number_total Total number of counterparties we had a position with on ItchySats.
# TYPE counterparty_number_total gauge
counterparty_number_total{position="all",status="closed"} 4
counterparty_number_total{position="all",status="failed"} 4
counterparty_number_total{position="all",status="new"} 6
counterparty_number_total{position="all",status="open"} 0
counterparty_number_total{position="all",status="refunded"} 3
counterparty_number_total{position="all",status="rejected"} 0
counterparty_number_total{position="long",status="closed"} 2
counterparty_number_total{position="long",status="failed"} 2
counterparty_number_total{position="long",status="new"} 2
counterparty_number_total{position="long",status="open"} 0
counterparty_number_total{position="long",status="refunded"} 2
counterparty_number_total{position="long",status="rejected"} 0
counterparty_number_total{position="short",status="closed"} 2
counterparty_number_total{position="short",status="failed"} 2
counterparty_number_total{position="short",status="new"} 3
counterparty_number_total{position="short",status="open"} 0
counterparty_number_total{position="short",status="refunded"} 2
counterparty_number_total{position="short",status="rejected"} 0
# HELP positions_number_total Total number of positions on ItchySats.
```