### PR TITLE
Ignore frequent spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4067,6 +4067,9 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "xtra-libp2p-offer",
+ "xtra-libp2p-ping",
+ "xtras",
 ]
 
 [[package]]

--- a/daemon/src/archive_closed_cfds.rs
+++ b/daemon/src/archive_closed_cfds.rs
@@ -26,7 +26,11 @@ impl xtra::Actor for Actor {
         let this = ctx.address().expect("we are alive");
         tokio_extras::spawn(
             &this.clone(),
-            this.send_interval(ARCHIVE_CFDS_INTERVAL, || ArchiveCfds),
+            this.send_interval(
+                ARCHIVE_CFDS_INTERVAL,
+                || ArchiveCfds,
+                xtras::IncludeSpan::Always,
+            ),
         );
     }
 

--- a/daemon/src/archive_failed_cfds.rs
+++ b/daemon/src/archive_failed_cfds.rs
@@ -26,7 +26,11 @@ impl xtra::Actor for Actor {
         let this = ctx.address().expect("we are alive");
         tokio_extras::spawn(
             &this.clone(),
-            this.send_interval(ARCHIVE_CFDS_INTERVAL, || ArchiveCfds),
+            this.send_interval(
+                ARCHIVE_CFDS_INTERVAL,
+                || ArchiveCfds,
+                xtras::IncludeSpan::Always,
+            ),
         );
     }
 

