### PR TITLE
Do not log all CFDs every time `GET /cfds` is called

### DIFF
--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -232,7 +232,7 @@ pub async fn put_sync_wallet(
 }
 
 #[rocket::get("/cfds")]
-#[instrument(name = "GET /cfds", skip(rx), ret, err)]
+#[instrument(name = "GET /cfds", skip(rx), err)]
 pub async fn get_cfds<'r>(
     rx: &State<Feeds>,
     _auth: Authenticated,


### PR DESCRIPTION
This may be the reason why the size of our logs has increased so much since d89e3dac31031062a944e3ca0b337a0c765e5210.