### PR TITLE
Temporary increase wait time for state changes

### DIFF
--- a/daemon-tests/src/flow.rs
+++ b/daemon-tests/src/flow.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use tokio::sync::watch;
 
 /// Waiting time for the time on the watch channel before returning error
-const NEXT_WAIT_TIME: Duration = Duration::from_secs(if cfg!(debug_assertions) { 60 } else { 30 });
+const NEXT_WAIT_TIME: Duration = Duration::from_secs(if cfg!(debug_assertions) { 90 } else { 30 });
 
 pub async fn next_maker_offers(
     rx_a: &mut watch::Receiver<MakerOffers>,


### PR DESCRIPTION
This is an attempt to temporarily fix failing macos test job on CI - an
underlying regression makes the tests not finish within previously working
constraints, particularly in the rollover case.