### PR TITLE
Add test spans

### DIFF
--- a/xtras/src/send_async_safe.rs
+++ b/xtras/src/send_async_safe.rs
@@ -47,11 +47,11 @@ where
             return Err(xtra::Error::Disconnected);
         }
 
-        let send_fut = self.send(msg);
+        let rx = self.send(msg).split_receiver().await;
 
         #[allow(clippy::disallowed_methods)]
         tokio::spawn(async {
-            let e = match send_fut.await {
+            let e = match rx.await {
                 Ok(Err(e)) => format!("{e:#}"),
                 Err(e) => format!("{e:#}"),
                 Ok(Ok(())) => return,


### PR DESCRIPTION
On testnet, some spans in handle connection ready last for 3 minutes... this is strange, since there are no children lasting this long, and the handler prints that it's done!

This adds some extra spans just to try close in on this suspected trace time leak.

CC @klochowicz 