### PR TITLE
Ensure to monitor for finality after `LockConfirmedAfterFinality`

### DIFF
--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -242,7 +242,7 @@ impl Cfd {
                 commit_tx: None,
                 ..self
             },
-            LockConfirmed => Self {
+            LockConfirmed | LockConfirmedAfterFinality => Self {
                 monitor_lock_finality: false,
                 lock_tx: None,
                 ..self
@@ -253,10 +253,7 @@ impl Cfd {
                 ..self
             },
             // final states, don't monitor anything
-            CetConfirmed
-            | RefundConfirmed
-            | CollaborativeSettlementConfirmed
-            | LockConfirmedAfterFinality => Self {
+            CetConfirmed | RefundConfirmed | CollaborativeSettlementConfirmed => Self {
                 monitor_lock_finality: false,
                 monitor_commit_finality: false,
                 monitor_cet_timelock: false,


### PR DESCRIPTION
Resolves #2387 

We should not treat `LockConfirmedAfterFinality` as final state in the monitor, because this would mean we just stop monitoring for other things.
This can lead to scenarios where we never confirm collab settlement or CET in cases where `LockConfirmedAfterFinality` is recorded before the finality confirmation is picked up.

Treating `LockConfirmedAfterFinality` like `LockConfirmed` is correct and should not have side effects in the monitor.
`LockConfirmedAfterFinality` should not have any influence on other monitoring decisions besides the lock transaction.

---

Note: I went through the commit history of this code section to make sure that we didn't specify `LockConfirmedAfterFinality` on purpose at this point. There was no specific change concerning this. I think this was wrong all along but we never noticed because it only becomes apparent in edge cases where a user closes a position before lock was confirmed (which happens rarely).