### PR TITLE
Log foreign peer ID when failing to upgrade connection

### DIFF
--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -477,8 +477,9 @@ impl Endpoint {
                                 let this = this.clone();
                                 tasks.add_fallible(
                                     async move {
-                                        let (peer, control, incoming_substreams, worker) =
-                                            upgrade.await?;
+                                        let (peer, control, incoming_substreams, worker) = upgrade
+                                            .await
+                                            .context("Failed to connect with peer: {peer}")?;
                                         this.send_async_next(NewConnection {
                                             peer,
                                             control,
@@ -489,7 +490,7 @@ impl Endpoint {
                                         Ok(())
                                     },
                                     move |e: anyhow::Error| async move {
-                                        tracing::warn!("Could not upgrade connection {e:#}");
+                                        tracing::warn!("Could not upgrade connection: {e:#}");
                                     },
                                 );
                             }


### PR DESCRIPTION
This helps verify if particular peers are systematically failing to connect to a listening `Endpoint`.