### PR TITLE
Use patched electrum-client to fix a bug with high CPU load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,8 +1010,7 @@ dependencies = [
 [[package]]
 name = "electrum-client"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef9b40020912229e947b45d91f9ff96b10d543e0eddd75ff41b9eda24d9c051"
+source = "git+https://github.com/comit-network/rust-electrum-client/?branch=do-not-ignore-empty-lines#2f99465316fb49d5bd4143d563b81deaae4745a2"
 dependencies = [
  "bitcoin",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ xtra = { git = "https://github.com/Restioson/xtra", rev = "afff02dd0fc8b92ae264d
 maia = { git = "https://github.com/comit-network/maia", rev = "fc6b78b98407b10b55f8cfd152062ad77f98cd9f" } # Unreleased
 maia-core = { git = "https://github.com/comit-network/maia", tag = "0.1.1", package = "maia-core" } # Pinned to support maia 0.1 and 0.2
 xtra_productivity = { git = "https://github.com/comit-network/xtra-productivity", rev = "bebe45425ae44980186df7b96b41f70cad58a4bb" } # Unreleased
+electrum-client = { git = "https://github.com/comit-network/rust-electrum-client/", branch = "do-not-ignore-empty-lines" }
 
 [profile.dev.package.sqlx-macros]
 opt-level = 3


### PR DESCRIPTION
BDK 0.19 release includes the change that ignores empty lines from electrum,
which was known to cause issues on testnet. Revert this in order to reduce CPU
load until BDK merges a fix.