### PR TITLE
Spawn wallet actor as a blocking task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5550,7 +5550,7 @@ dependencies = [
 [[package]]
 name = "xtra"
 version = "0.6.0"
-source = "git+https://github.com/Restioson/xtra?rev=a0c1ad6b6141e28417dadeaaf9595b405153f84e#a0c1ad6b6141e28417dadeaaf9595b405153f84e"
+source = "git+https://github.com/Restioson/xtra?rev=ff782ad379abad33c715173d21e2221189e252c0#ff782ad379abad33c715173d21e2221189e252c0"
 dependencies = [
  "async-trait",
  "catty",

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -23,7 +23,6 @@ use shared_bin::fairings;
 use shared_bin::logger;
 use std::net::SocketAddr;
 use tokio_extras::Tasks;
-use xtra::Actor;
 use xtras::supervisor::always_restart;
 use xtras::supervisor::Supervisor;
 
@@ -79,14 +78,12 @@ async fn main() -> Result<()> {
     let mut wallet_dir = data_dir.clone();
 
     wallet_dir.push(MAKER_WALLET_ID);
-    let (wallet, wallet_feed_receiver) = wallet::Actor::new(
+    let (wallet, wallet_feed_receiver) = wallet::Actor::spawn(
         opts.network.electrum(),
         ext_priv_key,
         wallet_dir,
         MAKER_WALLET_ID.to_string(),
     )?;
-
-    let wallet = wallet.create(None).spawn(&mut tasks);
 
     if let Some(Withdraw::Withdraw {
         amount,

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -38,7 +38,6 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio_extras::Tasks;
-use xtra::Actor;
 
 mod routes;
 
@@ -241,14 +240,12 @@ async fn main() -> Result<()> {
 
     let mut wallet_dir = data_dir.clone();
     wallet_dir.push(TAKER_WALLET_ID);
-    let (wallet, wallet_feed_receiver) = wallet::Actor::new(
+    let (wallet, wallet_feed_receiver) = wallet::Actor::spawn(
         network.electrum(),
         ext_priv_key,
         wallet_dir,
         TAKER_WALLET_ID.to_string(),
     )?;
-
-    let wallet = wallet.create(None).spawn(&mut tasks);
 
     if let Some(Withdraw::Withdraw {
         amount,


### PR DESCRIPTION
This is solution 2 to #2453. It spawns the wallet actor as a blocking task. I am not 100% sure if this will correctly make the thread park when nothing is being sent to the wallet actor.