### PR TITLE
Define transparent Debug implementation for PeerId newtype

### DIFF
--- a/model/src/libp2p.rs
+++ b/model/src/libp2p.rs
@@ -3,8 +3,14 @@ use serde::Serialize;
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PeerId(libp2p_core::PeerId);
+
+impl fmt::Debug for PeerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 impl PeerId {
     /// Value used as placeholder for legacy CFDs where no PeerId is stored.


### PR DESCRIPTION
This makes it appear consistently in tracing, as sometimes we return the
underlying libp2p type, and sometimes the newtype.