### PR TITLE
Extract vergen version into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid 1.1.2",
- "vergen",
+ "vergen-version",
  "x25519-dalek",
  "xtra",
  "xtra-bitmex-price-feed",
@@ -2096,6 +2096,7 @@ dependencies = [
  "tokio-util 0.7.3",
  "tracing",
  "uuid 1.1.2",
+ "vergen-version",
  "x25519-dalek",
  "xtra",
  "xtra-bitmex-price-feed",
@@ -4478,6 +4479,7 @@ dependencies = [
  "tokio-extras",
  "tracing",
  "uuid 0.8.2",
+ "vergen-version",
  "webbrowser",
  "x25519-dalek",
  "xtra",
@@ -5165,6 +5167,14 @@ dependencies = [
  "sysinfo",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "vergen-version"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "vergen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "xtra-libp2p-ping",
   "xtra-libp2p-offer",
   "sqlite-db",
+  "vergen-version",
 ]
 resolver = "2"
 

--- a/bors.toml
+++ b/bors.toml
@@ -20,6 +20,7 @@ status = [
   "clippy (xtra-libp2p-offer)",
   "clippy (otel-tests)",
   "clippy (otel-tests-macro)",
+  "clippy (vergen-version)",
   "lint-commits",
   "frontend (maker)",
   "frontend (taker)",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -48,6 +48,7 @@ tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tracing = { version = "0.1" }
 uuid = { version = "1.1", features = ["serde", "v4"] }
+vergen-version = { path = "../vergen-version" }
 x25519-dalek = { version = "1.1" }
 xtra = { version = "0.6", features = ["instrumentation", "sink"] }
 xtra-bitmex-price-feed = { path = "../xtra-bitmex-price-feed" }
@@ -65,5 +66,4 @@ time = { version = "0.3.11", features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "tracing-log"] }
 
 [build-dependencies]
-vergen = "7"
 anyhow = "1"

--- a/daemon/build.rs
+++ b/daemon/build.rs
@@ -1,14 +1,7 @@
 use anyhow::Result;
-use vergen::vergen;
-use vergen::Config;
-use vergen::SemverKind;
 
 fn main() -> Result<()> {
     std::fs::create_dir_all("../maker-frontend/dist/maker")?;
     std::fs::create_dir_all("../taker-frontend/dist/taker")?;
-
-    let mut config = Config::default();
-    *config.git_mut().semver_kind_mut() = SemverKind::Lightweight;
-
-    vergen(config)
+    Ok(())
 }

--- a/daemon/src/connection.rs
+++ b/daemon/src/connection.rs
@@ -1,6 +1,5 @@
 use crate::noise;
 use crate::setup_taker;
-use crate::version;
 use crate::wire;
 use crate::wire::EncryptedJsonCodec;
 use crate::wire::Version;
@@ -203,7 +202,7 @@ impl Actor {
         write
             .send(wire::TakerToMaker::HelloV4 {
                 proposed_wire_version: proposed_version.clone(),
-                daemon_version: version::version().to_string(),
+                daemon_version: vergen_version::git_semver().to_string(),
                 peer_id: self.peer_id,
                 environment: self.environment.into(),
             })

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -66,7 +66,6 @@ pub mod setup_contract;
 pub mod setup_contract_deprecated;
 pub mod setup_taker;
 pub mod taker_cfd;
-pub mod version;
 pub mod wallet;
 pub mod wire;
 

--- a/daemon/src/version.rs
+++ b/daemon/src/version.rs
@@ -1,3 +1,0 @@
-pub fn version() -> &'static str {
-    env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT")
-}

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -34,6 +34,7 @@ tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tracing = { version = "0.1" }
 uuid = "1.1"
+vergen-version = { path = "../vergen-version" }
 x25519-dalek = { version = "1.1" }
 xtra = { version = "0.6", features = ["instrumentation"] }
 xtra-bitmex-price-feed = { path = "../xtra-bitmex-price-feed" }

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
         &opts.collector_endpoint,
     )
     .context("initialize logger")?;
-    tracing::info!("Running version: {}", daemon::version::version());
+    tracing::info!("Running version: {}", vergen_version::git_semver());
     let settlement_interval_hours = SETTLEMENT_INTERVAL.whole_hours();
 
     tracing::info!(

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -309,6 +309,6 @@ pub struct HealthCheck {
 #[instrument(name = "GET /version")]
 pub async fn get_version() -> Json<HealthCheck> {
     Json(HealthCheck {
-        daemon_version: daemon::version::version().to_string(),
+        daemon_version: vergen_version::git_semver().to_string(),
     })
 }

--- a/taker/Cargo.toml
+++ b/taker/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net",
 tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tracing = { version = "0.1" }
 uuid = "0.8"
+vergen-version = { path = "../vergen-version" }
 webbrowser = "0.7.1"
 x25519-dalek = "1.1"
 xtra = { version = "0.6", features = ["instrumentation"] }

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -208,7 +208,7 @@ async fn main() -> Result<()> {
         &opts.collector_endpoint,
     )
     .context("initialize logger")?;
-    tracing::info!("Running version: {}", daemon::version::version());
+    tracing::info!("Running version: {}", vergen_version::git_semver());
     let settlement_interval_hours = SETTLEMENT_INTERVAL.whole_hours();
 
     tracing::info!(

--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -324,7 +324,7 @@ pub struct HealthCheck {
 #[instrument(name = "GET /version")]
 pub async fn get_version() -> Json<HealthCheck> {
     Json(HealthCheck {
-        daemon_version: daemon::version::version().to_string(),
+        daemon_version: vergen_version::git_semver().to_string(),
     })
 }
 

--- a/vergen-version/Cargo.toml
+++ b/vergen-version/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "vergen-version"
+version = "0.1.0"
+edition = "2021"
+description = "Expose workspace version with git hash using vergen"
+
+[dependencies]
+
+[build-dependencies]
+anyhow = "1"
+vergen = "7"

--- a/vergen-version/build.rs
+++ b/vergen-version/build.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+use vergen::vergen;
+use vergen::Config;
+use vergen::SemverKind;
+
+fn main() -> Result<()> {
+    let mut config = Config::default();
+    *config.git_mut().semver_kind_mut() = SemverKind::Lightweight;
+
+    vergen(config)
+}

--- a/vergen-version/src/lib.rs
+++ b/vergen-version/src/lib.rs
@@ -1,0 +1,8 @@
+/// Return git semver version
+///
+/// Examples:
+/// * 0.5.0 (released version)
+/// * 0.5.0-42-gb1f262c (local branch, 42 commits after 0.5.0 release, with git tag)
+pub fn git_semver() -> &'static str {
+    env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT")
+}


### PR DESCRIPTION
Vergen compiles whole libgit2 as its dependency, which takes a lot of time.
As this crate has no other dependencies, it can be built earlier.