### PR TITLE
Use xtra::scoped where possible

### DIFF
--- a/daemon/src/archive_failed_cfds.rs
+++ b/daemon/src/archive_failed_cfds.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use sqlite_db;
 use std::time::Duration;
-use tokio_extras::Tasks;
 use xtra_productivity::xtra_productivity;
 use xtras::SendInterval;
 
@@ -11,15 +10,11 @@ const ARCHIVE_CFDS_INTERVAL: Duration = Duration::from_secs(30 * 60);
 
 pub struct Actor {
     db: sqlite_db::Connection,
-    tasks: Tasks,
 }
 
 impl Actor {
     pub fn new(db: sqlite_db::Connection) -> Self {
-        Self {
-            db,
-            tasks: Tasks::default(),
-        }
+        Self { db }
     }
 }
 
@@ -29,8 +24,10 @@ impl xtra::Actor for Actor {
 
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("we are alive");
-        self.tasks
-            .add(this.send_interval(ARCHIVE_CFDS_INTERVAL, || ArchiveCfds));
+        tokio_extras::spawn(
+            &this.clone(),
+            this.send_interval(ARCHIVE_CFDS_INTERVAL, || ArchiveCfds),
+        );
     }
 
     async fn stopped(self) -> Self::Stop {}

--- a/daemon/src/collab_settlement/maker.rs
+++ b/daemon/src/collab_settlement/maker.rs
@@ -34,7 +34,6 @@ type ListenerConnection = (
 /// There is only one instance of this actor for all connections, meaning we must always spawn a
 /// task whenever we interact with a substream to not block the execution of other connections.
 pub struct Actor {
-    tasks: Tasks,
     protocol_tasks: HashMap<OrderId, Tasks>,
     pending_protocols: HashMap<OrderId, ListenerConnection>,
     executor: command::Executor,
@@ -44,7 +43,6 @@ pub struct Actor {
 impl Actor {
     pub fn new(executor: command::Executor, n_payouts: usize) -> Self {
         Self {
-            tasks: Tasks::default(),
             protocol_tasks: HashMap::default(),
             pending_protocols: HashMap::default(),
             executor,
@@ -66,7 +64,8 @@ impl Actor {
         let NewInboundSubstream { peer, stream } = msg;
         let address = ctx.address().expect("we are alive");
 
-        self.tasks.add_fallible(
+        tokio_extras::spawn_fallible(
+            &address.clone(),
             async move {
                 let mut framed =
                     Framed::new(stream, JsonCodec::<ListenerMessage, DialerMessage>::new());

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -274,7 +274,7 @@ where
             move || xtra_libp2p_offer::taker::Actor::new(cfd_actor_addr.clone().into())
         });
 
-        let pong_address = pong::Actor::default().create(None).spawn(&mut tasks);
+        let pong_address = pong::Actor.create(None).spawn(&mut tasks);
 
         let (supervisor, ping_actor) = supervisor::Actor::new({
             move || ping::Actor::new(endpoint_addr.clone(), PING_INTERVAL)

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -54,7 +54,6 @@ use std::collections::HashSet;
 use std::time::Duration;
 use time::OffsetDateTime;
 use tokio::sync::watch;
-use tokio_extras::Tasks;
 use xtra::prelude::MessageChannel;
 use xtra_productivity::xtra_productivity;
 use xtras::SendAsyncSafe;
@@ -77,7 +76,6 @@ pub struct Actor {
     state: State,
     price_feed:
         MessageChannel<xtra_bitmex_price_feed::LatestQuote, Option<xtra_bitmex_price_feed::Quote>>,
-    tasks: Tasks,
 }
 
 pub struct Feeds {
@@ -114,7 +112,6 @@ impl Actor {
             },
             state: State::new(network),
             price_feed,
-            tasks: Tasks::default(),
         };
         let feeds = Feeds {
             cfds: rx_cfds,
@@ -1194,7 +1191,7 @@ impl xtra::Actor for Actor {
             .await
             .expect("we just started");
 
-        self.tasks.add({
+        tokio_extras::spawn(&this.clone(), {
             let price_feed = self.price_feed.clone();
 
             async move {

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -192,7 +192,7 @@ where
             always_restart_after(RESTART_INTERVAL),
         );
 
-        let pong_address = pong::Actor::default().create(None).spawn(&mut tasks);
+        let pong_address = pong::Actor.create(None).spawn(&mut tasks);
 
         let endpoint = Endpoint::new(
             Box::new(TokioTcpConfig::new),

--- a/maker/src/cfd.rs
+++ b/maker/src/cfd.rs
@@ -45,7 +45,6 @@ use sqlite_db;
 use std::collections::HashSet;
 use time::Duration;
 use tokio_extras::FutureExt;
-use tokio_extras::Tasks;
 use xtra::Actor as _;
 use xtra_productivity::xtra_productivity;
 use xtras::address_map::NotConnected;
@@ -195,7 +194,6 @@ pub struct Actor<O: 'static, T: 'static, W: 'static> {
     time_to_first_position: xtra::Address<time_to_first_position::Actor>,
     connected_takers: HashSet<Identity>,
     n_payouts: usize,
-    tasks: Tasks,
     libp2p_rollover: xtra::Address<daemon::rollover::maker::Actor>,
     libp2p_collab_settlement: xtra::Address<daemon::collab_settlement::maker::Actor>,
     libp2p_offer: xtra::Address<xtra_libp2p_offer::maker::Actor>,
@@ -235,7 +233,6 @@ impl<O, T, W> Actor<O, T, W> {
             n_payouts,
             connected_takers: HashSet::new(),
             settlement_actors: AddressMap::default(),
-            tasks: Tasks::default(),
             libp2p_rollover,
             libp2p_collab_settlement,
             libp2p_offer,
@@ -299,8 +296,9 @@ where
         RolloverProposal { order_id, .. }: RolloverProposal,
         taker_id: Identity,
         version: RolloverVersion,
+        this: &xtra::Address<Self>,
     ) -> Result<()> {
-        let rollover_actor_addr = rollover::Actor::new(
+        let (rollover_actor_addr, fut) = rollover::Actor::new(
             order_id,
             self.n_payouts,
             self.takers.clone().into(),
@@ -313,7 +311,9 @@ where
             version,
         )
         .create(None)
-        .spawn(&mut self.tasks);
+        .run();
+
+        tokio_extras::spawn(this, fut);
 
         self.rollover_actors.insert(order_id, rollover_actor_addr);
 
@@ -338,6 +338,7 @@ where
         order_id: OrderId,
         quantity: Usd,
         leverage: Leverage,
+        this: &xtra::Address<Self>,
     ) -> Result<()> {
         tracing::debug!(%taker_id, %quantity, %order_id, "Taker wants to take an order");
 
@@ -415,7 +416,7 @@ where
             .await??;
 
         // 5. Start up contract setup actor
-        let addr = contract_setup::Actor::new(
+        let (addr, fut) = contract_setup::Actor::new(
             self.db.clone(),
             self.process_manager.clone(),
             (order_to_take.clone(), cfd.quantity(), self.n_payouts),
@@ -430,7 +431,9 @@ where
             self.time_to_first_position.clone(),
         )
         .create(None)
-        .spawn(&mut self.tasks);
+        .run();
+
+        tokio_extras::spawn(this, fut);
 
         disconnected.insert(addr);
 
@@ -719,6 +722,7 @@ where
         &mut self,
         taker_id: Identity,
         proposal: SettlementProposal,
+        this: &xtra::Address<Self>,
     ) -> Result<()> {
         let order_id = proposal.order_id;
 
@@ -727,7 +731,7 @@ where
             .get_disconnected(order_id)
             .with_context(|| format!("Settlement for order {order_id} is already in progress",))?;
 
-        let addr = collab_settlement::Actor::new(
+        let (addr, fut) = collab_settlement::Actor::new(
             proposal,
             taker_id,
             self.takers.clone().into(),
@@ -736,8 +740,9 @@ where
             self.n_payouts,
         )
         .create(None)
-        .spawn(&mut self.tasks);
+        .run();
 
+        tokio_extras::spawn(this, fut);
         disconnected.insert(addr);
 
         Ok(())
@@ -796,7 +801,10 @@ where
             peer_id,
             msg,
         }: FromTaker,
+        ctx: &mut xtra::Context<Self>,
     ) {
+        let this = ctx.address().expect("self to be alive");
+
         match msg {
             wire::TakerToMaker::DeprecatedTakeOrder { order_id, quantity } => {
                 // Old clients do not send over leverage. Hence we default to Leverage::TWO which
@@ -804,7 +812,7 @@ where
                 let leverage = Leverage::TWO;
 
                 if let Err(e) = self
-                    .handle_take_order(taker_id, peer_id, order_id, quantity, leverage)
+                    .handle_take_order(taker_id, peer_id, order_id, quantity, leverage, &this)
                     .await
                 {
                     tracing::error!("Error when handling order take request: {:#}", e)
@@ -816,7 +824,7 @@ where
                 leverage,
             } => {
                 if let Err(e) = self
-                    .handle_take_order(taker_id, peer_id, order_id, quantity, leverage)
+                    .handle_take_order(taker_id, peer_id, order_id, quantity, leverage, &this)
                     .await
                 {
                     tracing::error!("Error when handling order take request: {:#}", e)
@@ -841,6 +849,7 @@ where
                             maker,
                             price,
                         },
+                        &this,
                     )
                     .await
                 {
@@ -865,6 +874,7 @@ where
                         },
                         taker_id,
                         RolloverVersion::V1,
+                        &this,
                     )
                     .await
                 {
@@ -883,6 +893,7 @@ where
                         },
                         taker_id,
                         RolloverVersion::V2,
+                        &this,
                     )
                     .await
                 {
@@ -901,6 +912,7 @@ where
                         },
                         taker_id,
                         RolloverVersion::V3,
+                        &this,
                     )
                     .await
                 {

--- a/maker/src/collab_settlement.rs
+++ b/maker/src/collab_settlement.rs
@@ -10,7 +10,6 @@ use model::CollaborativeSettlement;
 use model::Identity;
 use model::SettlementProposal;
 use std::time::Duration;
-use tokio_extras::Tasks;
 use xtra::prelude::MessageChannel;
 use xtra_productivity::xtra_productivity;
 
@@ -31,7 +30,6 @@ pub struct Actor {
     n_payouts: usize,
     executor: command::Executor,
     db: sqlite_db::Connection,
-    tasks: Tasks,
 }
 
 #[derive(Clone, Copy)]
@@ -154,7 +152,6 @@ impl Actor {
             n_payouts,
             executor: command::Executor::new(db.clone(), process_manager),
             db,
-            tasks: Tasks::default(),
             is_initiated: false,
         }
     }
@@ -233,8 +230,10 @@ impl Actor {
             })
             .await?;
 
+        let this = ctx.address().expect("self to be alive");
+
         let timeout = {
-            let this = ctx.address().expect("self to be alive");
+            let this = this.clone();
             async move {
                 tokio_extras::time::sleep(INITIATE_TIMEOUT).await;
 
@@ -245,7 +244,7 @@ impl Actor {
                     .await;
             }
         };
-        self.tasks.add(timeout);
+        tokio_extras::spawn(&this, timeout);
 
         let this = ctx.address().expect("self to be alive");
         self.connections

--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -111,7 +111,6 @@ pub struct Actor {
     setup_actors: AddressMap<OrderId, contract_setup::Actor>,
     settlement_actors: AddressMap<OrderId, collab_settlement::Actor>,
     rollover_actors: AddressMap<OrderId, rollover::Actor>,
-    tasks: Tasks,
 }
 
 /// A connection to a taker.
@@ -228,7 +227,6 @@ impl Actor {
             setup_actors: AddressMap::default(),
             settlement_actors: AddressMap::default(),
             rollover_actors: AddressMap::default(),
-            tasks: Tasks::default(),
         }
     }
 
@@ -303,7 +301,7 @@ impl Actor {
 
         let noise_priv_key = self.noise_priv_key.clone();
 
-        self.tasks.add(async move {
+        tokio_extras::spawn(&this.clone(), async move {
             let mut tasks = Tasks::default();
 
             loop {

--- a/tokio-extras/src/tasks.rs
+++ b/tokio-extras/src/tasks.rs
@@ -2,8 +2,12 @@ use crate::future_ext::FutureExt;
 use futures::future::RemoteHandle;
 use futures::Future;
 
+#[cfg(feature = "xtra")]
+pub use actor_scoped::*;
 pub use task_map::*;
 
+#[cfg(feature = "xtra")]
+mod actor_scoped;
 mod task_map;
 
 /// Struct controlling the lifetime of the async tasks, such as

--- a/tokio-extras/src/tasks/actor_scoped.rs
+++ b/tokio-extras/src/tasks/actor_scoped.rs
@@ -1,0 +1,35 @@
+use futures::FutureExt;
+use std::future::Future;
+use xtra::refcount::RefCounter;
+use xtra::Address;
+
+/// Spawn a task that is scoped to the lifetime of the given address.
+pub fn spawn<A, Rc, F>(addr: &Address<A, Rc>, fut: F)
+where
+    Rc: RefCounter,
+    F: Future + Send + 'static,
+{
+    #[allow(clippy::disallowed_methods)]
+    tokio::spawn(xtra::scoped(addr, fut.map(|_| ())));
+}
+
+/// Spawn a fallible task that is scoped to the lifetime of the given address.
+pub fn spawn_fallible<A, Rc, Task, Ok, Err, Fn, FnFut>(
+    addr: &Address<A, Rc>,
+    fut: Task,
+    handle_err: Fn,
+) where
+    Rc: RefCounter,
+    Task: Future<Output = Result<Ok, Err>> + Send + 'static,
+    Fn: FnOnce(Err) -> FnFut + Send + 'static,
+    FnFut: Future + Send,
+    Ok: Send,
+    Err: Send,
+{
+    #[allow(clippy::disallowed_methods)]
+    tokio::spawn(xtra::scoped(addr, async {
+        if let Err(e) = fut.await {
+            handle_err(e).await;
+        }
+    }));
+}

--- a/xtra-bitmex-price-feed/Cargo.toml
+++ b/xtra-bitmex-price-feed/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1"
 thiserror = "1"
 time = { version = "0.3.11", features = ["serde-well-known"] }
 tokio = "1"
-tokio-extras = { path = "../tokio-extras" }
+tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tracing = "0.1"
 xtra = "0.6"
 xtra_productivity = { version = "0.1.0", features = ["instrumentation"] }

--- a/xtra-bitmex-price-feed/src/lib.rs
+++ b/xtra-bitmex-price-feed/src/lib.rs
@@ -5,13 +5,11 @@ use futures::TryStreamExt;
 use rust_decimal::Decimal;
 use std::fmt;
 use time::OffsetDateTime;
-use tokio_extras::Tasks;
 use xtra_productivity::xtra_productivity;
 
 pub const QUOTE_INTERVAL_MINUTES: i64 = 1;
 
 pub struct Actor {
-    tasks: Tasks,
     latest_quote: Option<Quote>,
 
     /// Contains the reason we are stopping.
@@ -22,7 +20,6 @@ pub struct Actor {
 impl Actor {
     pub fn new(network: Network) -> Self {
         Self {
-            tasks: Default::default(),
             latest_quote: None,
             stop_reason: None,
             network,
@@ -37,15 +34,17 @@ impl xtra::Actor for Actor {
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("we are alive");
 
-        self.tasks.add_fallible(
+        tokio_extras::spawn_fallible(
+            &this.clone(),
             {
                 let this = this.clone();
                 let network = self.network;
 
                 async move {
-                    let mut stream = bitmex_stream::subscribe([format!(
-                        "quoteBin{QUOTE_INTERVAL_MINUTES}m:XBTUSD"
-                    )], network);
+                    let mut stream = bitmex_stream::subscribe(
+                        [format!("quoteBin{QUOTE_INTERVAL_MINUTES}m:XBTUSD")],
+                        network,
+                    );
 
                     while let Some(text) = stream
                         .try_next()
@@ -76,8 +75,8 @@ impl xtra::Actor for Actor {
                     Err(Error::StreamEnded)
                 }
             },
-            |e: Error| async move {
-                let _: Result<(), xtra::Error> = this.send(e).await;
+            |err| async move {
+                let _: Result<(), xtra::Error> = this.send(err).await;
             },
         );
     }

--- a/xtra-libp2p-ping/src/lib.rs
+++ b/xtra-libp2p-ping/src/lib.rs
@@ -87,7 +87,7 @@ mod tests {
         let ping_address = ping::Actor::new(endpoint_address.clone(), Duration::from_secs(1))
             .create(None)
             .spawn_global();
-        let pong_address = pong::Actor::default().create(None).spawn_global();
+        let pong_address = pong::Actor.create(None).spawn_global();
 
         let endpoint = Endpoint::new(
             Box::new(MemoryTransport::default),

--- a/xtra-libp2p-ping/src/ping.rs
+++ b/xtra-libp2p-ping/src/ping.rs
@@ -6,7 +6,6 @@ use prometheus::Histogram;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::time::Duration;
-use tokio_extras::Tasks;
 use xtra::prelude::async_trait;
 use xtra::Address;
 use xtra::Context;
@@ -40,7 +39,6 @@ pub struct Actor {
     endpoint: Address<Endpoint>,
     ping_interval: Duration,
     connected_peers: HashSet<PeerId>,
-    tasks: Tasks,
     spawner: Option<Address<spawner::Actor>>,
     latencies: HashMap<PeerId, Duration>,
 }
@@ -51,7 +49,6 @@ impl Actor {
             endpoint,
             ping_interval,
             connected_peers: HashSet::default(),
-            tasks: Tasks::default(),
             spawner: None,
             latencies: HashMap::default(),
         }
@@ -65,7 +62,9 @@ impl xtra::Actor for Actor {
     async fn started(&mut self, ctx: &mut Context<Self>) {
         let this = ctx.address().expect("we just started");
 
-        self.spawner = Some(spawner::Actor::new().create(None).spawn(&mut self.tasks));
+        let (addr, fut) = spawner::Actor::new().create(None).run();
+        tokio_extras::spawn(&this, fut);
+        self.spawner = Some(addr);
 
         match self.endpoint.send(GetConnectionStats).await {
             Ok(connection_stats) => self
@@ -83,8 +82,10 @@ impl xtra::Actor for Actor {
             }
         }
 
-        self.tasks
-            .add(this.send_interval(self.ping_interval, || Ping));
+        tokio_extras::spawn(
+            &this.clone(),
+            this.send_interval(self.ping_interval, || Ping),
+        );
     }
 
     async fn stopped(self) -> Self::Stop {}

--- a/xtra-libp2p-ping/src/pong.rs
+++ b/xtra-libp2p-ping/src/pong.rs
@@ -1,24 +1,26 @@
 use crate::protocol;
 use async_trait::async_trait;
-use tokio_extras::Tasks;
+use xtra::Context;
 use xtra_libp2p::NewInboundSubstream;
 use xtra_productivity::xtra_productivity;
 
-#[derive(Default)]
-pub struct Actor {
-    tasks: Tasks,
-}
+#[derive(Copy, Clone)]
+pub struct Actor;
 
 #[xtra_productivity(message_impl = false)]
 impl Actor {
-    async fn handle(&mut self, message: NewInboundSubstream) {
+    async fn handle(&mut self, message: NewInboundSubstream, ctx: &mut Context<Self>) {
         let NewInboundSubstream { stream, peer } = message;
 
         let future = protocol::recv(stream);
 
-        self.tasks.add_fallible(future, move |e| async move {
-            tracing::debug!(%peer, "Inbound ping protocol failed: {e}");
-        });
+        tokio_extras::spawn_fallible(
+            &ctx.address().expect("self to be alive"),
+            future,
+            move |e| async move {
+                tracing::debug!(%peer, "Inbound ping protocol failed: {e}");
+            },
+        );
     }
 }
 

--- a/xtra-libp2p/Cargo.toml
+++ b/xtra-libp2p/Cargo.toml
@@ -18,7 +18,7 @@ pin-project = "1"
 prometheus = { version = "0.13", default-features = false }
 thiserror = "1"
 tokio = { version = "1", features = ["time"] }
-tokio-extras = { path = "../tokio-extras" }
+tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tracing = "0.1"
 void = "1"
 xtra = { version = "0.6", features = ["with-tokio-1"] }

--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -30,6 +30,8 @@ use tokio_extras::Tasks;
 use tracing::instrument;
 use tracing::Instrument;
 use xtra::message_channel::MessageChannel;
+use xtra::Address;
+use xtra::Context;
 use xtra_productivity::xtra_productivity;
 use xtras::SendAsyncSafe;
 
@@ -52,7 +54,6 @@ use xtras::SendAsyncSafe;
 /// Opening a new substream can be achieved by sending the [`OpenSubstream`] message.
 pub struct Endpoint {
     transport_fn: Box<dyn Fn() -> Boxed<Connection> + Send + 'static>,
-    tasks: Tasks,
     controls: HashMap<PeerId, (yamux::Control, Tasks)>,
     inbound_substream_channels: HashMap<&'static str, MessageChannel<NewInboundSubstream, ()>>,
     listen_addresses: HashSet<Multiaddr>,
@@ -241,7 +242,6 @@ impl Endpoint {
 
         Self {
             transport_fn,
-            tasks: Tasks::default(),
             inbound_substream_channels: verify_unique_handlers(inbound_substream_handlers),
             controls: HashMap::default(),
             listen_addresses: HashSet::default(),
@@ -251,14 +251,14 @@ impl Endpoint {
         }
     }
 
-    async fn drop_connection(&mut self, peer: &PeerId) {
+    async fn drop_connection(&mut self, this: &Address<Self>, peer: &PeerId) {
         let (mut control, tasks) = match self.controls.remove(peer) {
             None => return,
             Some(control) => control,
         };
 
         // TODO: Evaluate whether dropping and closing has to be in a particular order.
-        self.tasks.add(async move {
+        tokio_extras::spawn(this, async move {
             let _ = control.close().await;
             drop(tasks);
         });
@@ -300,7 +300,7 @@ impl Endpoint {
 
 #[xtra_productivity]
 impl Endpoint {
-    async fn handle(&mut self, msg: NewConnection, ctx: &mut xtra::Context<Self>) {
+    async fn handle(&mut self, msg: NewConnection, ctx: &mut Context<Self>) {
         self.inflight_connections.remove(&msg.peer);
         let this = ctx.address().expect("we are alive");
 
@@ -366,19 +366,21 @@ impl Endpoint {
         self.notify_listen_address_removed(msg.address).await;
     }
 
-    async fn handle(&mut self, msg: FailedToConnect) {
+    async fn handle(&mut self, msg: FailedToConnect, ctx: &mut Context<Self>) {
         tracing::debug!("Failed to connect: {:#}", msg.error);
         let peer = msg.peer;
 
         self.inflight_connections.remove(&peer);
-        self.drop_connection(&peer).await;
+        self.drop_connection(&ctx.address().expect("self to be alive"), &peer)
+            .await;
     }
 
-    async fn handle(&mut self, msg: ExistingConnectionFailed) {
+    async fn handle(&mut self, msg: ExistingConnectionFailed, ctx: &mut Context<Self>) {
         tracing::debug!("Connection failed: {:#}", msg.error);
         let peer = msg.peer;
 
-        self.drop_connection(&peer).await;
+        self.drop_connection(&ctx.address().expect("self to be alive"), &peer)
+            .await;
     }
 
     async fn handle(&mut self, _: GetConnectionStats) -> ConnectionStats {
@@ -388,7 +390,7 @@ impl Endpoint {
         }
     }
 
-    async fn handle(&mut self, msg: Connect, ctx: &mut xtra::Context<Self>) -> Result<(), Error> {
+    async fn handle(&mut self, msg: Connect, ctx: &mut Context<Self>) -> Result<(), Error> {
         let this = ctx.address().expect("we are alive");
 
         let peer = msg
@@ -404,7 +406,8 @@ impl Endpoint {
         let mut transport = (self.transport_fn)();
 
         self.inflight_connections.insert(peer);
-        self.tasks.add_fallible(
+        tokio_extras::spawn_fallible(
+            &this.clone(),
             {
                 let this = this.clone();
                 let connection_timeout = self.connection_timeout;
@@ -438,17 +441,19 @@ impl Endpoint {
         Ok(())
     }
 
-    async fn handle(&mut self, msg: Disconnect) {
-        self.drop_connection(&msg.0).await;
+    async fn handle(&mut self, msg: Disconnect, ctx: &mut Context<Self>) {
+        self.drop_connection(&ctx.address().expect("self to be alive"), &msg.0)
+            .await;
     }
 
-    async fn handle(&mut self, msg: ListenOn, ctx: &mut xtra::Context<Self>) {
+    async fn handle(&mut self, msg: ListenOn, ctx: &mut Context<Self>) {
         let this = ctx.address().expect("we are alive");
         let listen_address = msg.0.clone();
 
         let mut transport = (self.transport_fn)();
 
-        self.tasks.add_fallible(
+        tokio_extras::spawn_fallible::<_, _, _, (), _, _, _>(
+            &this.clone(),
             {
                 let this = this.clone();
                 let listen_address = listen_address.clone();

--- a/xtra-libp2p/tests/basic.rs
+++ b/xtra-libp2p/tests/basic.rs
@@ -8,11 +8,11 @@ use libp2p_core::multiaddr::Protocol;
 use libp2p_core::Multiaddr;
 use std::collections::HashSet;
 use std::time::Duration;
-use tokio_extras::Tasks;
 use xtra::message_channel::MessageChannel;
 use xtra::spawn::TokioGlobalSpawnExt;
 use xtra::Actor;
 use xtra::Address;
+use xtra::Context;
 use xtra_libp2p::endpoint;
 use xtra_libp2p::endpoint::Subscribers;
 use xtra_libp2p::libp2p::identity::Keypair;
@@ -426,19 +426,20 @@ struct GetConnectedPeers;
 struct GetListenAddresses;
 
 #[derive(Default)]
-struct HelloWorld {
-    tasks: Tasks,
-}
+struct HelloWorld;
 
 #[xtra_productivity(message_impl = false)]
 impl HelloWorld {
-    async fn handle(&mut self, msg: NewInboundSubstream) {
+    async fn handle(&mut self, msg: NewInboundSubstream, ctx: &mut Context<Self>) {
         tracing::info!("New hello world stream from {}", msg.peer);
 
-        self.tasks
-            .add_fallible(hello_world_listener(msg.stream), move |e| async move {
+        tokio_extras::spawn_fallible(
+            &ctx.address().unwrap(),
+            hello_world_listener(msg.stream),
+            move |e| async move {
                 tracing::warn!("Hello world protocol with peer {} failed: {}", msg.peer, e);
-            });
+            },
+        );
     }
 }
 

--- a/xtras/Cargo.toml
+++ b/xtras/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = "0.1.56"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
-tokio-extras = { path = "../tokio-extras" }
+tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tracing = { version = "0.1" }
 uuid = { version = "1.1", features = ["v4"] }
 xtra = { version = "0.6", features = ["instrumentation"] }

--- a/xtras/src/supervisor.rs
+++ b/xtras/src/supervisor.rs
@@ -8,7 +8,6 @@ use std::fmt;
 use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::time::Duration;
-use tokio_extras::Tasks;
 use xtra::Address;
 use xtra::Context;
 use xtra_productivity::xtra_productivity;
@@ -18,7 +17,6 @@ use xtra_productivity::xtra_productivity;
 pub struct Actor<T, R> {
     context: Context<T>,
     ctor: Box<dyn Fn() -> T + Send + 'static>,
-    tasks: Tasks,
     restart_policy: AsyncClosure<R>,
     _actor: Address<T>, // kept around to ensure that the supervised actor stays alive
     metrics: Metrics,
@@ -96,7 +94,6 @@ where
         let supervisor = Self {
             context,
             ctor: Box::new(ctor),
-            tasks: Tasks::default(),
             restart_policy: always_restart(),
             _actor: address.clone(),
             metrics: Metrics::default(),
@@ -126,7 +123,6 @@ where
         let supervisor = Self {
             context,
             ctor: Box::new(ctor),
-            tasks: Tasks::default(),
             restart_policy,
             _actor: address.clone(),
             metrics: Metrics::default(),
@@ -143,7 +139,7 @@ where
         let actor = (self.ctor)();
 
         self.metrics.num_spawns += 1;
-        self.tasks.add({
+        tokio_extras::spawn(&this.clone(), {
             let task = self.context.attach(actor);
 
             async move {


### PR DESCRIPTION
This removes a substantial number of Tasks structs in favour of `xtra::scoped`, which is a bit cleaner for when the tasks are tied to the actor's lifecycle. 

cc @klochowicz, this might be a little less ambitious than what you had in your branch, which is maybe why it works? ~~There are some actors (Maker and Taker) which still have actor-lifetime tasks structs, which I haven't touched yet since they are involved in `new`, when the context is not yet available. Could some of these be moved to `Actor::started`, perhaps?~~ edit: looks like I just assumed these are actors, but they aren't :sweat_smile: 