### PR TITLE
Instrument wallet sync

### DIFF
--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -415,6 +415,7 @@ impl Actor {
         }
     }
 
+    #[tracing::instrument("Sync monitor", skip_all, err)]
     async fn sync(&mut self) -> Result<()> {
         // Fetch the latest block for storing the height.
         // We do not act on this subscription after this call, as we cannot rely on


### PR DESCRIPTION
Also add a span for monitor sync to disambiguate.

Example span from this PR: 
![image](https://user-images.githubusercontent.com/6688948/179461916-a1c31abe-01e8-4e61-a1a6-1e901aebd4fa.png)

Unfortunately, it is not a whole lot better than not instrumenting this at all, since the main block of time is uninstrumented inside of bdk. 