### PR TITLE
Add support for tokio console

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,8 +6,11 @@ dev-maker = "run --bin maker -- --instrumentation testnet"
 dev-taker = "run --bin taker -- --instrumentation --maker localhost:9999 --maker-id 10d4ba2ac3f7a22da4009d813ff1bc3f404dfe2cc93a32bedf1512aa9951c95e --maker-peer-id 12D3KooWDjzHna3pNi1Bt1DoRfrpsBREykJKXDRDxXvhJNAdDZEk testnet" # Maker ID matches seed found in `testnet/maker_seed`
 
 # Inspired by https://github.com/EmbarkStudios/rust-ecosystem/pull/68.
+# tokio_unstable enabled for tokio_console and tokio_metrics only
 [build]
 rustflags = [
+  "--cfg",
+  "tokio_unstable",
   "-Wclippy::disallowed_methods",
   "-Wclippy::dbg_macro",
   "-Wclippy::print_stderr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +221,49 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4af7447fc1214c1f3a1ace861d0216a6c8bb13965b64bbad9650f375b67689a"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa 1.0.1",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bdc19781b16e32f8a7200368a336fa4509d4b72ef15dd4e41df5290855ee1e6"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+]
 
 [[package]]
 name = "base64"
@@ -570,6 +619,42 @@ name = "conquer-util"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e763eef8846b13b380f37dfecda401770b0ca4e56e95170237bd7c25c7db3582"
+
+[[package]]
+name = "console-api"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c5fd425783d81668ed68ec98408a80498fb4ae2fd607797539e1a9dfa3618f"
+dependencies = [
+ "prost 0.10.4",
+ "prost-types 0.10.1",
+ "tonic 0.7.2",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31432bc31ff8883bf6a693a79371862f73087822470c82d6a1ec778781ee3978"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "prost-types 0.10.1",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.7.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "cookie"
@@ -1076,6 +1161,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,6 +1477,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
+dependencies = [
+ "base64",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1591,12 @@ name = "httpdate"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1903,6 +2023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,6 +2072,15 @@ checksum = "da39fc7a8adea97a677337b0091779dd86349226b869053af496584a9b9e5847"
 dependencies = [
  "bitcoin",
  "serde",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -2437,7 +2572,7 @@ dependencies = [
  "prost 0.9.0",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.6.2",
  "tonic-build",
 ]
 
@@ -3747,6 +3882,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "console-subscriber",
  "daemon",
  "http-api-problem",
  "model",
@@ -4122,6 +4258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4317,6 +4459,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "winapi 0.3.9",
 ]
 
@@ -4471,6 +4614,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.10.4",
+ "prost-derive 0.10.1",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.3",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4500,6 +4675,25 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/bitmex-stream/Cargo.toml
+++ b/bitmex-stream/Cargo.toml
@@ -9,7 +9,7 @@ description = "A stable and simple connection to BitMex's websocket API."
 [dependencies]
 async-stream = "0.3"
 futures = "0.3"
-tokio = { version = "1", features = ["macros", "time"] }
+tokio = { version = "1", features = ["macros", "time", "tracing"] }
 tokio-extras = { path = "../tokio-extras" }
 tokio-tungstenite = { version = "0.15", features = ["rustls-tls"] }
 tracing = "0.1"

--- a/daemon-tests/Cargo.toml
+++ b/daemon-tests/Cargo.toml
@@ -18,7 +18,7 @@ rust_decimal = "1.25"
 rust_decimal_macros = "1.25"
 sqlite-db = { path = "../sqlite-db" }
 time = "0.3.11"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "tracing"] }
 tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter", "local-time", "tracing-log", "json"] }

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -43,7 +43,7 @@ sqlx = { version = "0.6.0", features = ["offline", "sqlite", "uuid", "runtime-to
 statrs = "0.15"
 thiserror = "1"
 time = { version = "0.3.11", features = ["serde", "macros", "parsing", "formatting", "serde-well-known"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "tracing"] }
 tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tracing = { version = "0.1" }

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -29,7 +29,7 @@ shared-bin = { path = "../shared-bin" }
 sqlite-db = { path = "../sqlite-db" }
 thiserror = "1"
 time = { version = "0.3.11", features = ["serde", "macros", "parsing", "formatting", "serde-well-known"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "tracing"] }
 tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tracing = { version = "0.1" }

--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -42,6 +42,10 @@ pub struct Opts {
     #[clap(long)]
     pub instrumentation: bool,
 
+    /// If enabled, tokio runtime can be locally debugged with tokio_console
+    #[clap(long)]
+    pub tokio_console: bool,
+
     /// OTEL collector endpoint address
     ///
     /// If not specified it defaults to the local collector endpoint.

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -35,6 +35,7 @@ async fn main() -> Result<()> {
         opts.log_level,
         opts.json,
         opts.instrumentation,
+        opts.tokio_console,
         "maker",
         &opts.collector_endpoint,
     )

--- a/shared-bin/Cargo.toml
+++ b/shared-bin/Cargo.toml
@@ -10,6 +10,7 @@ description = "Code that is shared between the daemons but application specific 
 [dependencies]
 anyhow = "1"
 atty = "0.2"
+console-subscriber = "0.1.6"
 daemon = { path = "../daemon" }
 http-api-problem = { version = "0.53.0", features = ["rocket"] }
 model = { path = "../model" }

--- a/sqlite-db/Cargo.toml
+++ b/sqlite-db/Cargo.toml
@@ -29,4 +29,4 @@ x25519-dalek = "1.1"
 
 [dev-dependencies]
 pretty_assertions = "1"
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "tracing"] }

--- a/taker/Cargo.toml
+++ b/taker/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1", features = ["derive"] }
 shared-bin = { path = "../shared-bin" }
 sqlite-db = { path = "../sqlite-db" }
 time = "0.3.11"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "tracing"] }
 tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tracing = { version = "0.1" }
 uuid = "0.8"

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -90,6 +90,10 @@ struct Opts {
     #[clap(long)]
     instrumentation: bool,
 
+    /// If enabled, tokio runtime can be locally debugged with tokio_console
+    #[clap(long)]
+    pub tokio_console: bool,
+
     /// OTEL collector endpoint address
     ///
     /// If not specified it defaults to the local collector endpoint.
@@ -299,6 +303,7 @@ async fn main() -> Result<()> {
         opts.log_level,
         opts.json,
         opts.instrumentation,
+        opts.tokio_console,
         "taker",
         &opts.collector_endpoint,
     )

--- a/tokio-extras/Cargo.toml
+++ b/tokio-extras/Cargo.toml
@@ -7,9 +7,9 @@ description = "Utilities for working with tokio, including instrumented futures 
 [dependencies]
 futures = { version = "0.3", default-features = false, features = ["std"] }
 pin-project-lite = "0.2.9"
-tokio = { version = "1", default-features = false, features = ["rt-multi-thread"] }
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "tracing"] }
 tracing = { version = "0.1.35" }
 xtra = { version = "0.6", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["time", "macros"] }
