### PR TITLE
Fix panic when parsing vergen version

### DIFF
--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -503,7 +503,7 @@ impl Actor {
             let can_remove_heartbeats = match parse_daemon_version(&daemon_version) {
                 Ok(daemon_semver) => {
                     let can_remove_heartbeats =
-                        semver::VersionReq::parse(">= 0.4.20").expect("to parse VersionReq");
+                        semver::VersionReq::parse("> 0.5").expect("to parse VersionReq");
                     can_remove_heartbeats.matches(&daemon_semver)
                 }
                 Err(e) => {


### PR DESCRIPTION
Vergen version was used to determine need for heartbeats.
Whilst at there, move the version without the heartbeats to past 0.5