--- a/daemon/src/auto_rollover.rs
+++ b/daemon/src/auto_rollover.rs
@@ -122,7 +122,11 @@ impl xtra::Actor for Actor {
         let this = ctx.address().expect("we are alive");
         tokio_extras::spawn(
             &this.clone(),
-            this.send_interval(Duration::from_secs(5 * 60), || AutoRollover),
+            this.send_interval(
+                Duration::from_secs(5 * 60),
+                || AutoRollover,
+                xtras::IncludeSpan::Always,
+            ),
         );
     }
 

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -549,7 +549,11 @@ impl xtra::Actor for Actor {
         let this = ctx.address().expect("we are alive");
         tokio_extras::spawn(
             &this,
-            this.clone().send_interval(Duration::from_secs(20), || Sync),
+            this.clone().send_interval(
+                Duration::from_secs(20),
+                || Sync,
+                xtras::IncludeSpan::Always,
+            ),
         );
 
         tokio_extras::spawn_fallible(

--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -340,8 +340,11 @@ impl xtra::Actor for Actor {
         let this = ctx.address().expect("we are alive");
         tokio_extras::spawn(
             &this,
-            this.clone()
-                .send_interval(SYNC_ANNOUNCEMENTS_INTERVAL, || SyncAnnouncements),
+            this.clone().send_interval(
+                SYNC_ANNOUNCEMENTS_INTERVAL,
+                || SyncAnnouncements,
+                xtras::IncludeSpan::Always,
+            ),
         );
 
         tokio_extras::spawn(&this.clone(), {
@@ -373,8 +376,12 @@ impl xtra::Actor for Actor {
                     .instrument(span)
                     .await;
 
-                this.send_interval(SYNC_ATTESTATIONS_INTERVAL, || SyncAttestations)
-                    .await;
+                this.send_interval(
+                    SYNC_ATTESTATIONS_INTERVAL,
+                    || SyncAttestations,
+                    xtras::IncludeSpan::Always,
+                )
+                .await;
             }
         });
     }

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -313,7 +313,10 @@ where
     async fn started(&mut self, ctx: &mut xtra::Context<Self>) {
         let this = ctx.address().expect("self to be alive");
 
-        tokio_extras::spawn(&this.clone(), this.send_interval(SYNC_INTERVAL, || Sync));
+        tokio_extras::spawn(
+            &this.clone(),
+            this.send_interval(SYNC_INTERVAL, || Sync, xtras::IncludeSpan::Always),
+        );
     }
 
     async fn stopped(self) -> Self::Stop {}

--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -49,6 +49,11 @@ pub struct Opts {
     #[clap(long)]
     pub tokio_console: bool,
 
+    /// If enabled, libp2p ping and offer broadcast spans will be included in the traces exported
+    /// by the application.
+    #[clap(long)]
+    pub verbose_spans: bool,
+
     /// OTEL collector endpoint address
     ///
     /// If not specified it defaults to the local collector endpoint.

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -35,6 +35,7 @@ async fn main() -> Result<()> {
         opts.json_span_list,
         opts.instrumentation,
         opts.tokio_console,
+        opts.verbose_spans,
         &opts.service_name,
         &opts.collector_endpoint,
     )

--- a/shared-bin/Cargo.toml
+++ b/shared-bin/Cargo.toml
@@ -25,3 +25,6 @@ time = "0.3.11"
 tracing = { version = "0.1" }
 tracing-opentelemetry = "0.17.4"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter", "local-time", "tracing-log", "json"] }
+xtra-libp2p-offer = { path = "../xtra-libp2p-offer" }
+xtra-libp2p-ping = { path = "../xtra-libp2p-ping" }
+xtras = { path = "../xtras" }

--- a/shared-bin/src/logger.rs
+++ b/shared-bin/src/logger.rs
@@ -6,10 +6,12 @@ use opentelemetry::sdk::Resource;
 use opentelemetry::KeyValue;
 use opentelemetry_otlp::WithExportConfig;
 use time::macros::format_description;
+use tracing::Level;
+use tracing_subscriber::filter::Directive;
+use tracing_subscriber::filter::FilterExt;
 use tracing_subscriber::fmt::time::UtcTime;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Layer;
-use tracing_subscriber::Registry;
 
 pub use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -20,13 +22,20 @@ pub const LOCAL_COLLECTOR_ENDPOINT: &str = "http://localhost:4317";
 
 const RUST_LOG_ENV: &str = "RUST_LOG";
 
-#[allow(clippy::print_stdout)] // because the logger is only initialized at the end of this function but we want to print a warning
+/// Names for specific spans which may be disabled as they are generally too spammy
+pub mod span_names {
+    pub const OLD_BROADCAST_OFFERS: &str = "Broadcast offers to taker";
+}
+
+// because the logger is only initialized at the end of this function but we want to print a warning
+#[allow(clippy::print_stdout, clippy::too_many_arguments)]
 pub fn init(
     level: LevelFilter,
     json_format: bool,
     json_span_list: bool,
     instrumentation: bool,
     use_tokio_console: bool,
+    verbose_spans: bool,
     service_name: &str,
     collector_endpoint: &str,
 ) -> Result<()> {
@@ -36,27 +45,32 @@ pub fn init(
 
     let is_terminal = atty::is(atty::Stream::Stderr);
 
-    let filter = match std::env::var_os(RUST_LOG_ENV).map(|s| s.into_string()) {
-        Some(Ok(env)) => {
-            let mut filter = log_base_directives(EnvFilter::new(""))?;
-            for directive in env.split(',') {
-                match directive.parse() {
-                    Ok(d) => filter = filter.add_directive(d),
-                    Err(e) => println!("WARN ignoring log directive: `{directive}`: {e}"),
-                };
+    let filter = || -> Result<EnvFilter> {
+        let filter = match std::env::var_os(RUST_LOG_ENV).map(|s| s.into_string()) {
+            Some(Ok(env)) => {
+                let mut filter = log_base_directives(EnvFilter::new(""))?;
+                for directive in env.split(',') {
+                    match directive.parse() {
+                        Ok(d) => filter = filter.add_directive(d),
+                        Err(e) => println!("WARN ignoring log directive: `{directive}`: {e}"),
+                    };
+                }
+                filter
             }
-            filter
-        }
-        _ => log_base_directives(EnvFilter::from_env(RUST_LOG_ENV))?,
-    };
-    let filter = filter.add_directive(format!("{level}").parse()?);
+            _ => log_base_directives(EnvFilter::from_env(RUST_LOG_ENV))?,
+        };
 
-    let filter = if use_tokio_console {
-        filter
-            .add_directive("tokio=trace".parse()?)
-            .add_directive("runtime=trace".parse()?)
-    } else {
-        filter
+        let filter = filter.add_directive(format!("{level}").parse()?);
+
+        let filter = if use_tokio_console {
+            filter
+                .add_directive("tokio=trace".parse()?)
+                .add_directive("runtime=trace".parse()?)
+        } else {
+            filter
+        };
+
+        Ok(filter)
     };
 
     let fmt_layer = tracing_subscriber::fmt::layer()
@@ -113,9 +127,26 @@ pub fn init(
         None
     };
 
-    Registry::default()
-        .with(Layer::and_then(telemetry, fmt_layer).with_filter(filter))
+    let mut error_only = vec![
+        span_names::OLD_BROADCAST_OFFERS,
+        xtras::send_interval::QUIET_NAME,
+    ];
+
+    if !verbose_spans {
+        error_only.extend([
+            xtra_libp2p_ping::ping::PING_PEER_SPAN,
+            xtra_libp2p_offer::maker::LIBP2P_BROADCAST_OFFERS_SPAN,
+        ]);
+    }
+
+    let disable_spans = tracing_subscriber::filter::filter_fn(move |meta| {
+        !(*meta.level() > Level::ERROR && error_only.contains(&meta.name()))
+    });
+
+    tracing_subscriber::registry()
         .with(console_layer)
+        .with(telemetry.with_filter(filter()?.and(disable_spans.clone())))
+        .with(fmt_layer.with_filter(filter()?.and(disable_spans)))
         .try_init()
         .context("Failed to init logger")?;
 
@@ -126,6 +157,7 @@ pub fn init(
 
 fn log_base_directives(env: EnvFilter) -> Result<EnvFilter> {
     let filter = env
+        .add_directive(Directive::from(LevelFilter::INFO))
         .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
         .add_directive("sqlx=warn".parse()?) // sqlx logs all queries on INFO
         .add_directive("hyper=warn".parse()?)

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -96,6 +96,11 @@ struct Opts {
     #[clap(long)]
     pub tokio_console: bool,
 
+    /// If enabled, libp2p ping and offer broadcast spans will be included in the traces exported
+    /// by the application.
+    #[clap(long)]
+    pub verbose_spans: bool,
+
     /// OTEL collector endpoint address
     ///
     /// If not specified it defaults to the local collector endpoint.
@@ -198,6 +203,7 @@ async fn main() -> Result<()> {
         opts.json_span_list,
         opts.instrumentation,
         opts.tokio_console,
+        opts.verbose_spans,
         &opts.service_name,
         &opts.collector_endpoint,
     )

--- a/tokio-extras/src/time.rs
+++ b/tokio-extras/src/time.rs
@@ -81,8 +81,9 @@ where
                     "Future with timeout",
                     timeout_secs = duration.as_secs(),
                     timed_out = field::Empty,
-                );
-                let child = parent.in_scope(child_span);
+                )
+                .or_current();
+                let child = parent.in_scope(child_span).or_current();
 
                 let poll = child.in_scope(|| this.fut.poll(cx));
 

--- a/xtra-libp2p-ping/src/ping.rs
+++ b/xtra-libp2p-ping/src/ping.rs
@@ -20,6 +20,8 @@ use xtra_productivity::xtra_productivity;
 use xtras::SendAsyncNext;
 use xtras::SendInterval;
 
+pub const PING_PEER_SPAN: &str = "Ping peer";
+
 /// An actor implementing the official ipfs/libp2p ping protocol.
 ///
 /// The ping protocol serves two purposes:
@@ -79,7 +81,7 @@ impl xtra::Actor for Actor {
 
         tokio_extras::spawn(
             &this.clone(),
-            this.send_interval(self.ping_interval, || Ping),
+            this.send_interval(self.ping_interval, || Ping, xtras::IncludeSpan::Always),
         );
     }
 
@@ -130,7 +132,7 @@ impl Actor {
 
             spawn_fallible(
                 &this,
-                ping_fut.instrument(tracing::debug_span!("Ping peer")),
+                ping_fut.instrument(tracing::debug_span!(PING_PEER_SPAN).or_current()),
                 err_handler,
             );
         }

--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -431,7 +431,7 @@ impl Endpoint {
                     anyhow::Ok(())
                 };
 
-                fut.instrument(tracing::debug_span!("Dial new connection"))
+                fut.instrument(tracing::debug_span!("Dial new connection").or_current())
             },
             move |error| async move {
                 this.send_async_next(FailedToConnect { peer, error }).await;

--- a/xtras/src/lib.rs
+++ b/xtras/src/lib.rs
@@ -3,7 +3,7 @@ pub mod address_map;
 pub mod handler_timeout;
 mod send_async_next;
 mod send_async_safe;
-mod send_interval;
+pub mod send_interval;
 pub mod supervisor;
 
 pub use actor_name::ActorName;
@@ -11,4 +11,5 @@ pub use address_map::AddressMap;
 pub use handler_timeout::HandlerTimeoutExt;
 pub use send_async_next::SendAsyncNext;
 pub use send_async_safe::SendAsyncSafe;
+pub use send_interval::IncludeSpan;
 pub use send_interval::SendInterval;


### PR DESCRIPTION
Using a Directive in an EnvFilter didn't seem to do anything at all so I landed on this. This was very painful as reordering anything at all in the registry init lead to completely broken output.

 It is still not perfect as it will ignore every span, even if it has an error. I am opening this for now since I am stumped on how to solve this large issue and I've been trying to solve it for a few hours to no avail. This means this change is a bit far in the *other* direction - even erroring send offers, ping, and send heartbeat spans will be ignored. This will still reduce the load and log the error, but the error will not be attached to any span anymore.

As part of the implementation, I added a new `quiet: bool` field to `send_interval`, which is currently only `true` for `SendHeartbeat`. An alternative is a new `send_interval_quiet`, but I thought that it could be good to force the caller to consider whether to be quiet or noisy. For most situation, noisy will be fine, I think.