### PR TITLE
Load tests that shows starving bobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
+name = "bindgen"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "boringssl-src"
+version = "0.3.0+688fc5c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f901accdf830d2ea2f4e27f923a5e1125cd8b1a39ab578b9db1a42d578a6922b"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +507,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+dependencies = [
+ "nom 5.1.2",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +564,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1434,6 +1482,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "grpcio"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d99e00eed7e0a04ee2705112e7cfdbe1a3cc771147f22f016a8cd2d002187b"
+dependencies = [
+ "futures",
+ "grpcio-sys",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+ "protobuf",
+]
+
+[[package]]
+name = "grpcio-sys"
+version = "0.9.1+1.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9447d1a926beeef466606cc45717f80897998b548e7dc622873d453e1ecb4be4"
+dependencies = [
+ "bindgen",
+ "boringssl-src",
+ "cc",
+ "cmake",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+ "walkdir",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,7 +1563,7 @@ dependencies = [
  "base64",
  "byteorder",
  "flate2",
- "nom",
+ "nom 7.0.0",
  "num-traits",
 ]
 
@@ -1772,6 +1850,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1871,16 @@ dependencies = [
  "libc",
  "libz-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+dependencies = [
+ "cfg-if",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2378,6 +2472,16 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
@@ -2567,9 +2671,11 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-util",
+ "grpcio",
  "http",
  "opentelemetry",
  "prost 0.9.0",
+ "protobuf",
  "thiserror",
  "tokio",
  "tonic 0.6.2",
@@ -2702,6 +2808,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -3022,6 +3134,12 @@ dependencies = [
  "bytes",
  "prost 0.10.4",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "quick-error"
@@ -3535,6 +3653,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3898,6 +4022,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4037,7 +4167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4b7922be017ee70900be125523f38bdd644f4f06a1b16e8fa5a8ee8c34bffd4"
 dependencies = [
  "itertools",
- "nom",
+ "nom 7.0.0",
  "unicode_categories",
 ]
 
@@ -5421,6 +5551,8 @@ dependencies = [
  "libp2p-noise",
  "libp2p-tcp",
  "multistream-select",
+ "opentelemetry",
+ "opentelemetry-otlp",
  "pin-project",
  "prometheus",
  "rand 0.8.4",
@@ -5428,6 +5560,7 @@ dependencies = [
  "tokio",
  "tokio-extras",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "void",
  "xtra",

--- a/xtra-libp2p/Cargo.toml
+++ b/xtra-libp2p/Cargo.toml
@@ -17,7 +17,7 @@ multistream-select = "0.11"
 pin-project = "1"
 prometheus = { version = "0.13", default-features = false }
 thiserror = "1"
-tokio = { version = "1", features = ["time", "tracing"] }
+tokio = { version = "1", features = ["time"] }
 tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tracing = "0.1"
 void = "1"
@@ -30,6 +30,9 @@ yamux = "0.10"
 asynchronous-codec = "0.6"
 clap = { version = "3.2", features = ["derive"] }
 libp2p-tcp = { version = "0.33", default-features = false, features = ["tokio"] }
+opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.10.0", features = ["grpc-sys", "trace"] }
 rand = "0.8"
 tokio = { version = "1", features = ["full"] }
+tracing-opentelemetry = "0.17.4"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }

--- a/xtra-libp2p/tests/load_alice_opens_substream.rs
+++ b/xtra-libp2p/tests/load_alice_opens_substream.rs
@@ -1,0 +1,393 @@
+use anyhow::Context;
+use anyhow::Result;
+use async_trait::async_trait;
+use asynchronous_codec::Bytes;
+use futures::SinkExt;
+use futures::StreamExt;
+use libp2p_core::identity::Keypair;
+use libp2p_core::transport::MemoryTransport;
+use libp2p_core::Multiaddr;
+use libp2p_core::PeerId;
+use opentelemetry::sdk::trace::Config;
+use opentelemetry::sdk::Resource;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use std::collections::HashSet;
+use std::sync::Once;
+use std::time::Duration;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Layer;
+use tracing_subscriber::Registry;
+use xtra::spawn::TokioGlobalSpawnExt;
+use xtra::Actor;
+use xtra::Address;
+use xtra_libp2p::endpoint::ConnectionDropped;
+use xtra_libp2p::endpoint::ConnectionEstablished;
+use xtra_libp2p::endpoint::Subscribers;
+use xtra_libp2p::Connect;
+use xtra_libp2p::Disconnect;
+use xtra_libp2p::Endpoint;
+use xtra_libp2p::ListenOn;
+use xtra_libp2p::NewInboundSubstream;
+use xtra_libp2p::OpenSubstream;
+use xtra_productivity::xtra_productivity;
+use xtras::SendAsyncSafe;
+
+const BOB_EXPECTS_MESSAGE_WITHIN_SECS: u64 = 20;
+
+#[tokio::test]
+async fn give_10_bobs_then_passes() {
+    test_runner(10).await
+}
+
+#[tokio::test]
+async fn give_300_bobs_then_panics_because_some_bobs_get_starved() {
+    test_runner(300).await
+}
+
+async fn test_runner(nr_of_bobs: usize) {
+    init_tracing();
+
+    const PROTOCOL: &str = "/foo/1.0.0";
+
+    let port = rand::random::<u16>();
+
+    let (alice, alice_endpoint, alice_peer_id) = create_alice(PROTOCOL.to_string()).await;
+
+    let alice_listen = format!("/memory/{port}").parse::<Multiaddr>().unwrap();
+    alice_endpoint
+        .send(ListenOn(alice_listen.clone()))
+        .await
+        .unwrap();
+
+    let mut bobs = Vec::new();
+
+    for index in 0..nr_of_bobs {
+        let (bob, bob_endpoint) = create_bob(format!("Bob-{index}"), PROTOCOL.to_string()).await;
+
+        bob_endpoint
+            .send(Connect(
+                format!("/memory/{port}/p2p/{alice_peer_id}")
+                    .parse()
+                    .unwrap(),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+
+        bobs.push((bob, bob_endpoint));
+    }
+
+    // This simulates piling up messages in Alice's protocol handler
+    for (index, (bob, bob_endpoint)) in bobs.iter().enumerate() {
+        // send a message to all the bobs
+        alice.send(MessageAllBobs).await.unwrap();
+        retry_until_message_received(bob.clone(), index + 1).await;
+        bob_endpoint.send(Disconnect(alice_peer_id)).await.unwrap();
+    }
+
+    opentelemetry::global::shutdown_tracer_provider();
+}
+
+async fn retry_until_message_received(bob: Bob, expected: usize) {
+    let future = {
+        let address = bob.address.clone();
+        async move {
+            loop {
+                let message_counter = address.send(GetReceivedMessageCount).await.unwrap();
+                if message_counter == expected {
+                    break;
+                }
+
+                #[allow(clippy::disallowed_methods)]
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    };
+
+    tokio::time::timeout(Duration::from_secs(BOB_EXPECTS_MESSAGE_WITHIN_SECS), future)
+        .await
+        .with_context(|| format!("{} never reached counter {}", bob.tag, expected))
+        .unwrap()
+}
+
+async fn create_alice(
+    protocol_name: String,
+) -> (
+    Address<AliceOpenSubstreamListener>,
+    Address<Endpoint>,
+    PeerId,
+) {
+    let (endpoint_addr, endpoint_context) = xtra::Context::new(None);
+
+    let listener_actor = AliceOpenSubstreamListener::new(
+        Box::leak(protocol_name.into_boxed_str()),
+        endpoint_addr.clone(),
+    )
+    .create(None)
+    .spawn_global();
+    let id = Keypair::generate_ed25519();
+    let peer_id = id.public().to_peer_id();
+
+    let endpoint = Endpoint::new(
+        Box::new(MemoryTransport::default),
+        id,
+        Duration::from_secs(20),
+        [],
+        Subscribers::new(
+            vec![listener_actor.clone().into()],
+            vec![listener_actor.clone().into()],
+            vec![],
+            vec![],
+        ),
+    );
+
+    #[allow(clippy::disallowed_methods)]
+    tokio::task::spawn(endpoint_context.run(endpoint));
+
+    (listener_actor, endpoint_addr, peer_id)
+}
+
+#[derive(Clone, Debug)]
+struct Bob {
+    tag: String,
+    address: Address<AliceOpensSubstreamDialer>,
+}
+
+async fn create_bob(tag: String, protocol_name: String) -> (Bob, Address<Endpoint>) {
+    let (endpoint_addr, endpoint_context) = xtra::Context::new(None);
+
+    let dialer_actor = AliceOpensSubstreamDialer::new(tag.clone(), protocol_name.clone())
+        .create(None)
+        .spawn_global();
+    let id = Keypair::generate_ed25519();
+
+    let endpoint = Endpoint::new(
+        Box::new(MemoryTransport::default),
+        id,
+        Duration::from_secs(20),
+        [(
+            Box::leak(protocol_name.into_boxed_str()),
+            dialer_actor.clone().into(),
+        )],
+        Subscribers::new(vec![], vec![], vec![], vec![]),
+    );
+
+    #[allow(clippy::disallowed_methods)]
+    tokio::task::spawn(endpoint_context.run(endpoint));
+
+    (
+        Bob {
+            tag,
+            address: dialer_actor,
+        },
+        endpoint_addr,
+    )
+}
+
+struct AliceOpenSubstreamListener {
+    connected_bobs: HashSet<PeerId>,
+    protocol: &'static str,
+    endpoint: Address<Endpoint>,
+}
+
+impl AliceOpenSubstreamListener {
+    pub fn new(protocol: &'static str, endpoint: Address<Endpoint>) -> Self {
+        Self {
+            connected_bobs: HashSet::default(),
+            protocol,
+            endpoint,
+        }
+    }
+}
+
+#[xtra_productivity(message_impl = false)]
+impl AliceOpenSubstreamListener {
+    async fn handle(&mut self, msg: ConnectionEstablished) {
+        tracing::info!("Connection established with {}", msg.peer);
+
+        self.connected_bobs.insert(msg.peer);
+    }
+
+    async fn handle(&mut self, msg: ConnectionDropped) {
+        tracing::info!("Connection dropped for {}", msg.peer);
+
+        self.connected_bobs.remove(&msg.peer);
+    }
+}
+
+struct MessageAllBobs;
+
+#[xtra_productivity]
+impl AliceOpenSubstreamListener {
+    async fn handle(&mut self, _msg: MessageAllBobs, ctx: &mut xtra::Context<Self>) {
+        for peer in &self.connected_bobs {
+            let future = {
+                let peer = *peer;
+                let endpoint = self.endpoint.clone();
+                let protocol = self.protocol;
+                async move {
+                    let alice_to_bob = endpoint
+                        .send(OpenSubstream::single_protocol(peer, protocol))
+                        .await
+                        .unwrap()
+                        .unwrap();
+
+                    alice_sends(alice_to_bob).await.unwrap();
+
+                    tracing::info!("Finished {protocol} for peer {peer}");
+                    anyhow::Ok(())
+                }
+            };
+
+            let this = ctx.address().expect("self to be alive");
+            tokio_extras::spawn_fallible(&this, future, move |e| async move {
+                tracing::error!("Listener failed to spawn future: {e:#}");
+            });
+        }
+    }
+}
+
+#[async_trait]
+impl Actor for AliceOpenSubstreamListener {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+struct AliceOpensSubstreamDialer {
+    tag: String,
+    protocol: String,
+    received_messages_counter: usize,
+}
+
+impl AliceOpensSubstreamDialer {
+    pub fn new(tag: String, protocol: String) -> Self {
+        Self {
+            tag,
+            protocol,
+            received_messages_counter: 0,
+        }
+    }
+}
+
+#[xtra_productivity(message_impl = false)]
+impl AliceOpensSubstreamDialer {
+    async fn handle(&mut self, msg: NewInboundSubstream, ctx: &mut xtra::Context<Self>) {
+        tracing::info!("{} handling NewInboundSubstream", self.protocol);
+
+        let this = ctx.address().expect("self to be alive");
+
+        let protocol = self.protocol.clone();
+        let future = {
+            let this = this.clone();
+            let tag = self.tag.clone();
+            async move {
+                bob_receives(msg.stream).await?;
+                this.send_async_safe(Done).await?;
+
+                tracing::info!("{tag} sent ListenerDone for protocol {protocol}");
+
+                anyhow::Ok(())
+            }
+        };
+
+        tokio_extras::spawn_fallible(&this, future, move |e| async move {
+            tracing::warn!("Parallel message with peer {} failed: {}", msg.peer, e);
+        });
+    }
+}
+
+#[xtra_productivity]
+impl AliceOpensSubstreamDialer {
+    async fn handle(&mut self, _: Done) {
+        self.received_messages_counter += 1;
+
+        tracing::info!(
+            "{} received ListenerDone for trigger time {}",
+            self.protocol,
+            self.received_messages_counter
+        );
+    }
+
+    async fn handle(&mut self, _check_done: GetReceivedMessageCount) -> usize {
+        self.received_messages_counter
+    }
+}
+
+#[async_trait]
+impl Actor for AliceOpensSubstreamDialer {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+struct Done;
+struct GetReceivedMessageCount;
+
+pub fn into_arr<T, const N: usize>(v: Vec<T>) -> [T; N] {
+    v.try_into()
+        .unwrap_or_else(|v: Vec<T>| panic!("Expected a Vec of length {} but it was {}", N, v.len()))
+}
+
+async fn alice_sends(stream: xtra_libp2p::Substream) -> Result<()> {
+    let mut stream =
+        asynchronous_codec::Framed::new(stream, asynchronous_codec::LengthCodec).fuse();
+
+    stream.send(Bytes::from("Message")).await?;
+
+    Ok(())
+}
+
+async fn bob_receives(stream: xtra_libp2p::Substream) -> Result<()> {
+    let mut stream =
+        asynchronous_codec::Framed::new(stream, asynchronous_codec::LengthCodec).fuse();
+
+    let bytes = stream.select_next_some().await?;
+    let name = String::from_utf8(bytes.to_vec())?;
+
+    assert_eq!(name, "Message");
+
+    Ok(())
+}
+
+static INIT_OTLP_EXPORTER: Once = Once::new();
+
+pub fn init_tracing() {
+    INIT_OTLP_EXPORTER.call_once(|| {
+        let cfg = Config::default().with_resource(Resource::new([KeyValue::new(
+            "service.name",
+            "daemon-tests",
+        )]));
+
+        let tracer = opentelemetry_otlp::new_pipeline()
+            .tracing()
+            .with_trace_config(cfg)
+            .with_exporter(
+                opentelemetry_otlp::new_exporter()
+                    .grpcio()
+                    .with_endpoint("localhost:4317"),
+            )
+            .install_simple()
+            .unwrap();
+
+        let filter = EnvFilter::from_default_env()
+            // apply warning level globally
+            .add_directive(LevelFilter::WARN.into())
+            // log traces from test itself
+            .add_directive("regression=debug".parse().unwrap())
+            .add_directive("xtra=debug".parse().unwrap())
+            .add_directive("xtra_libp2p=debug".parse().unwrap())
+            .add_directive("xtras=debug".parse().unwrap());
+
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_test_writer()
+            .with_filter(filter);
+        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+
+        Registry::default().with(telemetry).with(fmt_layer).init();
+    })
+}


### PR DESCRIPTION
Adds a load test that simulates a similar setup as `offers` protocol, i.e. alice sends out a message to "all connected bobs".
We loop over all the bobs, send a message to all and then disconnect the current bob looped over.
This should result in the bobs getting disconnected one by one each receiving one more message.
For ten problems this is no problem, but note that we do see `ERROR` logs even with 10 bobs where Alice tries to an already disconnected bob.

With load the test panics because earlier bobs some bobs don't receive the message within 10 seconds because they get starved.

---

Note: This test does *not* reproduce the problem where the endpoint runs into a timeout when opening substreams as we see on `testnet` as described in https://github.com/itchysats/itchysats/issues/2414 - it might be worth writing another test that tries to reproduce this, but I was unable to achieve this so far. 
With the test proposed in this PR we should hopefully be able to validate that https://github.com/itchysats/itchysats/pull/2415 and https://github.com/itchysats/itchysats/pull/2426 help us overcome problems.

Note: This load test shows problems with our protocols where the maker opens a substream with all takers. This is potentially just not a good pattern. This explains, to some extent, why we only recently run into trouble, because we now have multiple protocols that follow this pattern, namely `ping`, `offers` and `identify`.
When running the test with `20s` timeout for Bob to receive the message it passes but takes an insane amount of time. Alice sends `300 * 300 - 300` (`300 + 299 + 298, ...`) = `89700` messages (and consequently opens as many substreams), which is a big amount. I let it run for a while and it felt like it was slowing down over time. I stopped it after about `30` minutes. With `10s` timeout it fails quite consistently within `40s`.