+tokio = { version = "1", features = ["time", "macros", "tracing"] }

--- a/xtra-libp2p-offer/Cargo.toml
+++ b/xtra-libp2p-offer/Cargo.toml
@@ -13,7 +13,7 @@ futures = { version = "0.3", default-features = false }
 model = { path = "../model" }
 prometheus = { version = "0.13", default-features = false }
 thiserror = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "tracing"] }
 tokio-extras = { path = "../tokio-extras" }
 tracing = "0.1"
 xtra = { version = "0.6" }
@@ -26,5 +26,5 @@ rust_decimal = "1.25"
 rust_decimal_macros = "1.25"
 sluice = "0.5"
 time = { version = "0.3.11", features = ["macros"] }
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "tracing"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }

--- a/xtra-libp2p-ping/Cargo.toml
+++ b/xtra-libp2p-ping/Cargo.toml
@@ -13,7 +13,7 @@ conquer-once = "0.3"
 futures = "0.3"
 prometheus = { version = "0.13", default-features = false }
 rand = "0.8"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "tracing"] }
 tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tracing = "0.1"
 xtra = "0.6"

--- a/xtra-libp2p/Cargo.toml
+++ b/xtra-libp2p/Cargo.toml
@@ -17,7 +17,7 @@ multistream-select = "0.11"
 pin-project = "1"
 prometheus = { version = "0.13", default-features = false }
 thiserror = "1"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["time", "tracing"] }
 tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tracing = "0.1"
 void = "1"

--- a/xtras/Cargo.toml
+++ b/xtras/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 async-trait = "0.1.56"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 thiserror = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "tracing"] }
 tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tracing = { version = "0.1" }
 uuid = { version = "1.1", features = ["v4"] }


### PR DESCRIPTION
Tokio console support can be enabled by passing `--tokio-console` flag to maker
or taker binary.

When enabled, it is possible to see spawned tasks via `tokio-console` CLI util.

See more: https://docs.rs/tokio-console/