### PR TITLE
Reimplement supervisor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5214,7 +5214,7 @@ dependencies = [
 [[package]]
 name = "xtra"
 version = "0.6.0"
-source = "git+https://github.com/Restioson/xtra?rev=afff02dd0fc8b92ae264db8a5457773f8af95487#afff02dd0fc8b92ae264db8a5457773f8af95487"
+source = "git+https://github.com/Restioson/xtra?rev=7e9fccc1e02dae3df4ba99126e6f1a0059673d7e#7e9fccc1e02dae3df4ba99126e6f1a0059673d7e"
 dependencies = [
  "async-trait",
  "catty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-xtra = { git = "https://github.com/Restioson/xtra", rev = "afff02dd0fc8b92ae264db8a5457773f8af95487" } # Unreleased
+xtra = { git = "https://github.com/Restioson/xtra", rev = "7e9fccc1e02dae3df4ba99126e6f1a0059673d7e" } # Unreleased
 maia = { git = "https://github.com/comit-network/maia", rev = "fc6b78b98407b10b55f8cfd152062ad77f98cd9f" } # Unreleased
 maia-core = { git = "https://github.com/comit-network/maia", tag = "0.1.1", package = "maia-core" } # Pinned to support maia 0.1 and 0.2
 xtra_productivity = { git = "https://github.com/comit-network/xtra-productivity", rev = "0bfd589b42a63149221dec7e95aca932875374dd" } # Unreleased

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -24,8 +24,8 @@ use shared_bin::logger;
 use std::net::SocketAddr;
 use tokio_extras::Tasks;
 use xtra::Actor;
-use xtras::supervisor;
 use xtras::supervisor::always_restart;
+use xtras::supervisor::Supervisor;
 
 #[rocket::main]
 async fn main() -> Result<()> {
@@ -149,12 +149,12 @@ async fn main() -> Result<()> {
         endpoint_listen,
     )?;
 
-    let (supervisor, price_feed) = supervisor::Actor::with_policy(
+    let (supervisor, price_feed) = Supervisor::with_policy(
         move || xtra_bitmex_price_feed::Actor::new(opts.network.price_feed_network()),
         always_restart::<xtra_bitmex_price_feed::Error>(),
     );
 
-    let _supervisor_address = supervisor.create(None).spawn(&mut tasks);
+    tasks.add(supervisor.run_log_summary());
 
     let (proj_actor, projection_feeds) =
         projection::Actor::new(db.clone(), bitcoin_network, price_feed.clone().into());

--- a/xtra-libp2p/examples/hello_world_dialer.rs
+++ b/xtra-libp2p/examples/hello_world_dialer.rs
@@ -15,8 +15,8 @@ use xtra_libp2p::dialer;
 use xtra_libp2p::endpoint::Subscribers;
 use xtra_libp2p::Endpoint;
 use xtra_libp2p::OpenSubstream;
-use xtras::supervisor;
 use xtras::supervisor::always_restart;
+use xtras::supervisor::Supervisor;
 
 #[derive(Parser)]
 struct Opts {
@@ -52,8 +52,10 @@ async fn main() -> Result<()> {
     };
 
     let (supervisor, _dialer_actor) =
-        supervisor::Actor::with_policy(dialer_constructor, always_restart::<dialer::Error>());
-    let _dialer_supervisor = supervisor.create(None).spawn_global();
+        Supervisor::with_policy(dialer_constructor, always_restart::<dialer::Error>());
+
+    #[allow(clippy::disallowed_methods)]
+    tokio::spawn(supervisor.run());
 
     tokio_extras::time::sleep(Duration::from_secs(1)).await;
 

--- a/xtra-libp2p/examples/hello_world_listener.rs
+++ b/xtra-libp2p/examples/hello_world_listener.rs
@@ -16,8 +16,8 @@ use xtra_libp2p::listener;
 use xtra_libp2p::Endpoint;
 use xtra_libp2p::NewInboundSubstream;
 use xtra_productivity::xtra_productivity;
-use xtras::supervisor;
 use xtras::supervisor::always_restart;
+use xtras::supervisor::Supervisor;
 
 // Listen on TCP
 
@@ -68,8 +68,10 @@ async fn main() -> Result<()> {
         listener::Actor::new(endpoint_addr, endpoint_listen)
     };
     let (supervisor, _listener_actor) =
-        supervisor::Actor::with_policy(listener_constructor, always_restart::<listener::Error>());
-    let _listener_supervisor = supervisor.create(None).spawn_global();
+        Supervisor::with_policy(listener_constructor, always_restart::<listener::Error>());
+
+    #[allow(clippy::disallowed_methods)]
+    tokio::spawn(supervisor.run());
 
     tokio_extras::time::sleep(Duration::from_secs(opts.duration_secs)).await;
 


### PR DESCRIPTION
The old supervisor kept a `Context` around that was never received from, which meant that broadcasts would pile up until they reach the bound. This new supervisor does not do that, since the introduction of `Context::next_message` allows us to write our own manager loop and restart the actor that way.