### PR TITLE
Remove duplicated 'Revoked logic not implemented' error message

### DIFF
--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -296,7 +296,7 @@ impl Cfd {
             | CollaborativeSettlementFailed
             | CollaborativeSettlementProposalAccepted => self,
             RevokeConfirmed => {
-                tracing::error!("Revoked logic not implemented");
+                // TODO: Implement revoked logic
                 self
             }
         }

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -547,7 +547,7 @@ impl Cfd {
                 self.aggregated.state = CfdState::PendingCommit;
             }
             RevokeConfirmed => {
-                tracing::error!(order_id = %self.order_id, "Revoked logic not implemented");
+                // TODO: Implement revoked logic
                 self.aggregated.state = CfdState::OpenCommitted;
             }
             RolloverStarted { .. } => {


### PR DESCRIPTION
This issue is tracked in the issue tracker:
https://github.com/itchysats/itchysats/issues/907

We became blind to this error message (even turned it off on our mainnet maker).
Meanwhile, testnet is spammed with hundreds of these error messages whenever we restart.