### PR TITLE
Add spans with `OrderId` when broadcasting TXs

### DIFF
--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -25,6 +25,7 @@ use serde_json::Value;
 use sqlite_db;
 use std::collections::HashMap;
 use std::time::Duration;
+use tracing::Instrument;
 use xtra_productivity::xtra_productivity;
 use xtras::SendInterval;
 
@@ -582,11 +583,13 @@ impl xtra::Actor for Actor {
                             }
                         };
                         if let Some(tx) = commit_tx {
+                            let span = tracing::debug_span!("Broadcast commit TX", order_id = %id);
                             if let Err(e) = this
                                 .send(TryBroadcastTransaction {
                                     tx,
                                     kind: TransactionKind::Commit,
                                 })
+                                .instrument(span)
                                 .await?
                             {
                                 tracing::warn!("{e:#}")
@@ -594,11 +597,13 @@ impl xtra::Actor for Actor {
                         }
 
                         if let Some(tx) = cet {
+                            let span = tracing::debug_span!("Broadcast CET", order_id = %id);
                             if let Err(e) = this
                                 .send(TryBroadcastTransaction {
                                     tx,
                                     kind: TransactionKind::Cet,
                                 })
+                                .instrument(span)
                                 .await?
                             {
                                 tracing::warn!("{e:#}")
@@ -606,11 +611,13 @@ impl xtra::Actor for Actor {
                         }
 
                         if let Some(tx) = lock_tx {
+                            let span = tracing::debug_span!("Broadcast lock TX", order_id = %id);
                             if let Err(e) = this
                                 .send(TryBroadcastTransaction {
                                     tx,
                                     kind: TransactionKind::Lock,
                                 })
+                                .instrument(span)
                                 .await?
                             {
                                 tracing::warn!("{e:#}")

--- a/daemon/src/process_manager.rs
+++ b/daemon/src/process_manager.rs
@@ -124,22 +124,8 @@ impl Actor {
                     })
                     .await?;
             }
-            CetTimelockExpiredPostOracleAttestation { cet } => {
-                let _ = self
-                    .monitor_cet_finality
-                    .send_async_safe(MonitorCetFinality {
-                        order_id: event.id,
-                        cet: cet.clone(),
-                    })
-                    .await?;
-                self.try_broadcast_transaction
-                    .send_async_safe(TryBroadcastTransaction {
-                        tx: cet,
-                        kind: TransactionKind::Cet,
-                    })
-                    .await?;
-            }
-            OracleAttestedPostCetTimelock { cet, .. } => {
+            CetTimelockExpiredPostOracleAttestation { cet }
+            | OracleAttestedPostCetTimelock { cet, .. } => {
                 let _ = self
                     .monitor_cet_finality
                     .send_async_safe(MonitorCetFinality {

--- a/daemon/src/process_manager.rs
+++ b/daemon/src/process_manager.rs
@@ -141,17 +141,10 @@ impl Actor {
                     .await?;
             }
             OracleAttestedPriorCetTimelock {
-                commit_tx: Some(commit_tx),
+                commit_tx: Some(tx),
                 ..
-            } => {
-                self.try_broadcast_transaction
-                    .send_async_safe(TryBroadcastTransaction {
-                        tx: commit_tx,
-                        kind: TransactionKind::Commit,
-                    })
-                    .await?;
             }
-            ManualCommit { tx } => {
+            | ManualCommit { tx } => {
                 self.try_broadcast_transaction
                     .send_async_safe(TryBroadcastTransaction {
                         tx,


### PR DESCRIPTION
Otherwise it is very hard to associate transactions with CFDs.