### PR TITLE
Allow specifying custom OTEL collector endpoint

### DIFF
--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -5,6 +5,7 @@ use daemon::bdk;
 use daemon::bdk::bitcoin;
 use daemon::bdk::bitcoin::Amount;
 use shared_bin::logger::LevelFilter;
+use shared_bin::logger::LOCAL_COLLECTOR_ENDPOINT;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
@@ -40,6 +41,12 @@ pub struct Opts {
     /// If enabled, traces will be exported to the OTEL collector
     #[clap(long)]
     pub instrumentation: bool,
+
+    /// OTEL collector endpoint address
+    ///
+    /// If not specified it defaults to the local collector endpoint.
+    #[clap(long, default_value = LOCAL_COLLECTOR_ENDPOINT )]
+    pub collector_endpoint: String,
 
     /// If enabled the application will not fail if an error occurred during db migration.
     #[clap(short, long)]

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -31,8 +31,14 @@ use xtras::supervisor::always_restart;
 async fn main() -> Result<()> {
     let opts = Opts::parse();
 
-    logger::init(opts.log_level, opts.json, opts.instrumentation, "maker")
-        .context("initialize logger")?;
+    logger::init(
+        opts.log_level,
+        opts.json,
+        opts.instrumentation,
+        "maker",
+        &opts.collector_endpoint,
+    )
+    .context("initialize logger")?;
     tracing::info!("Running version: {}", daemon::version::version());
     let settlement_interval_hours = SETTLEMENT_INTERVAL.whole_hours();
 


### PR DESCRIPTION
Required for our production setup, in order to point to a different container
with OTEL collector.

If not specified, defaults to localhost:4317, which is compatible with jaeger.