### PR TITLE
Bump xtra to try to fix panic when using grafana agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5371,7 +5371,7 @@ dependencies = [
 [[package]]
 name = "xtra"
 version = "0.6.0"
-source = "git+https://github.com/comit-network/xtra?branch=span-late-create#764260a53bab43a22c2c6b81ffd7e8e53aeb2d44"
+source = "git+https://github.com/comit-network/xtra?branch=span-late-create-improved#58030512b5d133a30bec976b1056de14ab3517d9"
 dependencies = [
  "async-trait",
  "catty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-xtra = { git = "https://github.com/comit-network/xtra", branch = "span-late-create" } # TODO Switch back to xtra/master after https://github.com/Restioson/xtra/pull/120 gets merged
+xtra = { git = "https://github.com/comit-network/xtra", branch = "span-late-create-improved" } # TODO Switch back to xtra/master after https://github.com/Restioson/xtra/pull/120 gets merged
 maia = { git = "https://github.com/comit-network/maia", rev = "fc6b78b98407b10b55f8cfd152062ad77f98cd9f" } # Unreleased
 maia-core = { git = "https://github.com/comit-network/maia", tag = "0.1.1", package = "maia-core" } # Pinned to support maia 0.1 and 0.2
 xtra_productivity = { git = "https://github.com/comit-network/xtra-productivity", rev = "0bfd589b42a63149221dec7e95aca932875374dd" } # Unreleased


### PR DESCRIPTION
When using grafana agent, we started encountering multiple panics in the logs.
This might be either due to a bug in a 3rd-party crate (tracing-subscriber)or us
misusing that crate.

changes in xtra:
   -  add more asserts
   -  removes redundant `parent` argument in debug_span! invocation.