### PR TITLE
Add C++ compiler for ARM build in build release binary workflow

### DIFF
--- a/.github/actions/build-release-binary/action.yml
+++ b/.github/actions/build-release-binary/action.yml
@@ -28,6 +28,7 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install 'gcc-aarch64-linux-gnu'
+        sudo apt-get install 'g++-aarch64-linux-gnu'
 
     - uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
We updated this on the CI, but not for here.