### PR TITLE
Revert addition of instrumentation argument to cargo aliases

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,8 +2,8 @@
 linker = "aarch64-linux-gnu-gcc"
 
 [alias]
-dev-maker = "run --bin maker -- --instrumentation testnet"
-dev-taker = "run --bin taker -- --instrumentation --maker localhost:9999 --maker-id 10d4ba2ac3f7a22da4009d813ff1bc3f404dfe2cc93a32bedf1512aa9951c95e --maker-peer-id 12D3KooWDjzHna3pNi1Bt1DoRfrpsBREykJKXDRDxXvhJNAdDZEk testnet" # Maker ID matches seed found in `testnet/maker_seed`
+dev-maker = "run --bin maker -- testnet"
+dev-taker = "run --bin taker -- --maker localhost:9999 --maker-id 10d4ba2ac3f7a22da4009d813ff1bc3f404dfe2cc93a32bedf1512aa9951c95e --maker-peer-id 12D3KooWDjzHna3pNi1Bt1DoRfrpsBREykJKXDRDxXvhJNAdDZEk testnet" # Maker ID matches seed found in `testnet/maker_seed`
 
 # Inspired by https://github.com/EmbarkStudios/rust-ecosystem/pull/68.
 [build]


### PR DESCRIPTION
Without an OTEL collector available locally we just emit errors nonstop.