### PR TITLE
Do not block `Endpoint` when opening substreams

### DIFF
--- a/daemon/src/collab_settlement/protocol.rs
+++ b/daemon/src/collab_settlement/protocol.rs
@@ -41,6 +41,8 @@ pub async fn dialer(
         .send(OpenSubstream::single_protocol(counterparty, PROTOCOL))
         .await
         .context("Endpoint is disconnected")?
+        .context("No connection to peer")?
+        .await
         .context("Failed to open substream")?;
     let mut framed = asynchronous_codec::Framed::new(
         substream,

--- a/daemon/src/rollover/taker.rs
+++ b/daemon/src/rollover/taker.rs
@@ -82,15 +82,19 @@ impl Actor {
 impl Actor {
     #[tracing::instrument(skip(self))]
     async fn open_substream(&self, peer_id: PeerId) -> anyhow::Result<Substream> {
-        Ok(self
+        let substream = self
             .endpoint
             .send(OpenSubstream::single_protocol(
                 peer_id.inner(),
                 rollover::PROTOCOL,
             ))
             .await
-            .context("Endpoint is disconnected")
-            .context("Failed to open substream")??)
+            .context("Endpoint is disconnected")?
+            .context("No connection to peer")?
+            .await
+            .context("Failed to open substream")?;
+
+        Ok(substream)
     }
 }
 

--- a/xtra-libp2p-offer/src/maker.rs
+++ b/xtra-libp2p-offer/src/maker.rs
@@ -36,7 +36,8 @@ impl Actor {
         let task = async move {
             let stream = endpoint
                 .send(OpenSubstream::single_protocol(peer, PROTOCOL_NAME))
-                .await??;
+                .await??
+                .await?;
 
             protocol::send(stream, offers).await?;
 

--- a/xtra-libp2p-ping/src/ping.rs
+++ b/xtra-libp2p-ping/src/ping.rs
@@ -115,7 +115,8 @@ impl Actor {
                 async move {
                     let stream = endpoint
                         .send(OpenSubstream::single_protocol(peer, PROTOCOL_NAME))
-                        .await??;
+                        .await??
+                        .await?;
                     let latency = protocol::send(stream).await?;
 
                     this.send_async_safe(RecordLatency { peer, latency })

--- a/xtra-libp2p/examples/hello_world_dialer.rs
+++ b/xtra-libp2p/examples/hello_world_dialer.rs
@@ -66,6 +66,8 @@ async fn main() -> Result<()> {
         ))
         .await
         .unwrap()
+        .unwrap()
+        .await
         .unwrap();
 
     let message = hello_world_dialer(stream, opts.name).await.unwrap();

--- a/xtra-libp2p/tests/basic.rs
+++ b/xtra-libp2p/tests/basic.rs
@@ -47,6 +47,8 @@ async fn hello_world() {
         ))
         .await
         .unwrap()
+        .unwrap()
+        .await
         .unwrap();
 
     let string = hello_world_dialer(bob_to_alice, "Bob").await.unwrap();
@@ -210,6 +212,8 @@ async fn cannot_open_substream_for_unhandled_protocol() {
         ))
         .await
         .unwrap()
+        .unwrap()
+        .await
         .unwrap_err();
 
     assert!(matches!(
@@ -260,6 +264,8 @@ async fn chooses_first_protocol_in_list_of_multiple() {
         ))
         .await
         .unwrap()
+        .unwrap()
+        .await
         .unwrap();
 
     assert_eq!(actual_protocol, "/hello-world/1.0.0");
@@ -299,6 +305,8 @@ async fn falls_back_to_next_protocol_if_unsupported() {
         ))
         .await
         .unwrap()
+        .unwrap()
+        .await
         .unwrap();
 
     assert_eq!(actual_protocol, "/hello-world/1.0.0");


### PR DESCRIPTION
Fixes #2414 (I think).

It is sufficient to just look for the corresponding `yamux::Control` for a particular peer inside `Endpoint` and then release the lock (by returning from the handler).

The actual opening of the substream using `yamux` can be delegated to a future which is returned to the caller, who must `await` it.