### PR TITLE
PoC: see how much we benefit from rust-cache for test runs on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
         run: rustup show
-      - uses: Swatinem/rust-cache@v2.0.0
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Compile tests before running


### PR DESCRIPTION
rust-cache only caches external crates, and apparently it's most useful in small
projects, where own crates are an exception.