### PR TITLE
Disable span list from json logs by default

### DIFF
--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -36,6 +36,11 @@ pub struct Opts {
     #[clap(short, long)]
     pub json: bool,
 
+    /// If enabled, logs in json format will contain a list of all ancestor spans of log events.
+    /// This **only** has an effect when `json` is also enabled.
+    #[clap(long)]
+    pub json_span_list: bool,
+
     /// If enabled, traces will be exported to the OTEL collector
     #[clap(long)]
     pub instrumentation: bool,

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -35,6 +35,7 @@ async fn main() -> Result<()> {
     logger::init(
         opts.log_level,
         opts.json,
+        opts.json_span_list,
         opts.instrumentation,
         opts.tokio_console,
         &service_name,

--- a/shared-bin/src/logger.rs
+++ b/shared-bin/src/logger.rs
@@ -24,6 +24,7 @@ const RUST_LOG_ENV: &str = "RUST_LOG";
 pub fn init(
     level: LevelFilter,
     json_format: bool,
+    json_span_list: bool,
     instrumentation: bool,
     use_tokio_console: bool,
     service_name: &str,
@@ -63,7 +64,11 @@ pub fn init(
         .with_ansi(is_terminal);
 
     let fmt_layer = if json_format {
-        fmt_layer.json().with_timer(UtcTime::rfc_3339()).boxed()
+        fmt_layer
+            .json()
+            .with_span_list(json_span_list)
+            .with_timer(UtcTime::rfc_3339())
+            .boxed()
     } else {
         fmt_layer
             .compact()

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -84,6 +84,11 @@ struct Opts {
     #[clap(short, long)]
     json: bool,
 
+    /// If enabled, logs in json format will contain a list of all ancestor spans of log events.
+    /// This **only** has an effect when `json` is also enabled.
+    #[clap(long)]
+    pub json_span_list: bool,
+
     /// If enabled, traces will be exported to the OTEL collector
     #[clap(long)]
     instrumentation: bool,
@@ -188,6 +193,7 @@ async fn main() -> Result<()> {
     logger::init(
         opts.log_level,
         opts.json,
+        opts.json_span_list,
         opts.instrumentation,
         opts.tokio_console,
         &service_name,


### PR DESCRIPTION
Added a new `--json-span-list` option to re-enable them. This should help reduce log size on disk.