### PR TITLE
Separate test execution from compilation on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,10 @@ jobs:
       - name: Setup rust toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@v2.0.0
-      - run: cargo test --workspace
+      - name: Compile tests before running
+        run: cargo test --workspace --no-run
+      - name: Test execution
+        run: cargo test --workspace
 
   smoke_test:
     strategy:


### PR DESCRIPTION
This should give us more insight into test execution time regressions vs
compilation issues.