### PR TITLE
`otlp` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,7 +1507,6 @@ dependencies = [
  "cmake",
  "libc",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
  "walkdir",
 ]
@@ -2641,29 +2640,6 @@ name = "openssl-probe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
-
-[[package]]
-name = "openssl-src"
-version = "111.22.0+1.1.1q"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
-dependencies = [
- "autocfg 1.1.0",
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"

--- a/daemon-tests/Cargo.toml
+++ b/daemon-tests/Cargo.toml
@@ -13,7 +13,7 @@ maker = { path = "../maker" }
 mockall = "0.11"
 mockall_derive = "0.11"
 model = { path = "../model" }
-otel-tests = { path = "../otel-tests" }
+otel-tests = { path = "../otel-tests", default-features = false }
 rand = "0.6"
 rust_decimal = "1.25"
 rust_decimal_macros = "1.25"
@@ -26,3 +26,6 @@ xtra = { version = "0.6", features = ["instrumentation"] }
 xtra-bitmex-price-feed = { path = "../xtra-bitmex-price-feed" }
 xtra-libp2p = { path = "../xtra-libp2p" }
 xtra_productivity = { version = "0.1", features = ["instrumentation"] }
+
+[features]
+otlp = ["otel-tests/otlp"]

--- a/otel-tests/Cargo.toml
+++ b/otel-tests/Cargo.toml
@@ -2,14 +2,17 @@
 name = "otel-tests"
 version = "0.1.0"
 edition = "2021"
-description = "Internal #[otel_test] macro to export test spans over OTLP"
+description = "Internal #[otel_test] macro to export test spans over OTLP when the `otlp` feature is enabled"
 
 [dependencies]
 futures = "0.3"
-opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.10.0", features = ["grpc-sys", "trace", "openssl-vendored"] }
+opentelemetry = { version = "0.17.0", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.10.0", features = ["grpc-sys", "trace", "openssl-vendored"], optional = true }
 otel-tests-macro = { path = "../otel-tests-macro" }
 tokio = { version = "1", features = ["macros"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.17.4"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter", "local-time", "tracing-log", "json"] }
+
+[features]
+otlp = ["dep:opentelemetry", "dep:opentelemetry-otlp"]

--- a/otel-tests/Cargo.toml
+++ b/otel-tests/Cargo.toml
@@ -7,7 +7,7 @@ description = "Internal #[otel_test] macro to export test spans over OTLP when t
 [dependencies]
 futures = "0.3"
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"], optional = true }
-opentelemetry-otlp = { version = "0.10.0", features = ["grpc-sys", "trace", "openssl-vendored"], optional = true }
+opentelemetry-otlp = { version = "0.10.0", features = ["grpc-sys", "trace"], optional = true }
 otel-tests-macro = { path = "../otel-tests-macro" }
 tokio = { version = "1", features = ["macros"] }
 tracing = "0.1"


### PR DESCRIPTION


Closes #2524 by adding an `otlp` feature, which is disabled by default and prevents having to compile gRPC when OTLP instrumentation is not required. Both the `otlp` feature and `ITCHYSATS_TEST_INSTRUMENTATION` need to be enabled for instrumentation to work. If just the env var is passed, the test will panic.