### PR TITLE
Add db-failsafe mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   removed in favour of the new `instrumentation` feature combined with
   [Grafana Tempo's span metrics](https://grafana.com/docs/tempo/latest/server_side_metrics/span_metrics/).
 
+### Added
+
+- Add new argument to the maker: `ignore-migration-errors`. If enabled, the maker will start if an error occurred when opening the database, if not, it will fail fast. This can come handy to prevent accidentally creating a new empty database in case database migration was unsuccessful.
+
 ## [0.4.21] - 2022-06-27
 
 ### Added

--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -38,6 +38,10 @@ pub struct Opts {
     #[clap(short, long)]
     pub json: bool,
 
+    /// If enabled the application will not fail if an error occurred during db migration.
+    #[clap(short, long)]
+    pub ignore_migration_errors: bool,
+
     /// If provided will be used for internal wallet instead of a random key. The keys will be
     /// derived according to Bip84
     #[clap(short, long)]

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -114,7 +114,8 @@ async fn main() -> Result<()> {
     let p2p_port = opts.p2p_port;
     let p2p_socket = format!("0.0.0.0:{p2p_port}").parse::<SocketAddr>().unwrap();
 
-    let db = sqlite_db::connect(data_dir.join("maker.sqlite")).await?;
+    let db =
+        sqlite_db::connect(data_dir.join("maker.sqlite"), opts.ignore_migration_errors).await?;
 
     // Create actors
 

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -335,7 +335,7 @@ async fn main() -> Result<()> {
         .merge(("port", opts.http_address.port()))
         .merge(("cli_colors", false));
 
-    let db = sqlite_db::connect(data_dir.join("taker.sqlite")).await?;
+    let db = sqlite_db::connect(data_dir.join("taker.sqlite"), true).await?;
 
     // Create actors
 


### PR DESCRIPTION
This will prevent the maker from starting up if the database migration was unsuccessful
