### PR TITLE
Tell users to include contact details in details

### DIFF
--- a/taker-frontend/src/components/Footer.tsx
+++ b/taker-frontend/src/components/Footer.tsx
@@ -18,6 +18,7 @@ import {
     ModalOverlay,
     Switch,
     Text,
+    Tooltip,
     useColorModeValue,
     useDisclosure,
 } from "@chakra-ui/react";
@@ -146,7 +147,11 @@ export default function Footer(
                             leftIcon={<FaRegCommentDots />}
                             variant={"ghost"}
                         >
-                            <Text display={["none", "none", "inherit"]}>Send Feedback</Text>
+                            <Tooltip
+                                label={"To receive a response please include contact details such as an email address or Telegram handle in the ticket text."}
+                            >
+                                <Text display={["none", "none", "inherit"]}>Send Feedback</Text>
+                            </Tooltip>
                         </Button>
                     </FeedbackFish>
                 </HStack>


### PR DESCRIPTION
At the moment it is not obvious that we cannot contact users when they send a request via feedback fish.
There is no means to specify additional fields in the feedback fish form.

We can opt for asking users for their emails to "register" their ItchySats version, and then attach the email as metadata, but this is a separate feature that will require some more time.
The easiest way to tell the user that they have to provide contact details in order to receive a response is a tooltip.

![image](https://user-images.githubusercontent.com/5557790/180746204-193ed4d8-28dd-4889-ad57-1fef12e077c9.png)
