### PR TITLE
Log multi-address if we cannot extract a peer ID

### DIFF
--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -487,7 +487,7 @@ impl Endpoint {
                                                     Some(peer_id) => format!(
                                                         "Failed to connect with peer: {peer_id}"
                                                     ),
-                                                    None => "Failed to connect with peer".into(),
+                                                    None => format!("Failed to connect with multi-address: {remote_addr}"),
                                                 }
                                             })?;
                                         this.send_async_next(NewConnection {


### PR DESCRIPTION
Yet another attempt at making these logs a bit more informational.

Every time we fail to upgrade a connection we want to be able to associate the event with a particular peer. Ideally they have a peer ID, but if they don't we settle for their multi-address.