### PR TITLE
Change logs to default (not compact) format

### DIFF
--- a/shared-bin/src/logger.rs
+++ b/shared-bin/src/logger.rs
@@ -66,7 +66,6 @@ pub fn init(
         fmt_layer.json().with_timer(UtcTime::rfc_3339()).boxed()
     } else {
         fmt_layer
-            .compact()
             .with_timer(UtcTime::new(format_description!(
                 "[year]-[month]-[day] [hour]:[minute]:[second]"
             )))


### PR DESCRIPTION
This prints all the spans tags next to them in the span list which is more readable.

Before
```
2022-07-20 16:54:50 DEBUG Send message every interval:xtra_actor_request:xtra_message_handler:Handle SyncAnnouncements:Fetch announcement: daemon::oracle: Fetching announcement event_id=/x/BitMEX/BXBT/2022-07-21T17:00:00.price?n=20 interval_secs=60 actor_type=daemon::oracle::Actor message_type=daemon::oracle::SyncAnnouncements
```

After
```
2022-07-20 17:01:48 DEBUG Send message every interval{interval_secs=60}:xtra_actor_request{actor_type=daemon::oracle::Actor message_type=daemon::oracle::SyncAnnouncements}:xtra_message_handler:Handle SyncAnnouncements:Fetch announcement: daemon::oracle: Fetching announcement event_id=/x/BitMEX/BXBT/2022-07-20T19:00:00.price?n=20
```