### PR TITLE
Don't log successful open substreams

### DIFF
--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -267,7 +267,7 @@ impl Endpoint {
         self.notify_connection_dropped(*peer).await;
     }
 
-    #[instrument(skip(control), ret, err)]
+    #[instrument(skip(control), err)]
     async fn open_substream(
         mut control: yamux::Control,
         peer: PeerId,


### PR DESCRIPTION
This happens every ping so it's quite spammy