### PR TITLE
Remove xtra_productivity `message_impl = false` argument

### DIFF
--- a/daemon-tests/src/mocks/monitor.rs
+++ b/daemon-tests/src/mocks/monitor.rs
@@ -31,7 +31,7 @@ impl xtra::Actor for MonitorActor {
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl MonitorActor {
     async fn handle(&mut self, _: monitor::Sync) {}
 

--- a/daemon-tests/src/mocks/oracle.rs
+++ b/daemon-tests/src/mocks/oracle.rs
@@ -32,7 +32,7 @@ impl xtra::Actor for OracleActor {
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl OracleActor {
     async fn handle(
         &mut self,

--- a/daemon-tests/src/mocks/price_feed.rs
+++ b/daemon-tests/src/mocks/price_feed.rs
@@ -26,7 +26,7 @@ impl xtra::Actor for PriceFeedActor {
     }
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl PriceFeedActor {
     async fn handle(
         &mut self,

--- a/daemon-tests/src/mocks/wallet.rs
+++ b/daemon-tests/src/mocks/wallet.rs
@@ -42,7 +42,7 @@ impl xtra::Actor for WalletActor {
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl WalletActor {
     async fn handle(&mut self, msg: wallet::BuildPartyParams) -> Result<PartyParams> {
         self.mock.lock().await.build_party_params(msg)

--- a/daemon/src/collab_settlement/maker.rs
+++ b/daemon/src/collab_settlement/maker.rs
@@ -60,7 +60,7 @@ impl xtra::Actor for Actor {
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl Actor {
     async fn handle(&mut self, msg: NewInboundSubstream, ctx: &mut xtra::Context<Self>) {
         let NewInboundSubstream { peer, stream } = msg;

--- a/daemon/src/online_status.rs
+++ b/daemon/src/online_status.rs
@@ -76,7 +76,7 @@ impl xtra::Actor for Actor {
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl Actor {
     async fn handle_connection_established(&mut self, msg: endpoint::ConnectionEstablished) {
         tracing::debug!(

--- a/daemon/src/rollover/maker.rs
+++ b/daemon/src/rollover/maker.rs
@@ -83,7 +83,7 @@ impl xtra::Actor for Actor {
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl Actor {
     async fn handle(&mut self, msg: NewInboundSubstream, ctx: &mut xtra::Context<Self>) {
         let NewInboundSubstream { peer, stream } = msg;

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -104,7 +104,7 @@ where
     }
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl<O, W> Actor<O, W> {
     async fn handle_current_offers(&mut self, msg: xtra_libp2p_offer::taker::LatestMakerOffers) {
         let takers_perspective_of_maker_offers = msg.0.map(|mut maker_offers| {

--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -539,7 +539,7 @@ impl Actor {
     }
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl Actor {
     async fn handle_msg_from_taker(&mut self, msg: cfd::FromTaker) {
         let msg_str = msg.msg.name();

--- a/maker/src/contract_setup.rs
+++ b/maker/src/contract_setup.rs
@@ -245,7 +245,7 @@ impl Actor {
     }
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl Actor {
     fn handle(&mut self, msg: wire::SetupMsg) {
         if let Err(e) = self.forward_protocol_msg(msg).await {

--- a/xtra-libp2p-offer/src/lib.rs
+++ b/xtra-libp2p-offer/src/lib.rs
@@ -168,7 +168,7 @@ mod tests {
         async fn stopped(self) -> Self::Stop {}
     }
 
-    #[xtra_productivity(message_impl = false)]
+    #[xtra_productivity]
     impl OffersReceiver {
         async fn handle(&mut self, msg: LatestMakerOffers) {
             self.latest_offers = msg.0;

--- a/xtra-libp2p-offer/src/maker.rs
+++ b/xtra-libp2p-offer/src/maker.rs
@@ -75,7 +75,7 @@ impl Actor {
     }
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl Actor {
     async fn handle_connection_established(&mut self, msg: endpoint::ConnectionEstablished) {
         tracing::trace!("Adding newly established connection: {:?}", msg.peer);

--- a/xtra-libp2p-offer/src/taker.rs
+++ b/xtra-libp2p-offer/src/taker.rs
@@ -26,7 +26,7 @@ impl Actor {
     }
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl Actor {
     async fn handle(&mut self, msg: NewInboundSubstream) {
         let NewInboundSubstream { peer, stream } = msg;

--- a/xtra-libp2p-ping/src/ping.rs
+++ b/xtra-libp2p-ping/src/ping.rs
@@ -161,7 +161,7 @@ impl Actor {
     }
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl Actor {
     async fn handle_connection_established(&mut self, msg: endpoint::ConnectionEstablished) {
         tracing::trace!(

--- a/xtra-libp2p-ping/src/pong.rs
+++ b/xtra-libp2p-ping/src/pong.rs
@@ -9,7 +9,7 @@ pub struct Actor {
     tasks: Tasks,
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl Actor {
     async fn handle(&mut self, message: NewInboundSubstream) {
         let NewInboundSubstream { stream, peer } = message;

--- a/xtra-libp2p/examples/hello_world_listener.rs
+++ b/xtra-libp2p/examples/hello_world_listener.rs
@@ -82,7 +82,7 @@ pub struct HelloWorld {
     tasks: Tasks,
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl HelloWorld {
     async fn handle(&mut self, msg: NewInboundSubstream) {
         tracing::info!("New hello world stream from {}", msg.peer);

--- a/xtra-libp2p/src/dialer.rs
+++ b/xtra-libp2p/src/dialer.rs
@@ -130,7 +130,7 @@ impl Actor {
     }
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl Actor {
     async fn handle(&mut self, msg: endpoint::ConnectionDropped, ctx: &mut xtra::Context<Self>) {
         if msg.peer == self.peer_id() {

--- a/xtra-libp2p/src/listener.rs
+++ b/xtra-libp2p/src/listener.rs
@@ -93,7 +93,7 @@ impl Actor {
     }
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl Actor {
     async fn handle(&mut self, msg: endpoint::ListenAddressRemoved, ctx: &mut xtra::Context<Self>) {
         if msg.address == self.listen_address {

--- a/xtra-libp2p/tests/basic.rs
+++ b/xtra-libp2p/tests/basic.rs
@@ -389,7 +389,7 @@ impl Actor for EndpointSubscriberStats {
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl EndpointSubscriberStats {
     async fn handle(&mut self, msg: endpoint::ConnectionEstablished) {
         self.connected_peers.insert(msg.peer);
@@ -430,7 +430,7 @@ struct HelloWorld {
     tasks: Tasks,
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl HelloWorld {
     async fn handle(&mut self, msg: NewInboundSubstream) {
         tracing::info!("New hello world stream from {}", msg.peer);

--- a/xtras/src/supervisor.rs
+++ b/xtras/src/supervisor.rs
@@ -180,7 +180,7 @@ where
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[xtra_productivity(message_impl = false)]
+#[xtra_productivity]
 impl<T, R, S> Actor<T, R>
 where
     T: xtra::Actor<Stop = S>,


### PR DESCRIPTION
We don't add message impls anymore, so there's no need to specify this as
`false`.