### PR TITLE
Prove that `Endpoint` is harder to clog up 

### DIFF
--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -514,6 +514,10 @@ impl Endpoint {
         );
     }
 
+    // The diff in this file allows us to go back to the behaviour
+    // before patch 98b488f0db4e5867a1d1139a2e307ef40937cf67, without
+    // needing to rebase in between. Apply and stash to go back and
+    // forth.
     #[must_use]
     async fn handle(
         &mut self,
@@ -544,11 +548,17 @@ impl Endpoint {
                     "If negotiation is successful, must have selected the only protocol we sent."
                 );
 
-                Ok(stream)
+                Result::<_, Error>::Ok(stream)
             }
         };
 
-        Ok(Box::pin(fut))
+        // We await on the future directly and return a boxed future
+        // that resolves immediately: just as if we went back in time
+        // before patch 98b488f0db4e5867a1d1139a2e307ef40937cf67
+
+        let stream = fut.await?;
+
+        Ok(Box::pin(async { Ok(stream) }))
     }
 
     #[must_use]

--- a/xtra-libp2p/src/upgrade.rs
+++ b/xtra-libp2p/src/upgrade.rs
@@ -133,6 +133,23 @@ where
                 let supported_protocols = supported_inbound_protocols.clone();
 
                 let fut = async move {
+                    // This is an extremely hacky way of simulating
+                    // the behaviour of a protocol negotiation between
+                    // two `Endpoint`s which takes a really long time.
+                    //
+                    // Since this patch is not mergeable, we need to
+                    // find an alternative if we want to add this
+                    // test. Perhaps we could slow down the rate at
+                    // which we handle new `stream`s in this closure
+                    // or ensure that the
+                    // `multistream_seletc::{dialer,
+                    // listener}_select_proto` calls hang
+                    // indefinitely.
+                    if supported_protocols.contains(&"/infinite-negotiation") {
+                        #[allow(clippy::disallowed_methods)]
+                        tokio::time::sleep(Duration::from_secs(100_000)).await;
+                    }
+
                     let result = tokio_extras::time::timeout(
                         connection_timeout,
                         multistream_select::listener_select_proto(stream, &supported_protocols),

--- a/xtra-libp2p/tests/basic.rs
+++ b/xtra-libp2p/tests/basic.rs
@@ -7,25 +7,23 @@ use futures::StreamExt;
 use libp2p_core::multiaddr::Protocol;
 use libp2p_core::Multiaddr;
 use std::collections::HashSet;
-use std::time::Duration;
+use util::make_node;
+use util::GetConnectedPeers;
+use util::GetListenAddresses;
+use util::Node;
 use xtra::message_channel::MessageChannel;
 use xtra::spawn::TokioGlobalSpawnExt;
 use xtra::Actor;
-use xtra::Address;
 use xtra::Context;
-use xtra_libp2p::endpoint;
-use xtra_libp2p::endpoint::Subscribers;
-use xtra_libp2p::libp2p::identity::Keypair;
-use xtra_libp2p::libp2p::transport::MemoryTransport;
-use xtra_libp2p::libp2p::PeerId;
 use xtra_libp2p::Connect;
 use xtra_libp2p::Disconnect;
-use xtra_libp2p::Endpoint;
 use xtra_libp2p::GetConnectionStats;
 use xtra_libp2p::ListenOn;
 use xtra_libp2p::NewInboundSubstream;
 use xtra_libp2p::OpenSubstream;
 use xtra_productivity::xtra_productivity;
+
+mod util;
 
 #[tokio::test]
 async fn hello_world() {
@@ -342,96 +340,6 @@ async fn alice_and_bob<const AN: usize, const BN: usize>(
 
     (alice, bob, alice_listen)
 }
-
-/// Small aggregate dedicated to keep everything that's related to one party
-/// (e.g. alice or bob) in one place
-struct Node {
-    pub peer_id: PeerId,
-    pub endpoint: Address<Endpoint>,
-    pub subscriber_stats: Address<EndpointSubscriberStats>,
-}
-
-fn make_node<const N: usize>(
-    substream_handlers: [(&'static str, MessageChannel<NewInboundSubstream, ()>); N],
-) -> Node {
-    let id = Keypair::generate_ed25519();
-    let peer_id = id.public().to_peer_id();
-
-    let subscriber_stats = EndpointSubscriberStats::default()
-        .create(None)
-        .spawn_global();
-
-    let endpoint = Endpoint::new(
-        Box::new(MemoryTransport::default),
-        id,
-        Duration::from_secs(20),
-        substream_handlers,
-        Subscribers::new(
-            vec![subscriber_stats.clone().into()],
-            vec![subscriber_stats.clone().into()],
-            vec![subscriber_stats.clone().into()],
-            vec![subscriber_stats.clone().into()],
-        ),
-    )
-    .create(None)
-    .spawn_global();
-
-    Node {
-        peer_id,
-        endpoint,
-        subscriber_stats,
-    }
-}
-
-/// A test actor subscribing to all the notifications
-#[derive(Default)]
-struct EndpointSubscriberStats {
-    connected_peers: HashSet<PeerId>,
-    listen_addresses: HashSet<Multiaddr>,
-}
-
-#[async_trait]
-impl Actor for EndpointSubscriberStats {
-    type Stop = ();
-
-    async fn stopped(self) -> Self::Stop {}
-}
-
-#[xtra_productivity]
-impl EndpointSubscriberStats {
-    async fn handle(&mut self, msg: endpoint::ConnectionEstablished) {
-        self.connected_peers.insert(msg.peer);
-    }
-
-    async fn handle(&mut self, msg: endpoint::ConnectionDropped) {
-        self.connected_peers.remove(&msg.peer);
-    }
-
-    async fn handle(&mut self, msg: endpoint::ListenAddressAdded) {
-        self.listen_addresses.insert(msg.address);
-    }
-
-    async fn handle(&mut self, msg: endpoint::ListenAddressRemoved) {
-        self.listen_addresses.remove(&msg.address);
-    }
-}
-
-#[xtra_productivity]
-impl EndpointSubscriberStats {
-    async fn handle(&mut self, _msg: GetConnectedPeers) -> HashSet<PeerId> {
-        self.connected_peers.clone()
-    }
-
-    async fn handle(&mut self, _msg: GetListenAddresses) -> HashSet<Multiaddr> {
-        self.listen_addresses.clone()
-    }
-}
-
-/// Returns connected peers
-struct GetConnectedPeers;
-
-/// Returns current listen addressess
-struct GetListenAddresses;
 
 #[derive(Default)]
 struct HelloWorld;

--- a/xtra-libp2p/tests/hello_world.rs
+++ b/xtra-libp2p/tests/hello_world.rs
@@ -1,0 +1,62 @@
+use anyhow::Context as _;
+use anyhow::Result;
+use async_trait::async_trait;
+use asynchronous_codec::Bytes;
+use futures::SinkExt;
+use futures::StreamExt;
+use xtra::Actor;
+use xtra::Context;
+use xtra_libp2p::NewInboundSubstream;
+use xtra_productivity::xtra_productivity;
+
+pub const PROTOCOL_NAME: &str = "/hello-world/1.0.0";
+
+#[derive(Default)]
+pub struct HelloWorld;
+
+#[xtra_productivity]
+impl HelloWorld {
+    async fn handle(&mut self, msg: NewInboundSubstream, ctx: &mut Context<Self>) {
+        tracing::info!("New hello world stream from {}", msg.peer);
+
+        tokio_extras::spawn_fallible(
+            &ctx.address().unwrap(),
+            hello_world_listener(msg.stream),
+            move |e| async move {
+                tracing::warn!("Hello world protocol with peer {} failed: {}", msg.peer, e);
+            },
+        );
+    }
+}
+
+#[async_trait]
+impl Actor for HelloWorld {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+pub async fn hello_world_dialer(
+    stream: xtra_libp2p::Substream,
+    name: &'static str,
+) -> Result<String> {
+    let mut stream = asynchronous_codec::Framed::new(stream, asynchronous_codec::LengthCodec);
+
+    stream.send(Bytes::from(name)).await?;
+    let bytes = stream.next().await.context("Expected message")??;
+    let message = String::from_utf8(bytes.to_vec())?;
+
+    Ok(message)
+}
+
+pub async fn hello_world_listener(stream: xtra_libp2p::Substream) -> Result<()> {
+    let mut stream =
+        asynchronous_codec::Framed::new(stream, asynchronous_codec::LengthCodec).fuse();
+
+    let bytes = stream.select_next_some().await?;
+    let name = String::from_utf8(bytes.to_vec())?;
+
+    stream.send(Bytes::from(format!("Hello {name}!"))).await?;
+
+    Ok(())
+}

--- a/xtra-libp2p/tests/slow_protocol_negotiation.rs
+++ b/xtra-libp2p/tests/slow_protocol_negotiation.rs
@@ -1,0 +1,114 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use hello_world::hello_world_dialer;
+use hello_world::HelloWorld;
+use libp2p_core::Multiaddr;
+use libp2p_core::PeerId;
+use util::make_node;
+use util::Node;
+use xtra::spawn::TokioGlobalSpawnExt;
+use xtra::Actor;
+use xtra_libp2p::Connect;
+use xtra_libp2p::ListenOn;
+use xtra_libp2p::NewInboundSubstream;
+use xtra_libp2p::OpenSubstream;
+use xtra_productivity::xtra_productivity;
+
+mod hello_world;
+mod util;
+
+#[tokio::test]
+async fn hanging_during_protocol_negotation_does_not_block_endpoint() {
+    let alice = make_node([]);
+    let alice_port = listen_on_random_port(&alice).await.unwrap();
+
+    // Sloan has an endpoint which will get stuck when trying to
+    // negotiate a protocol
+    let infinite_negotiation_handler = InfiniteNegotiation.create(None).spawn_global();
+    let slow_sloan = make_node([("/infinite-negotiation", infinite_negotiation_handler.into())]);
+    connect_to_peer(&slow_sloan, alice.peer_id, alice_port)
+        .await
+        .unwrap();
+
+    // Alice tries to negotiate a protocol with Sloan in the
+    // background. This will never resolve in time!
+    #[allow(clippy::disallowed_methods)]
+    tokio::spawn({
+        let alice = alice.clone();
+        async move {
+            let _stream = alice
+                .endpoint
+                .send(OpenSubstream::single_protocol(
+                    slow_sloan.peer_id,
+                    "/infinite-negotiation",
+                ))
+                .await
+                .unwrap()
+                .unwrap()
+                .await;
+
+            unreachable!("Protocol can never be negotiated in time")
+        }
+    });
+
+    // In the meantime, Alice connects to a lot of Bobs to run the
+    // hello-world protocol
+    for _ in 0..1000 {
+        let bob_handler = HelloWorld::default().create(None).spawn_global();
+        let bob = make_node([(hello_world::PROTOCOL_NAME, bob_handler.clone().into())]);
+
+        connect_to_peer(&bob, alice.peer_id, alice_port)
+            .await
+            .unwrap();
+
+        let alice_to_bob = alice
+            .endpoint
+            .send(OpenSubstream::single_protocol(
+                bob.peer_id,
+                hello_world::PROTOCOL_NAME,
+            ))
+            .await
+            .unwrap()
+            .unwrap()
+            .await
+            .unwrap();
+
+        let string = hello_world_dialer(alice_to_bob, "Alice").await.unwrap();
+
+        assert_eq!(string, "Hello Alice!");
+    }
+
+    // If we succeed, it means that we were able to use the `Endpoint`
+    // whilst waiting for a protocol negotiation to finish
+}
+
+async fn listen_on_random_port(node: &Node) -> Result<u16> {
+    let port = rand::random::<u16>();
+    let listen_address = format!("/memory/{port}").parse::<Multiaddr>()?;
+
+    node.endpoint.send(ListenOn(listen_address)).await?;
+
+    Ok(port)
+}
+
+async fn connect_to_peer(node: &Node, peer_id: PeerId, port: u16) -> Result<()> {
+    node.endpoint
+        .send(Connect(format!("/memory/{port}/p2p/{peer_id}").parse()?))
+        .await??;
+
+    Ok(())
+}
+
+struct InfiniteNegotiation;
+
+#[async_trait]
+impl Actor for InfiniteNegotiation {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+#[xtra_productivity]
+impl InfiniteNegotiation {
+    fn handle(&mut self, _: NewInboundSubstream) {}
+}

--- a/xtra-libp2p/tests/util.rs
+++ b/xtra-libp2p/tests/util.rs
@@ -17,6 +17,7 @@ use xtra_productivity::xtra_productivity;
 
 /// Small aggregate dedicated to keep everything that's related to one party
 /// (e.g. alice or bob) in one place
+#[derive(Clone)]
 pub struct Node {
     pub peer_id: PeerId,
     pub endpoint: Address<Endpoint>,

--- a/xtra-libp2p/tests/util.rs
+++ b/xtra-libp2p/tests/util.rs
@@ -1,0 +1,106 @@
+use async_trait::async_trait;
+use libp2p_core::Multiaddr;
+use std::collections::HashSet;
+use std::time::Duration;
+use xtra::message_channel::MessageChannel;
+use xtra::spawn::TokioGlobalSpawnExt;
+use xtra::Actor;
+use xtra::Address;
+use xtra_libp2p::endpoint;
+use xtra_libp2p::endpoint::Subscribers;
+use xtra_libp2p::libp2p::identity::Keypair;
+use xtra_libp2p::libp2p::transport::MemoryTransport;
+use xtra_libp2p::libp2p::PeerId;
+use xtra_libp2p::Endpoint;
+use xtra_libp2p::NewInboundSubstream;
+use xtra_productivity::xtra_productivity;
+
+/// Small aggregate dedicated to keep everything that's related to one party
+/// (e.g. alice or bob) in one place
+pub struct Node {
+    pub peer_id: PeerId,
+    pub endpoint: Address<Endpoint>,
+    pub subscriber_stats: Address<EndpointSubscriberStats>,
+}
+
+pub fn make_node<const N: usize>(
+    substream_handlers: [(&'static str, MessageChannel<NewInboundSubstream, ()>); N],
+) -> Node {
+    let id = Keypair::generate_ed25519();
+    let peer_id = id.public().to_peer_id();
+
+    let subscriber_stats = EndpointSubscriberStats::default()
+        .create(None)
+        .spawn_global();
+
+    let endpoint = Endpoint::new(
+        Box::new(MemoryTransport::default),
+        id,
+        Duration::from_secs(20),
+        substream_handlers,
+        Subscribers::new(
+            vec![subscriber_stats.clone().into()],
+            vec![subscriber_stats.clone().into()],
+            vec![subscriber_stats.clone().into()],
+            vec![subscriber_stats.clone().into()],
+        ),
+    )
+    .create(None)
+    .spawn_global();
+
+    Node {
+        peer_id,
+        endpoint,
+        subscriber_stats,
+    }
+}
+
+/// A test actor subscribing to all the notifications
+#[derive(Default)]
+pub struct EndpointSubscriberStats {
+    connected_peers: HashSet<PeerId>,
+    listen_addresses: HashSet<Multiaddr>,
+}
+
+#[async_trait]
+impl Actor for EndpointSubscriberStats {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+#[xtra_productivity]
+impl EndpointSubscriberStats {
+    async fn handle(&mut self, msg: endpoint::ConnectionEstablished) {
+        self.connected_peers.insert(msg.peer);
+    }
+
+    async fn handle(&mut self, msg: endpoint::ConnectionDropped) {
+        self.connected_peers.remove(&msg.peer);
+    }
+
+    async fn handle(&mut self, msg: endpoint::ListenAddressAdded) {
+        self.listen_addresses.insert(msg.address);
+    }
+
+    async fn handle(&mut self, msg: endpoint::ListenAddressRemoved) {
+        self.listen_addresses.remove(&msg.address);
+    }
+}
+
+#[xtra_productivity]
+impl EndpointSubscriberStats {
+    async fn handle(&mut self, _msg: GetConnectedPeers) -> HashSet<PeerId> {
+        self.connected_peers.clone()
+    }
+
+    async fn handle(&mut self, _msg: GetListenAddresses) -> HashSet<Multiaddr> {
+        self.listen_addresses.clone()
+    }
+}
+
+/// Returns connected peers
+pub struct GetConnectedPeers;
+
+/// Returns current listen addressess
+pub struct GetListenAddresses;


### PR DESCRIPTION
Unfortunately I could not write a mergeable test, but perhaps someone else has a better idea and can build on this.