### PR TITLE
Append network type to service.name in traces

### DIFF
--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -171,4 +171,14 @@ impl Network {
             Network::Regtest { withdraw, .. } => withdraw,
         }
     }
+
+    /// Stringified network kind
+    pub fn kind(&self) -> &str {
+        match self {
+            Network::Mainnet { .. } => "mainnet",
+            Network::Testnet { .. } => "testnet",
+            Network::Signet { .. } => "signet",
+            Network::Regtest { .. } => "regtest",
+        }
+    }
 }

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -30,13 +30,14 @@ use xtras::supervisor::Supervisor;
 #[rocket::main]
 async fn main() -> Result<()> {
     let opts = Opts::parse();
+    let service_name = "maker_".to_string() + opts.network.kind();
 
     logger::init(
         opts.log_level,
         opts.json,
         opts.instrumentation,
         opts.tokio_console,
-        "maker",
+        &service_name,
         &opts.collector_endpoint,
     )
     .context("initialize logger")?;

--- a/shared-bin/src/logger.rs
+++ b/shared-bin/src/logger.rs
@@ -26,7 +26,7 @@ pub fn init(
     json_format: bool,
     instrumentation: bool,
     use_tokio_console: bool,
-    service_name: &'static str,
+    service_name: &str,
     collector_endpoint: &str,
 ) -> Result<()> {
     if level == LevelFilter::OFF {
@@ -83,8 +83,10 @@ pub fn init(
         })
         .expect("to be able to set error handler");
 
-        let cfg = trace::Config::default()
-            .with_resource(Resource::new([KeyValue::new("service.name", service_name)]));
+        let cfg = trace::Config::default().with_resource(Resource::new([KeyValue::new(
+            "service.name",
+            service_name.to_string(),
+        )]));
 
         let tracer = opentelemetry_otlp::new_pipeline()
             .tracing()

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -285,6 +285,16 @@ impl Network {
             Network::Regtest { withdraw, .. } => withdraw,
         }
     }
+
+    /// Stringified network kind
+    pub fn kind(&self) -> &str {
+        match self {
+            Network::Mainnet { .. } => "mainnet",
+            Network::Testnet { .. } => "testnet",
+            Network::Signet { .. } => "signet",
+            Network::Regtest { .. } => "regtest",
+        }
+    }
 }
 
 impl std::fmt::Debug for Network {
@@ -303,6 +313,7 @@ async fn main() -> Result<()> {
     let opts = Opts::parse();
 
     let network = opts.network();
+    let service_name = "taker_".to_string() + network.kind();
     let (maker_url, maker_id, maker_peer_id) = opts.maker()?;
 
     logger::init(
@@ -310,7 +321,7 @@ async fn main() -> Result<()> {
         opts.json,
         opts.instrumentation,
         opts.tokio_console,
-        "taker",
+        &service_name,
         &opts.collector_endpoint,
     )
     .context("initialize logger")?;


### PR DESCRIPTION
Allows easier differentiation between mainnet and testnet configs.

note: I've resisted the urge to refactor `Network` enum in this commit, but I'm doing it as a follow-up :)