### PR TITLE
Remove spammy return values from instrumented GET requests

### DIFF
--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -250,7 +250,7 @@ pub async fn get_cfds<'r>(
 }
 
 #[rocket::get("/takers")]
-#[instrument(name = "GET /takers", skip(rx), ret, err)]
+#[instrument(name = "GET /takers", skip(rx), err)]
 pub async fn get_takers<'r>(
     rx: &State<Feeds>,
     _auth: Authenticated,
@@ -263,7 +263,7 @@ pub async fn get_takers<'r>(
 }
 
 #[rocket::get("/metrics")]
-#[instrument(name = "GET /metrics", ret, err)]
+#[instrument(name = "GET /metrics", err)]
 pub async fn get_metrics<'r>(_auth: Authenticated) -> Result<String, HttpApiProblem> {
     let metrics = prometheus::TextEncoder::new()
         .encode_to_string(&prometheus::gather())

--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -287,7 +287,7 @@ pub async fn post_withdraw_request(
 }
 
 #[rocket::get("/metrics")]
-#[instrument(name = "GET /metrics", ret, err)]
+#[instrument(name = "GET /metrics", err)]
 pub async fn get_metrics<'r>(_auth: Authenticated) -> Result<String, HttpApiProblem> {
     let metrics = prometheus::TextEncoder::new()
         .encode_to_string(&prometheus::gather())


### PR DESCRIPTION
GET /metrics would print all the metric values, which whole purpose is to be
used in prometheus metrics, not in loki/tempo.

taker identities are also already collected in a different place.