### PR TITLE
Allow specifying service_name from command line

### DIFF
--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -55,6 +55,12 @@ pub struct Opts {
     #[clap(long, default_value = LOCAL_COLLECTOR_ENDPOINT )]
     pub collector_endpoint: String,
 
+    /// Service name for OTEL.
+    ///
+    /// If not specified it defaults to the binary name.
+    #[clap(long, default_value = "maker")]
+    pub service_name: String,
+
     /// If enabled the application will not fail if an error occurred during db migration.
     #[clap(short, long)]
     pub ignore_migration_errors: bool,

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -29,15 +29,13 @@ use xtras::supervisor::Supervisor;
 #[rocket::main]
 async fn main() -> Result<()> {
     let opts = Opts::parse();
-    let service_name = "maker_".to_string() + opts.network.kind();
-
     logger::init(
         opts.log_level,
         opts.json,
         opts.json_span_list,
         opts.instrumentation,
         opts.tokio_console,
-        &service_name,
+        &opts.service_name,
         &opts.collector_endpoint,
     )
     .context("initialize logger")?;


### PR DESCRIPTION
This way we can use appropriate names for both `maker_mainnet` and
`maker_testnet`, as well as `taker_master` and `taker_release`.

Note: after this gets deployed, cloud-conf should be updated.