### PR TITLE
Reduce ping interval to 30s

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -80,7 +80,7 @@ pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 pub const RESTART_INTERVAL: Duration = Duration::from_secs(5);
 
 pub const ENDPOINT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(20);
-pub const PING_INTERVAL: Duration = Duration::from_secs(5);
+pub const PING_INTERVAL: Duration = Duration::from_secs(30);
 
 pub const N_PAYOUTS: usize = 200;
 

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -49,7 +49,7 @@ use xtras::supervisor::always_restart_after;
 use xtras::HandlerTimeoutExt;
 
 const ENDPOINT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(20);
-const PING_INTERVAL: Duration = Duration::from_secs(5);
+const PING_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Duration between the restart attempts after a supervised actor has quit with
 /// a failure.


### PR DESCRIPTION
With the endpoint timeout interval set to 20s, initiating ping protocol
unconditionally every 5s can lead to messages in the endpoint piling up in case
endpoint encounters problems.

Note: Ideally, we should not schedule a new ping if the previous one was not
processed yet.

It might be worthwhile to backport this change on top of 0.4.21 release on the maker and release a small patch release hotfix, in hope that this will alleviate the issue with not sending offers.