### PR TITLE
Bump Rust to 1.62.1

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -51,6 +51,7 @@ use serde::Serialize;
 use sqlite_db;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fmt::Write;
 use std::time::Duration;
 use time::OffsetDateTime;
 use tokio::sync::watch;
@@ -1552,7 +1553,7 @@ impl TxUrl {
 
     /// Highlight particular transaction output in the TxUrl
     fn with_output_index(mut self, index: u32) -> Self {
-        self.url.push_str(&format!(":{index}"));
+        let _ = write!(self.url, ":{index}");
         self
     }
 

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::let_unit_value)] // see: https://github.com/SergioBenitez/Rocket/issues/2211
 use crate::actor_system::ActorSystem;
 use anyhow::Result;
 use bdk::sled;

--- a/rocket-basicauth/src/lib.rs
+++ b/rocket-basicauth/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::let_unit_value)] // see: https://github.com/SergioBenitez/Rocket/issues/2211
 use rocket::http::Header;
 use rocket::http::Status;
 use rocket::outcome::try_outcome;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.60"
+channel = "1.62.1"
 components = ["clippy"]
 targets = ["aarch64-unknown-linux-gnu"]

--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::let_unit_value)] // see: https://github.com/SergioBenitez/Rocket/issues/2211
 use daemon::bdk;
 use daemon::bdk::bitcoin::Amount;
 use daemon::bdk::bitcoin::Network;


### PR DESCRIPTION
Some of the dependencies (e.g. vergen) require the latest version.