### PR TITLE
Add xtras::SendNext trait to schedule prioritised messages

### DIFF
--- a/daemon/src/auto_rollover.rs
+++ b/daemon/src/auto_rollover.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use time::OffsetDateTime;
 use xtra::Address;
 use xtra_productivity::xtra_productivity;
-use xtras::SendAsyncSafe;
+use xtras::SendAsyncNext;
 use xtras::SendInterval;
 
 pub struct Actor {
@@ -96,15 +96,13 @@ impl Actor {
 
             match cfd.can_auto_rollover_taker(OffsetDateTime::now_utc()) {
                 Ok((from_commit_txid, from_settlement_event_id)) => {
-                    // If we disconnect, we don't care.
-                    let _ = this
-                        .send_async_safe(Rollover {
-                            order_id: id,
-                            maker_peer_id,
-                            from_commit_txid,
-                            from_settlement_event_id,
-                        })
-                        .await;
+                    this.send_async_next(Rollover {
+                        order_id: id,
+                        maker_peer_id,
+                        from_commit_txid,
+                        from_settlement_event_id,
+                    })
+                    .await;
                 }
                 Err(reason) => {
                     tracing::trace!(order_id = %id, %reason, "CFD is not eligible for auto-rollover");

--- a/daemon/src/position_metrics.rs
+++ b/daemon/src/position_metrics.rs
@@ -20,7 +20,7 @@ use rust_decimal::Decimal;
 use sqlite_db;
 use std::collections::HashMap;
 use xtra_productivity::xtra_productivity;
-use xtras::SendAsyncSafe;
+use xtras::SendAsyncNext;
 
 pub struct Actor {
     db: sqlite_db::Connection,
@@ -47,9 +47,7 @@ impl xtra::Actor for Actor {
 
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("we are alive");
-        this.send_async_safe(Initialize)
-            .await
-            .expect("we just started");
+        this.send_async_next(Initialize).await;
     }
 
     async fn stopped(self) -> Self::Stop {}

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -58,7 +58,7 @@ use tracing::info_span;
 use tracing::Instrument;
 use xtra::prelude::MessageChannel;
 use xtra_productivity::xtra_productivity;
-use xtras::SendAsyncSafe;
+use xtras::SendAsyncNext;
 
 /// Store the latest state of `T` for display purposes
 /// (replaces previously stored values)
@@ -1115,7 +1115,7 @@ impl State {
 
 #[xtra_productivity]
 impl Actor {
-    async fn handle(&mut self, _: Initialize) -> Result<()> {
+    async fn handle(&mut self, _: Initialize) {
         let mut stream = self.db.load_all_cfds::<Cfd>(self.state.network);
 
         let mut cfds = HashMap::new();
@@ -1141,8 +1141,6 @@ impl Actor {
                 .expect("we initialized the state above; qed"),
             self.state.quote,
         );
-
-        Ok(())
     }
 
     async fn handle(&mut self, msg: CfdChanged) {
@@ -1189,9 +1187,7 @@ impl xtra::Actor for Actor {
     type Stop = ();
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("we just started");
-        this.send_async_safe(Initialize)
-            .await
-            .expect("we just started");
+        this.send_async_next(Initialize).await;
 
         tokio_extras::spawn(&this.clone(), {
             let price_feed = self.price_feed.clone();

--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -33,6 +33,7 @@ use xtra::message_channel::MessageChannel;
 use xtra_productivity::xtra_productivity;
 use xtras::address_map::NotConnected;
 use xtras::AddressMap;
+use xtras::SendAsyncNext;
 use xtras::SendAsyncSafe;
 use xtras::SendInterval;
 
@@ -288,7 +289,7 @@ impl Actor {
         {
             Ok(listener) => listener,
             Err(error) => {
-                let _ = this.send_async_safe(ListenerFailed { error }).await;
+                this.send_async_next(ListenerFailed { error }).await;
                 return;
             }
         };

--- a/xtra-libp2p-ping/src/ping.rs
+++ b/xtra-libp2p-ping/src/ping.rs
@@ -17,7 +17,7 @@ use xtra_libp2p::Endpoint;
 use xtra_libp2p::GetConnectionStats;
 use xtra_libp2p::OpenSubstream;
 use xtra_productivity::xtra_productivity;
-use xtras::SendAsyncSafe;
+use xtras::SendAsyncNext;
 use xtras::SendInterval;
 
 /// An actor implementing the official ipfs/libp2p ping protocol.
@@ -119,9 +119,7 @@ impl Actor {
                         .await?;
                     let latency = protocol::send(stream).await?;
 
-                    this.send_async_safe(RecordLatency { peer, latency })
-                        .await?;
-
+                    this.send_async_next(RecordLatency { peer, latency }).await;
                     anyhow::Ok(())
                 }
             };

--- a/xtra-libp2p/src/dialer.rs
+++ b/xtra-libp2p/src/dialer.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use tracing::instrument;
 use xtra::Address;
 use xtra_productivity::xtra_productivity;
-use xtras::SendAsyncSafe;
+use xtras::SendAsyncNext;
 
 /// If we're not connected by this time, stop the actor.
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
@@ -75,7 +75,7 @@ impl xtra::Actor for Actor {
         }
 
         let this = ctx.address().expect("self to be alive");
-        this.send_async_safe(Dial).await.expect("self to be alive");
+        this.send_async_next(Dial).await;
     }
 
     async fn stopped(self) -> Self::Stop {

--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -34,6 +34,7 @@ use xtra::message_channel::MessageChannel;
 use xtra::Address;
 use xtra::Context;
 use xtra_productivity::xtra_productivity;
+use xtras::SendAsyncNext;
 use xtras::SendAsyncSafe;
 
 /// An actor for managing multiplexed connections over a given transport thus representing an
@@ -349,7 +350,8 @@ impl Endpoint {
                 }
             },
             move |error| async move {
-                let _ = this.send(ExistingConnectionFailed { peer, error }).await;
+                this.send_async_next(ExistingConnectionFailed { peer, error })
+                    .await;
             },
         );
 
@@ -419,14 +421,13 @@ impl Endpoint {
                     .await
                     .context("Dialing timed out")??;
 
-                    let _ = this
-                        .send_async_safe(NewConnection {
-                            peer,
-                            control,
-                            incoming_substreams,
-                            worker,
-                        })
-                        .await;
+                    this.send_async_next(NewConnection {
+                        peer,
+                        control,
+                        incoming_substreams,
+                        worker,
+                    })
+                    .await;
 
                     anyhow::Ok(())
                 };
@@ -434,7 +435,7 @@ impl Endpoint {
                 fut.instrument(tracing::debug_span!("Dial new connection"))
             },
             move |error| async move {
-                let _ = this.send(FailedToConnect { peer, error }).await;
+                this.send_async_next(FailedToConnect { peer, error }).await;
             },
         );
 
@@ -479,14 +480,13 @@ impl Endpoint {
                                     async move {
                                         let (peer, control, incoming_substreams, worker) =
                                             upgrade.await?;
-                                        this.send_async_safe(NewConnection {
+                                        this.send_async_next(NewConnection {
                                             peer,
                                             control,
                                             incoming_substreams,
                                             worker,
                                         })
-                                        .await
-                                        .context("can't send new connection message")?;
+                                        .await;
                                         Ok(())
                                     },
                                     move |e: anyhow::Error| async move {

--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -591,12 +591,9 @@ impl Endpoint {
         tracing::info!(%peer, "Connection established");
 
         for subscriber in &self.subscribers.connection_established {
-            if let Err(e) = subscriber
-                .send_async_safe(ConnectionEstablished { peer })
-                .await
-            {
-                tracing::warn!("Unable to reach subscriber: {e:#}");
-            }
+            subscriber
+                .send_async_next(ConnectionEstablished { peer })
+                .await;
         }
     }
 
@@ -604,9 +601,7 @@ impl Endpoint {
         tracing::info!(%peer, "Connection dropped");
 
         for subscriber in &self.subscribers.connection_dropped {
-            if let Err(e) = subscriber.send_async_safe(ConnectionDropped { peer }).await {
-                tracing::warn!("Unable to reach subscriber: {e:#}");
-            }
+            subscriber.send_async_next(ConnectionDropped { peer }).await
         }
     }
 
@@ -614,14 +609,11 @@ impl Endpoint {
         tracing::info!(address=%added, "Listen address added");
 
         for subscriber in &self.subscribers.listen_address_added {
-            if let Err(e) = subscriber
-                .send_async_safe(ListenAddressAdded {
+            subscriber
+                .send_async_next(ListenAddressAdded {
                     address: added.clone(),
                 })
-                .await
-            {
-                tracing::warn!("Unable to reach subscriber: {e:#}");
-            }
+                .await;
         }
     }
 
@@ -629,14 +621,11 @@ impl Endpoint {
         tracing::info!(address=%removed, "Listen address removed");
 
         for subscriber in &self.subscribers.listen_address_removed {
-            if let Err(e) = subscriber
-                .send_async_safe(ListenAddressRemoved {
+            subscriber
+                .send_async_next(ListenAddressRemoved {
                     address: removed.clone(),
                 })
                 .await
-            {
-                tracing::warn!("Unable to reach subscriber: {e:#}");
-            }
         }
     }
 }

--- a/xtra-libp2p/src/listener.rs
+++ b/xtra-libp2p/src/listener.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tracing::instrument;
 use xtra::Address;
 use xtra_productivity::xtra_productivity;
-use xtras::SendAsyncSafe;
+use xtras::SendAsyncNext;
 
 /// If we're not connected by this time, stop the actor.
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
@@ -77,9 +77,7 @@ impl xtra::Actor for Actor {
 
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("self to be alive");
-        this.send_async_safe(Listen)
-            .await
-            .expect("self to be alive");
+        this.send_async_next(Listen).await;
     }
 
     async fn stopped(self) -> Self::Stop {

--- a/xtras/src/lib.rs
+++ b/xtras/src/lib.rs
@@ -1,6 +1,7 @@
 mod actor_name;
 pub mod address_map;
 pub mod handler_timeout;
+mod send_async_next;
 mod send_async_safe;
 mod send_interval;
 pub mod supervisor;
@@ -8,5 +9,6 @@ pub mod supervisor;
 pub use actor_name::ActorName;
 pub use address_map::AddressMap;
 pub use handler_timeout::HandlerTimeoutExt;
+pub use send_async_next::SendAsyncNext;
 pub use send_async_safe::SendAsyncSafe;
 pub use send_interval::SendInterval;

--- a/xtras/src/send_async_next.rs
+++ b/xtras/src/send_async_next.rs
@@ -1,0 +1,52 @@
+use async_trait::async_trait;
+use tracing::instrument;
+use xtra::message_channel::MessageChannel;
+use xtra::refcount::RefCounter;
+
+/// Arbitrarily high number allowing flexibility of prioritising messages in actors
+const INTERNAL_MSG_PRIORITY: u32 = 100;
+
+#[async_trait]
+pub trait SendAsyncNext<M: Send + 'static, R> {
+    /// Dispatch a prioritised message to an actor without waiting for it to handle it.
+    ///
+    /// If the actor is not connected, it logs a warning.
+    async fn send_async_next(&self, msg: M);
+}
+
+#[async_trait]
+impl<A, M> SendAsyncNext<M, ()> for xtra::Address<A>
+where
+    A: xtra::Handler<M, Return = ()>,
+    M: Send + 'static,
+{
+    #[instrument(skip_all)]
+    async fn send_async_next(&self, msg: M) {
+        if !self.is_connected() {
+            tracing::warn!("Actor not connected when sending message");
+        }
+        let _ = self
+            .send(msg)
+            .priority(INTERNAL_MSG_PRIORITY)
+            .split_receiver()
+            .await;
+    }
+}
+
+#[async_trait]
+impl<M, Rc: RefCounter> SendAsyncNext<M, ()> for MessageChannel<M, (), Rc>
+where
+    M: Send + 'static,
+{
+    #[instrument(skip(msg))]
+    async fn send_async_next(&self, msg: M) {
+        if !self.is_connected() {
+            tracing::warn!("Actor not connected when sending message");
+        }
+        let _ = self
+            .send(msg)
+            .priority(INTERNAL_MSG_PRIORITY)
+            .split_receiver()
+            .await;
+    }
+}


### PR DESCRIPTION
`xtras::SendAsyncSafe` by default does not take priority into account, so the
message dispatched by an actor will get scheduled on the back of the queue.

send_next() will dispatch messages with fixed priority
INTERNAL_MSG_PRIORITY (currently set to 100). This trait should be preferred
over send_async_safe() in cases where state changes as a result of the message
    handler.

Examples where send_next() was used in this changeset:
- Subscribers want to know about changes in the Endpoint before they handle a
    new external requests (because e.g. a connection got dropped in the meantime)
- Endpoint wants to process newly created/dropped connection as soon as it can,
    instead of scheduling it on the queue.