### PR TITLE
Allow taker to pass in extend private key for wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add new argument to the maker: `ignore-migration-errors`. If enabled, the maker will start if an error occurred when opening the database, if not, it will fail fast. This can come handy to prevent accidentally creating a new empty database in case database migration was unsuccessful.
 - New metrics: the maker tracks how many offers have been sent (`offer_messages_sent_total`) and the taker tracks how many offers have been received (`offer_messages_received_total`).
+- Allow taker to provide extended private key as argument when starting. This key will be used to derive the internal wallet according to (Bip84)[https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki].
 
 ## [0.4.21] - 2022-06-27
 

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -1,3 +1,4 @@
+use crate::bitcoin::util::bip32::ExtendedPrivKey;
 use crate::routes::IdentityInfo;
 use anyhow::bail;
 use anyhow::Context;
@@ -115,6 +116,11 @@ struct Opts {
 
     #[clap(short, long, parse(try_from_str = parse_umbrel_seed))]
     umbrel_seed: Option<[u8; 32]>,
+
+    /// If provided will be used for internal wallet instead of a random key or umbrel_seed. The
+    /// keys will be derived according to Bip84.
+    #[clap(short, long)]
+    pub wallet_xprv: Option<ExtendedPrivKey>,
 }
 
 impl Opts {
@@ -344,6 +350,11 @@ async fn main() -> Result<()> {
             let web_password = opts.password.unwrap_or_else(|| seed.derive_auth_password());
             (ext_priv_key, identities, web_password)
         }
+    };
+
+    let ext_priv_key = match opts.wallet_xprv {
+        Some(wallet_xprv) => wallet_xprv,
+        None => ext_priv_key,
     };
 
     let mut tasks = Tasks::default();


### PR DESCRIPTION
This key will be used to derive the internal wallet according to (Bip84)[https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki].

This will allow us to easier start a taker with a wallet with funds.