### PR TITLE
Don't sort events by timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,17 +658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-epoch"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,7 +775,6 @@ dependencies = [
  "pretty_assertions",
  "prometheus",
  "rand 0.6.5",
- "rayon",
  "reqwest",
  "rust_decimal",
  "rust_decimal_macros",
@@ -3128,30 +3116,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
-name = "rayon"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
-dependencies = [
- "autocfg 1.1.0",
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "num_cpus",
-]
-
-[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3956,7 +3920,6 @@ dependencies = [
  "maia-core",
  "model",
  "pretty_assertions",
- "rayon",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -29,7 +29,6 @@ model = { path = "../model" }
 parse-display = "0.5.5"
 prometheus = { version = "0.13", default-features = false }
 rand = "0.6"
-rayon = "1.5"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
 rust_decimal = { version = "1.25", features = ["serde-with-float"] }
 rust_decimal_macros = "1.25"

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -54,7 +54,6 @@ use rust_decimal_macros::dec;
 use serde::de::Error as _;
 use serde::Deserialize;
 use serde::Serialize;
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::ops::RangeInclusive;
@@ -389,32 +388,6 @@ impl CfdEvent {
             id,
             event,
         }
-    }
-
-    /// Comparison function to order two events chronologically.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use model::{CfdEvent, Timestamp, EventKind, OrderId};
-    ///
-    /// # let id = OrderId::default();
-    /// # let make_event_at = move |seconds| CfdEvent {
-    /// #    timestamp: Timestamp::new(seconds),
-    /// #    id,
-    /// #    event: EventKind::LockConfirmed,
-    /// # };
-    /// #
-    /// let first = make_event_at(2000);
-    /// let second = make_event_at(3000);
-    ///
-    /// let mut events = vec![second.clone(), first.clone()];
-    /// events.sort_unstable_by(CfdEvent::chronologically);
-    ///
-    /// assert_eq!(events, vec![first, second])
-    /// ```
-    pub fn chronologically(left: &CfdEvent, right: &CfdEvent) -> Ordering {
-        left.timestamp.cmp(&right.timestamp)
     }
 }
 

--- a/sqlite-db/Cargo.toml
+++ b/sqlite-db/Cargo.toml
@@ -16,7 +16,6 @@ libp2p-core = { version = "0.33", default-features = false }
 maia = "0.2.0"
 maia-core = "0.1.1"
 model = { path = "../model" }
-rayon = "1.5"
 rust_decimal = "1.25"
 rust_decimal_macros = "1.25"
 serde = { version = "1", features = ["derive"] }

--- a/sqlite-db/sqlx-data.json
+++ b/sqlite-db/sqlx-data.json
@@ -368,48 +368,6 @@
       "nullable": []
     }
   },
-  "7d9268dcb6f72fd7c9495dcde388bf998445ada4539d6adb3d3cf693c6339b3b": {
-    "query": "\n\n        select\n            c.id as cfd_row_id,\n            events.id as event_row_id,\n            name,\n            data,\n            created_at as \"created_at: models::Timestamp\"\n        from\n            events\n        join\n            cfds c on c.id = events.cfd_id\n        where\n            uuid = $1\n        limit $2,-1\n            ",
-    "describe": {
-      "columns": [
-        {
-          "name": "cfd_row_id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "event_row_id",
-          "ordinal": 1,
-          "type_info": "Int64"
-        },
-        {
-          "name": "name",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "data",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "created_at: models::Timestamp",
-          "ordinal": 4,
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Right": 2
-      },
-      "nullable": [
-        true,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
   "8175b7702d6a0b28843f03a9b6f507a64a703ae2ff649b3a28f339f3abb70fce": {
     "query": "\n        INSERT INTO closed_cets\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout,\n            price\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.uuid = $1),\n            $2, $3, $4, $5\n        )\n        ",
     "describe": {
@@ -1057,6 +1015,48 @@
         false,
         false,
         false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "f72ab7ae71904c030803d1c014a94370192e3d1182827951592dd6bb3d5a6072": {
+    "query": "\n\n        select\n            c.id as cfd_row_id,\n            events.id as event_row_id,\n            events.name,\n            events.data,\n            events.created_at as \"created_at: models::Timestamp\"\n        from\n            events\n        join\n            cfds c on c.id = events.cfd_id\n        where\n            uuid = $1\n        order by\n            events.id\n        limit $2,-1\n            ",
+    "describe": {
+      "columns": [
+        {
+          "name": "cfd_row_id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "event_row_id",
+          "ordinal": 1,
+          "type_info": "Int64"
+        },
+        {
+          "name": "name",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "data",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at: models::Timestamp",
+          "ordinal": 4,
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Right": 2
+      },
+      "nullable": [
+        true,
         false,
         false,
         false,

--- a/sqlite-db/src/lib.rs
+++ b/sqlite-db/src/lib.rs
@@ -23,7 +23,6 @@ use model::Price;
 use model::Role;
 use model::TxFeeRate;
 use model::Usd;
-use rayon::prelude::*;
 use sqlx::migrate::MigrateError;
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::Connection as _;
@@ -634,15 +633,17 @@ async fn load_cfd_events(
         select
             c.id as cfd_row_id,
             events.id as event_row_id,
-            name,
-            data,
-            created_at as "created_at: models::Timestamp"
+            events.name,
+            events.data,
+            events.created_at as "created_at: models::Timestamp"
         from
             events
         join
             cfds c on c.id = events.cfd_id
         where
             uuid = $1
+        order by
+            events.id
         limit $2,-1
             "#,
         id,
@@ -650,7 +651,7 @@ async fn load_cfd_events(
     )
     .fetch_all(&mut *conn)
     .await?
-    .into_par_iter()
+    .into_iter()
     .map(|row| {
         Ok((
             row.cfd_row_id.context("CFD with id not found {id}")?,
@@ -678,12 +679,10 @@ async fn load_cfd_events(
         }
     }
 
-    let mut events = events
+    let events = events
         .into_iter()
         .map(|(_, _, event)| event)
         .collect::<Vec<CfdEvent>>();
-
-    events.sort_unstable_by(CfdEvent::chronologically);
 
     Ok(events)
 }


### PR DESCRIPTION
- Remove the parallel iterator because it might change the order of events when processing them.
- Remove ordering by timestamp, because duplicated timestamps can happen; e.g. for collab settlement events this can have problematic side effects.
- Ensure order of events by `order by events.id`, because `events.id` is incremental, other than the timestamp.

Resolves #2196 