### PR TITLE
Cleanup timeout instrumentation

### DIFF
--- a/daemon-tests/src/flow.rs
+++ b/daemon-tests/src/flow.rs
@@ -54,8 +54,8 @@ where
         }
     };
 
-    let val = tokio_extras::time::timeout(NEXT_WAIT_TIME, wait_until_predicate, |parent| {
-        tracing::debug_span!(parent: parent, "wait until predicate")
+    let val = tokio_extras::time::timeout(NEXT_WAIT_TIME, wait_until_predicate, || {
+        tracing::debug_span!("wait until predicate")
     })
     .await
     .with_context(|| {

--- a/daemon/src/collab_settlement/maker.rs
+++ b/daemon/src/collab_settlement/maker.rs
@@ -156,7 +156,7 @@ impl Actor {
 
                     let DialerSignature { dialer_signature } = framed
                         .next()
-                        .timeout(SETTLEMENT_MSG_TIMEOUT, |parent| tracing::debug_span!(parent: parent, "receive dialer signature"))
+                        .timeout(SETTLEMENT_MSG_TIMEOUT, || tracing::debug_span!("receive dialer signature"))
                         .await
                         .with_context(|| {
                             format!(

--- a/daemon/src/collab_settlement/protocol.rs
+++ b/daemon/src/collab_settlement/protocol.rs
@@ -62,8 +62,8 @@ pub async fn dialer(
 
     if let Decision::Reject = framed
         .next()
-        .timeout(DECISION_TIMEOUT, |parent| {
-            tracing::debug_span!(parent: parent, "receive decision")
+        .timeout(DECISION_TIMEOUT, || {
+            tracing::debug_span!("receive decision")
         })
         .await
         .with_context(|| {

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -178,8 +178,8 @@ impl Actor {
 
         let (mut write, mut read) = {
             let mut connection = TcpStream::connect(&maker_addr)
-                .timeout(self.connect_timeout, |parent| {
-                    tracing::debug_span!(parent: parent, "TcpStream connect")
+                .timeout(self.connect_timeout, || {
+                    tracing::debug_span!("TcpStream connect")
                 })
                 .await
                 .with_context(|| {
@@ -208,12 +208,12 @@ impl Actor {
                 environment: self.environment.into(),
             })
             .instrument(tracing::debug_span!("send hello"))
-            .timeout(TCP_TIMEOUT, |parent| parent.clone())
+            .timeout(TCP_TIMEOUT, already_instrumented)
             .await??;
 
         match read
             .try_next()
-            .timeout(TCP_TIMEOUT, |parent| tracing::debug_span!(parent: parent, "receive hello"))
+            .timeout(TCP_TIMEOUT, already_instrumented)
             .await
             .with_context(|| {
                 format!(

--- a/daemon/src/rollover/maker.rs
+++ b/daemon/src/rollover/maker.rs
@@ -163,8 +163,8 @@ impl Actor {
             short_funding_rate,
         } = msg;
 
-        fn next_rollover_span(parent: &tracing::Span) -> tracing::Span {
-            tracing::debug_span!(parent: parent, "next rollover message")
+        fn next_rollover_span() -> tracing::Span {
+            tracing::debug_span!("next rollover message")
         }
 
         let (mut framed, _, from_params) =

--- a/daemon/src/rollover/taker.rs
+++ b/daemon/src/rollover/taker.rs
@@ -145,8 +145,8 @@ impl Actor {
 
                     match framed
                         .next()
-                        .timeout(DECISION_TIMEOUT, |parent| {
-                            tracing::debug_span!(parent: parent, "receive decision")
+                        .timeout(DECISION_TIMEOUT, || {
+                            tracing::debug_span!("receive decision")
                         })
                         .await
                         .with_context(|| {
@@ -203,8 +203,8 @@ impl Actor {
                                 .await
                                 .context("Failed to send Msg0")?;
 
-                            fn next_rollover_span(parent: &tracing::Span) -> tracing::Span {
-                                tracing::debug_span!(parent: parent, "next rollover message")
+                            fn next_rollover_span() -> tracing::Span {
+                                tracing::debug_span!("next rollover message")
                             }
 
                             let msg0 = framed

--- a/daemon/src/setup_contract.rs
+++ b/daemon/src/setup_contract.rs
@@ -78,8 +78,8 @@ pub async fn new(
         publish_pk,
     };
 
-    fn stream_next_span(parent: &tracing::Span) -> tracing::Span {
-        tracing::debug_span!(parent: parent, "SetupMsg stream next")
+    fn stream_next_span() -> tracing::Span {
+        tracing::debug_span!("SetupMsg stream next")
     }
 
     sink.send(SetupMsg::Msg0(Msg0::from((own_params.clone(), own_punish))))

--- a/daemon/src/setup_contract_deprecated.rs
+++ b/daemon/src/setup_contract_deprecated.rs
@@ -690,8 +690,8 @@ pub async fn roll_over(
     })
 }
 
-fn stream_select_next_span(parent: &tracing::Span) -> tracing::Span {
-    tracing::debug_span!(parent: parent, "SetupMsg stream select_next_some")
+fn stream_select_next_span() -> tracing::Span {
+    tracing::debug_span!("SetupMsg stream select_next_some")
 }
 
 /// A convenience struct for storing PartyParams and PunishParams of both

--- a/maker/src/cfd.rs
+++ b/maker/src/cfd.rs
@@ -452,8 +452,8 @@ impl<O, T, W> Actor<O, T, W> {
         match self
             .setup_actors
             .send(&order_id, contract_setup::Accepted)
-            .timeout(HANDLE_ACCEPT_CONTRACT_SETUP_MESSAGE_TIMEOUT, |parent| {
-                tracing::debug_span!(parent: parent, "send contract_setup::Accepted")
+            .timeout(HANDLE_ACCEPT_CONTRACT_SETUP_MESSAGE_TIMEOUT, || {
+                tracing::debug_span!("send contract_setup::Accepted")
             })
             .await
         {
@@ -486,8 +486,8 @@ impl<O, T, W> Actor<O, T, W> {
         match self
             .setup_actors
             .send(&order_id, contract_setup::Rejected)
-            .timeout(HANDLE_ACCEPT_CONTRACT_SETUP_MESSAGE_TIMEOUT, |parent| {
-                tracing::debug_span!(parent: parent, "send contract_setup::Rejected")
+            .timeout(HANDLE_ACCEPT_CONTRACT_SETUP_MESSAGE_TIMEOUT, || {
+                tracing::debug_span!("send contract_setup::Rejected")
             })
             .await
         {

--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -188,9 +188,7 @@ impl Connection {
 
         self.write
             .send(msg)
-            .timeout(TCP_TIMEOUT, |parent| {
-                tracing::debug_span!(parent: parent, "send to taker")
-            })
+            .timeout(TCP_TIMEOUT, || tracing::debug_span!("send to taker"))
             .await
             .with_context(|| format!("Failed to send msg {msg_str} to taker {taker_id}"))??;
         Ok(())
@@ -640,8 +638,8 @@ async fn upgrade(
 
     let first_message = read
         .try_next()
-        .timeout(Duration::from_secs(10), |parent| {
-            tracing::debug_span!(parent: parent, "receive message from taker")
+        .timeout(Duration::from_secs(10), || {
+            tracing::debug_span!("receive message from taker")
         })
         .await
         .context("No message from taker within 10 seconds")?

--- a/tokio-extras/src/future_ext.rs
+++ b/tokio-extras/src/future_ext.rs
@@ -20,7 +20,7 @@ pub trait FutureExt: Future + Sized {
     /// an error if time runs out. This is instrumented, unlike `tokio::time::timeout`. The
     /// `child_span` function constructs the span for the child future from the span of the parent
     /// (timeout) future.
-    fn timeout(self, duration: Duration, child_span: impl FnOnce(&Span) -> Span) -> Timeout<Self>;
+    fn timeout(self, duration: Duration, child_span: fn() -> Span) -> Timeout<Self>;
 }
 
 impl<F> FutureExt for F
@@ -44,7 +44,7 @@ where
         handle
     }
 
-    fn timeout(self, duration: Duration, child_span: impl FnOnce(&Span) -> Span) -> Timeout<F> {
+    fn timeout(self, duration: Duration, child_span: fn() -> Span) -> Timeout<F> {
         crate::time::timeout(duration, self, child_span)
     }
 }

--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -281,9 +281,8 @@ impl Endpoint {
         let (protocol, stream) = tokio_extras::time::timeout(
             connection_timeout,
             multistream_select::dialer_select_proto(stream, protocols, Version::V1),
-            |parent| tracing::debug_span!(parent: parent, "dialer_select_proto", version = ?Version::V1)
+            || tracing::debug_span!("dialer_select_proto", version = ?Version::V1),
         )
-        .instrument(tracing::debug_span!("timeout dialing select proto", timeout_secs = connection_timeout.as_secs()))
         .await
         .map_err(|_timeout| Error::NegotiationTimeoutReached)?
         .map_err(Error::NegotiationFailed)?;
@@ -414,7 +413,7 @@ impl Endpoint {
                     let (peer, control, incoming_substreams, worker) = tokio_extras::time::timeout(
                         connection_timeout,
                         transport.dial(msg.0)?,
-                        |parent| tracing::debug_span!(parent: parent, "transport dial"),
+                        || tracing::debug_span!("transport dial"),
                     )
                     .await
                     .context("Dialing timed out")??;

--- a/xtra-libp2p/src/upgrade.rs
+++ b/xtra-libp2p/src/upgrade.rs
@@ -136,13 +136,7 @@ where
                     let result = tokio_extras::time::timeout(
                         connection_timeout,
                         multistream_select::listener_select_proto(stream, &supported_protocols),
-                        |parent| {
-                            tracing::debug_span!(
-                                parent: parent,
-                                "listener_select_proto",
-                                ?supported_protocols
-                            )
-                        },
+                        || tracing::debug_span!("listener_select_proto"),
                     )
                     .await;
 
@@ -153,7 +147,10 @@ where
                     }
                 };
 
-                fut.instrument(tracing::debug_span!("Select protocol for incoming stream"))
+                fut.instrument(tracing::debug_span!(
+                    "Select protocol for incoming stream",
+                    ?supported_inbound_protocols
+                ))
             })
             .boxed();
 


### PR DESCRIPTION
This ensures that the span is only created at first poll, as well as removing the redundant `parent` argument from the child span constructor function by just running it in the scope of the parent