### PR TITLE
Log important taker connection info on `info`

### DIFF
--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -546,7 +546,7 @@ impl Actor {
                 .inc();
         });
 
-        tracing::debug!(taker_id = %identity, taker_address = %address, %wire_version, %daemon_version, %environment, ?peer_id, "Connection is ready");
+        tracing::info!(taker_id = %identity, taker_address = %address, %wire_version, %daemon_version, %environment, ?peer_id, "Connection is ready");
     }
 
     async fn handle_listener_failed(&mut self, msg: ListenerFailed, ctx: &mut xtra::Context<Self>) {


### PR DESCRIPTION
This piece of code is the only way we have to associate the `taker_id` with the `peer_id`. As long as the old connection is being used this is important, because otherwise we might now know which taker is failing.

---

This is a tiny change that will allow us to remove activating the `debug` logs for this module :)