### PR TITLE
Run clippy on quiet-spans in CI

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -20,6 +20,7 @@ status = [
   "clippy (xtra-libp2p-offer)",
   "clippy (otel-tests)",
   "clippy (otel-tests-macro)",
+  "clippy (quiet-spans)",
   "clippy (vergen-version)",
   "clippy (xtra-libp2p-rollover)",
   "lint-commits",


### PR DESCRIPTION
Based on #2547, but I am not sure if there is any other configuration required elsewhere for this to work.