### PR TITLE
Fix otel_test's auto-`#[tokio::test]` to ignore docs

### DIFF
--- a/otel-tests-macro/src/lib.rs
+++ b/otel-tests-macro/src/lib.rs
@@ -11,7 +11,10 @@ pub fn otel_test(_attribute: TokenStream, item: TokenStream) -> TokenStream {
     let name = &sig.ident;
     let attrs = fn_item.attrs;
 
-    let test = if attrs.is_empty() {
+    let test = if !attrs
+        .iter()
+        .any(|attr| attr.path.segments.last().unwrap().ident == "test")
+    {
         quote!(#[otel_tests::__reexport::tokio::test])
     } else {
         quote!()


### PR DESCRIPTION
This used to interpret any attribute, including docs, as functionally a test attribute. One test was therefore accidentally skipped - `retry_rollover_an_open_cfd`. Related to #2446 but orthogonal to it.