### PR TITLE
Add more spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5177,7 +5177,7 @@ dependencies = [
 [[package]]
 name = "xtra"
 version = "0.6.0"
-source = "git+https://github.com/Restioson/xtra?rev=7e9fccc1e02dae3df4ba99126e6f1a0059673d7e#7e9fccc1e02dae3df4ba99126e6f1a0059673d7e"
+source = "git+https://github.com/comit-network/xtra?branch=span-late-create#764260a53bab43a22c2c6b81ffd7e8e53aeb2d44"
 dependencies = [
  "async-trait",
  "catty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-xtra = { git = "https://github.com/Restioson/xtra", rev = "7e9fccc1e02dae3df4ba99126e6f1a0059673d7e" } # Unreleased
+xtra = { git = "https://github.com/comit-network/xtra", branch = "span-late-create" } # TODO Switch back to xtra/master after https://github.com/Restioson/xtra/pull/120 gets merged
 maia = { git = "https://github.com/comit-network/maia", rev = "fc6b78b98407b10b55f8cfd152062ad77f98cd9f" } # Unreleased
 maia-core = { git = "https://github.com/comit-network/maia", tag = "0.1.1", package = "maia-core" } # Pinned to support maia 0.1 and 0.2
 xtra_productivity = { git = "https://github.com/comit-network/xtra-productivity", rev = "0bfd589b42a63149221dec7e95aca932875374dd" } # Unreleased

--- a/daemon/src/collab_settlement/protocol.rs
+++ b/daemon/src/collab_settlement/protocol.rs
@@ -30,6 +30,7 @@ const DECISION_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub const SETTLEMENT_MSG_TIMEOUT: Duration = Duration::from_secs(120);
 
+#[tracing::instrument]
 pub async fn dialer(
     endpoint: Address<Endpoint>,
     order_id: OrderId,
@@ -116,16 +117,17 @@ pub async fn dialer(
     Ok(settlement)
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DialerFailed {
+    #[error("Rejected")]
     Rejected,
+    #[error("Failed after sending signature")]
     AfterSendingSignature {
         unsigned_tx: Transaction,
         error: anyhow::Error,
     },
-    BeforeSendingSignature {
-        source: anyhow::Error,
-    },
+    #[error("Failed before sending signature")]
+    BeforeSendingSignature { source: anyhow::Error },
 }
 
 impl From<anyhow::Error> for DialerFailed {

--- a/daemon/src/command.rs
+++ b/daemon/src/command.rs
@@ -5,12 +5,22 @@ use anyhow::Result;
 use model::Cfd;
 use model::CfdEvent;
 use sqlite_db;
+use std::fmt;
+use std::fmt::Debug;
 use xtra::Address;
 
 #[derive(Clone)]
 pub struct Executor {
     db: sqlite_db::Connection,
     process_manager: Address<process_manager::Actor>,
+}
+
+impl Debug for Executor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Executor")
+            .field("process_manager", &self.process_manager)
+            .finish()
+    }
 }
 
 impl Executor {

--- a/daemon/src/online_status.rs
+++ b/daemon/src/online_status.rs
@@ -37,6 +37,7 @@ impl Actor {
 impl xtra::Actor for Actor {
     type Stop = ();
 
+    #[tracing::instrument(name = "online_status::Actor started", skip_all)]
     async fn started(&mut self, ctx: &mut Context<Self>) {
         tracing::debug!(
             "Online status watch actor started. Monitoring for peer id changes: {:?}",

--- a/daemon/src/rollover/taker.rs
+++ b/daemon/src/rollover/taker.rs
@@ -34,6 +34,7 @@ use xtra_productivity::xtra_productivity;
 const DECISION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// One actor to rule all the rollovers
+#[derive(Debug)]
 pub struct Actor {
     endpoint: Address<Endpoint>,
     oracle_pk: XOnlyPublicKey,
@@ -80,6 +81,7 @@ impl Actor {
 }
 
 impl Actor {
+    #[tracing::instrument]
     async fn open_substream(&self, peer_id: PeerId) -> anyhow::Result<Substream> {
         Ok(self
             .endpoint

--- a/daemon/src/setup_taker.rs
+++ b/daemon/src/setup_taker.rs
@@ -23,6 +23,7 @@ use model::Role;
 use model::Usd;
 use sqlite_db;
 use std::time::Duration;
+use tracing::Instrument;
 use xtra::message_channel::MessageChannel;
 use xtra_productivity::xtra_productivity;
 
@@ -249,7 +250,11 @@ impl xtra::Actor for Actor {
             }
         };
 
-        tokio_extras::spawn(&this, maker_response_timeout);
+        tokio_extras::spawn(
+            &this,
+            maker_response_timeout
+                .instrument(tracing::debug_span!("Wait for maker response timeout")),
+        );
     }
 
     async fn stopped(self) -> Self::Stop {}

--- a/maker/src/cfd.rs
+++ b/maker/src/cfd.rs
@@ -239,6 +239,7 @@ impl<O, T, W> Actor<O, T, W> {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     async fn update_connected_takers(&mut self) -> Result<()> {
         self.projection
             .send_async_safe(projection::Update(

--- a/shared-bin/src/logger.rs
+++ b/shared-bin/src/logger.rs
@@ -36,7 +36,7 @@ pub fn init(
 
     let filter = match std::env::var_os(RUST_LOG_ENV).map(|s| s.into_string()) {
         Some(Ok(env)) => {
-            let mut filter = base_directives(EnvFilter::new(""))?;
+            let mut filter = log_base_directives(EnvFilter::new(""))?;
             for directive in env.split(',') {
                 match directive.parse() {
                     Ok(d) => filter = filter.add_directive(d),
@@ -45,7 +45,7 @@ pub fn init(
             }
             filter
         }
-        _ => base_directives(EnvFilter::from_env(RUST_LOG_ENV))?,
+        _ => log_base_directives(EnvFilter::from_env(RUST_LOG_ENV))?,
     };
     let filter = filter.add_directive(format!("{level}").parse()?);
 
@@ -88,7 +88,11 @@ pub fn init(
             .install_batch(opentelemetry::runtime::Tokio)
             .context("Failed to initialise OTLP exporter")?;
 
-        Some(tracing_opentelemetry::layer().with_tracer(tracer))
+        Some(
+            tracing_opentelemetry::layer()
+                .with_tracer(tracer)
+                .with_filter(trace_base_directives(EnvFilter::new(""))?),
+        )
     } else {
         None
     };
@@ -104,7 +108,7 @@ pub fn init(
     Ok(())
 }
 
-fn base_directives(env: EnvFilter) -> Result<EnvFilter> {
+fn log_base_directives(env: EnvFilter) -> Result<EnvFilter> {
     let filter = env
         .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
         .add_directive("sqlx=warn".parse()?) // sqlx logs all queries on INFO
@@ -131,5 +135,10 @@ fn base_directives(env: EnvFilter) -> Result<EnvFilter> {
         .add_directive("xtra=warn".parse()?)
         .add_directive("sled=warn".parse()?) // downgrade sled log level: it is spamming too much on DEBUG
         .add_directive("xtra_libp2p=info".parse()?);
+    Ok(filter)
+}
+
+fn trace_base_directives(env: EnvFilter) -> Result<EnvFilter> {
+    let filter = env.add_directive(LevelFilter::DEBUG.into());
     Ok(filter)
 }

--- a/tokio-extras/src/tasks.rs
+++ b/tokio-extras/src/tasks.rs
@@ -1,6 +1,8 @@
 use crate::future_ext::FutureExt;
 use futures::future::RemoteHandle;
 use futures::Future;
+use std::fmt::Display;
+use tracing::Instrument;
 
 #[cfg(feature = "xtra")]
 pub use actor_scoped::*;
@@ -36,13 +38,16 @@ impl Tasks {
         f: impl Future<Output = Result<(), E>> + Send + 'static,
         err_handler: impl FnOnce(E) -> EF + Send + 'static,
     ) where
-        E: Send + 'static,
+        E: Display + Send + 'static,
         EF: Future<Output = ()> + Send + 'static,
     {
         let fut = async move {
             match f.await {
                 Ok(()) => {}
-                Err(err) => err_handler(err).await,
+                Err(err) => {
+                    let span = tracing::error_span!("fallible task handle_error", %err);
+                    err_handler(err).instrument(span).await
+                }
             }
         };
 

--- a/tokio-extras/src/time.rs
+++ b/tokio-extras/src/time.rs
@@ -16,6 +16,12 @@ pub async fn sleep(duration: Duration) {
     tokio::time::sleep(duration).await
 }
 
+/// Sleep without instrumenting the span
+pub async fn sleep_silent(duration: Duration) {
+    #[allow(clippy::disallowed_methods)]
+    tokio::time::sleep(duration).await
+}
+
 /// Limit the future's time of execution to a certain duration, cancelling it and returning
 /// an error if time runs out. This is instrumented, unlike `tokio::time::timeout`. The
 /// `child_span` function constructs the span for the child future from the span of the parent

--- a/xtra-libp2p/src/dialer.rs
+++ b/xtra-libp2p/src/dialer.rs
@@ -60,6 +60,7 @@ impl Actor {
 impl xtra::Actor for Actor {
     type Stop = Error;
 
+    #[tracing::instrument("Start dialer actor", skip(ctx))]
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         tracing::debug!("Starting dialer actor");
         match self

--- a/xtra-libp2p/src/listener.rs
+++ b/xtra-libp2p/src/listener.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use libp2p_core::Multiaddr;
 use std::time::Duration;
+use tracing::instrument;
 use xtra::Address;
 use xtra_productivity::xtra_productivity;
 use xtras::SendAsyncSafe;
@@ -40,6 +41,7 @@ impl Actor {
         ctx.stop_self();
     }
 
+    #[instrument(skip(self), ret, err)]
     async fn is_listening(&self) -> Result<bool> {
         Ok(self
             .endpoint
@@ -49,6 +51,7 @@ impl Actor {
             .contains(&self.listen_address))
     }
 
+    #[instrument(skip(self), err)]
     async fn listen(&self) -> Result<()> {
         anyhow::ensure!(
             !self.is_listening().await?,

--- a/xtras/src/send_async_safe.rs
+++ b/xtras/src/send_async_safe.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use std::fmt;
+use tracing::instrument;
 use xtra::message_channel::MessageChannel;
 use xtra::refcount::RefCounter;
 
@@ -21,6 +22,7 @@ where
     A: xtra::Handler<M, Return = ()>,
     M: Send + 'static,
 {
+    #[instrument(skip(msg), err)]
     async fn send_async_safe(&self, msg: M) -> Result<(), xtra::Error> {
         let _ = self.send(msg).split_receiver().await;
 
@@ -39,6 +41,7 @@ where
     E: fmt::Display + Send + 'static,
     M: Send + 'static,
 {
+    #[instrument(skip(msg), err)]
     async fn send_async_safe(&self, msg: M) -> Result<(), xtra::Error> {
         if !self.is_connected() {
             return Err(xtra::Error::Disconnected);
@@ -65,6 +68,7 @@ impl<M, Rc: RefCounter> SendAsyncSafe<M, ()> for MessageChannel<M, (), Rc>
 where
     M: Send + 'static,
 {
+    #[instrument(skip(msg), err)]
     async fn send_async_safe(&self, msg: M) -> Result<(), xtra::Error> {
         let _ = self.send(msg).split_receiver().await;
 
@@ -83,6 +87,7 @@ where
     M: Send + 'static,
     Rc: RefCounter,
 {
+    #[instrument(skip(msg), err)]
     async fn send_async_safe(&self, msg: M) -> Result<(), xtra::Error> {
         if !self.is_connected() {
             return Err(xtra::Error::Disconnected);

--- a/xtras/src/supervisor.rs
+++ b/xtras/src/supervisor.rs
@@ -7,6 +7,7 @@ use std::ops::ControlFlow;
 use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::time::Duration;
+use tracing::Instrument;
 use xtra::Address;
 use xtra::Context;
 
@@ -44,7 +45,9 @@ where
     let wait_time = wait_time;
     Box::new(move |_: &E| {
         Box::pin(async move {
-            tokio_extras::time::sleep(wait_time).await;
+            tokio_extras::time::sleep(wait_time)
+                .instrument(tracing::trace_span!("Wait before restarting actor"))
+                .await;
             true
         })
     })


### PR DESCRIPTION
This adds more spans, which makes the jaeger span search a bit more readable - more semantic names, and less `xtra_actor_request` at the top level. I also set the level filter for traces to DEBUG, and added a new `sleep_silent` which does not emit a span.

~~This is a draft, as it requires some changes in xtra to be merged first.~~ I will switch this PR over to xtra master on Monday, rebase, and it should be ready for review.

## Before

This is with the backported DEBUG filter for a fair comparison.

![view of jaeger before this change](https://user-images.githubusercontent.com/6688948/177989071-8615e9b1-b456-451c-9619-d48e23df40d2.png)

This is kinda hard to read without opening all the spans manually to see what message they are.

## After

More readable at a glance, with semantically named spans representing the *purpose* of the operations being done in the code (e.g receive a new quote), rather than the *mechanism* by which they are carried out (i.e an actor request).

![view of jaeger after this change](https://user-images.githubusercontent.com/6688948/177988174-bdd20b79-9725-4236-9d8f-e6b2f5b0bbec.png)


