### PR TITLE
Add liquidation actor tests

### DIFF
--- a/daemon-tests/src/maia.rs
+++ b/daemon-tests/src/maia.rs
@@ -96,6 +96,20 @@ impl OliviaData {
         self.attestations().last().unwrap().clone()
     }
 
+    pub fn attested_price(&self) -> u64 {
+        self.price
+    }
+
+    pub fn attestation_for_event(
+        &self,
+        event_id: BitMexPriceEventId,
+    ) -> Option<oracle::Attestation> {
+        self.attestations()
+            .iter()
+            .find(|attestation| attestation.id() == event_id)
+            .cloned()
+    }
+
     const OLIVIA_PK: &'static str =
         "ddd4636845a90185991826be5a494cde9f4a6947b1727217afedc6292fa4caf7";
 

--- a/daemon-tests/src/mocks/oracle.rs
+++ b/daemon-tests/src/mocks/oracle.rs
@@ -71,9 +71,9 @@ impl MockOracle {
         }
     }
 
-    pub async fn simulate_attestation(&mut self, id: OrderId, attestation: oracle::Attestation) {
+    pub async fn simulate_attestation(&mut self, id: OrderId, attestation: &oracle::Attestation) {
         self.executor
-            .execute(id, |cfd| cfd.decrypt_cet(&attestation.into_inner()))
+            .execute(id, |cfd| cfd.decrypt_cet(attestation.as_inner()))
             .await
             .unwrap();
     }

--- a/daemon-tests/tests/collaborative_settlement.rs
+++ b/daemon-tests/tests/collaborative_settlement.rs
@@ -3,9 +3,10 @@ use daemon_tests::confirm;
 use daemon_tests::dummy_quote;
 use daemon_tests::flow::next_with;
 use daemon_tests::flow::one_cfd_with_state;
-use daemon_tests::maia::OliviaData;
-use daemon_tests::start_from_open_cfd_state;
+use daemon_tests::open_cfd;
+use daemon_tests::start_both;
 use daemon_tests::wait_next_state;
+use daemon_tests::OpenCfdArgs;
 use model::Position;
 use otel_tests::otel_test;
 use std::time::Duration;
@@ -23,8 +24,9 @@ async fn collaboratively_close_an_open_cfd_maker_going_long() {
 
 #[otel_test]
 async fn maker_rejects_collab_settlement_after_commit_finality() {
-    let (mut maker, mut taker, order_id, _) =
-        start_from_open_cfd_state(OliviaData::example_0().announcements(), Position::Short).await;
+    let (mut maker, mut taker) = start_both().await;
+    let (order_id, _) = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
+
     taker.mocks.mock_latest_quote(Some(dummy_quote())).await;
     maker.mocks.mock_latest_quote(Some(dummy_quote())).await;
     next_with(taker.quote_feed(), |q| q).await.unwrap(); // if quote is available on feed, it propagated through the system
@@ -49,8 +51,9 @@ async fn maker_rejects_collab_settlement_after_commit_finality() {
 
 #[otel_test]
 async fn maker_accepts_collab_settlement_after_commit_finality() {
-    let (mut maker, mut taker, order_id, _) =
-        start_from_open_cfd_state(OliviaData::example_0().announcements(), Position::Short).await;
+    let (mut maker, mut taker) = start_both().await;
+    let (order_id, _) = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
+
     taker.mocks.mock_latest_quote(Some(dummy_quote())).await;
     maker.mocks.mock_latest_quote(Some(dummy_quote())).await;
     next_with(taker.quote_feed(), |q| q).await.unwrap(); // if quote is available on feed, it propagated through the system
@@ -73,9 +76,17 @@ async fn maker_accepts_collab_settlement_after_commit_finality() {
     wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
 }
 
-async fn collaboratively_close_an_open_cfd(maker_position: Position) {
-    let (mut maker, mut taker, order_id, _) =
-        start_from_open_cfd_state(OliviaData::example_0().announcements(), maker_position).await;
+async fn collaboratively_close_an_open_cfd(position_maker: Position) {
+    let (mut maker, mut taker) = start_both().await;
+    let (order_id, _) = open_cfd(
+        &mut taker,
+        &mut maker,
+        OpenCfdArgs {
+            position_maker,
+            ..Default::default()
+        },
+    )
+    .await;
     taker.mocks.mock_latest_quote(Some(dummy_quote())).await;
     maker.mocks.mock_latest_quote(Some(dummy_quote())).await;
     next_with(taker.quote_feed(), |q| q).await.unwrap(); // if quote is available on feed, it propagated through the system

--- a/daemon-tests/tests/collaborative_settlement.rs
+++ b/daemon-tests/tests/collaborative_settlement.rs
@@ -25,7 +25,7 @@ async fn collaboratively_close_an_open_cfd_maker_going_long() {
 #[otel_test]
 async fn maker_rejects_collab_settlement_after_commit_finality() {
     let (mut maker, mut taker) = start_both().await;
-    let (order_id, _) = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
+    let order_id = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
 
     taker.mocks.mock_latest_quote(Some(dummy_quote())).await;
     maker.mocks.mock_latest_quote(Some(dummy_quote())).await;
@@ -52,7 +52,7 @@ async fn maker_rejects_collab_settlement_after_commit_finality() {
 #[otel_test]
 async fn maker_accepts_collab_settlement_after_commit_finality() {
     let (mut maker, mut taker) = start_both().await;
-    let (order_id, _) = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
+    let order_id = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
 
     taker.mocks.mock_latest_quote(Some(dummy_quote())).await;
     maker.mocks.mock_latest_quote(Some(dummy_quote())).await;
@@ -78,7 +78,7 @@ async fn maker_accepts_collab_settlement_after_commit_finality() {
 
 async fn collaboratively_close_an_open_cfd(position_maker: Position) {
     let (mut maker, mut taker) = start_both().await;
-    let (order_id, _) = open_cfd(
+    let order_id = open_cfd(
         &mut taker,
         &mut maker,
         OpenCfdArgs {

--- a/daemon-tests/tests/liquidation.rs
+++ b/daemon-tests/tests/liquidation.rs
@@ -57,7 +57,7 @@ async fn given_open_cfd_when_oracle_attests_long_liquidation_price_can_liquidate
         .attestation_for_event(first_liquidation_event)
         .unwrap();
 
-    simulate_attestation!(taker, maker, order_id, attestation.clone());
+    simulate_attestation!(taker, maker, order_id, &attestation);
     wait_next_state!(order_id, maker, taker, CfdState::PendingCet);
 
     confirm!(cet, order_id, maker, taker);
@@ -113,7 +113,7 @@ async fn given_rollover_when_oracle_attests_long_liquidation_price_can_liquidate
         .attestation_for_event(first_liquidation_event)
         .unwrap();
 
-    simulate_attestation!(taker, maker, order_id, attestation.clone());
+    simulate_attestation!(taker, maker, order_id, &attestation);
     wait_next_state!(order_id, maker, taker, CfdState::PendingCet);
 
     confirm!(cet, order_id, maker, taker);

--- a/daemon-tests/tests/liquidation.rs
+++ b/daemon-tests/tests/liquidation.rs
@@ -1,0 +1,143 @@
+use daemon::projection::CfdState;
+use daemon_tests::confirm;
+use daemon_tests::expire;
+use daemon_tests::flow::next_with;
+use daemon_tests::flow::one_cfd_with_state;
+use daemon_tests::maia::OliviaData;
+use daemon_tests::mock_oracle_announcements;
+use daemon_tests::open_cfd;
+use daemon_tests::simulate_attestation;
+use daemon_tests::start_both;
+use daemon_tests::wait_next_state;
+use daemon_tests::OpenCfdArgs;
+use model::Dlc;
+use model::Price;
+use otel_tests::otel_test;
+use rust_decimal::Decimal;
+
+#[otel_test]
+async fn given_open_cfd_when_oracle_attests_long_liquidation_price_can_liquidate() {
+    let (mut maker, mut taker) = start_both().await;
+
+    let oracle_data = OliviaData::example_0();
+
+    // We set the initial price to a value much higher than that of the price that the mock oracle
+    // will attest to. This is so that the price attested to falls within the long liquidation
+    // interval of the payout curve (the very first interval)
+    let future_attestation_price = oracle_data.attested_price();
+    let initial_price =
+        Price::new(Decimal::from(future_attestation_price * 8)).expect("positive price");
+
+    let (order_id, _) = open_cfd(
+        &mut taker,
+        &mut maker,
+        OpenCfdArgs {
+            initial_price,
+            oracle_data: oracle_data.clone(),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    assert!(
+        is_attestation_price_in_any_interval_of_all_liquidation_events(
+            &taker.latest_dlc(),
+            future_attestation_price
+        )
+    );
+
+    taker.system.commit(order_id).await.unwrap();
+    confirm!(commit transaction, order_id, maker, taker);
+    wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
+
+    expire!(cet timelock, order_id, maker, taker);
+
+    let first_liquidation_event = taker.latest_dlc().liquidation_event_ids()[0];
+    let attestation = oracle_data
+        .attestation_for_event(first_liquidation_event)
+        .unwrap();
+
+    simulate_attestation!(taker, maker, order_id, attestation.clone());
+    wait_next_state!(order_id, maker, taker, CfdState::PendingCet);
+
+    confirm!(cet, order_id, maker, taker);
+    wait_next_state!(order_id, maker, taker, CfdState::Closed);
+}
+
+#[otel_test]
+async fn given_rollover_when_oracle_attests_long_liquidation_price_can_liquidate() {
+    let (mut maker, mut taker) = start_both().await;
+
+    let oracle_data_contract_setup = OliviaData::example_0();
+
+    // We set the initial price to a value much higher than that of the price that the mock oracle
+    // will attest to. This is so that the price attested to falls within the long liquidation
+    // interval of the payout curve (the very first interval)
+    let future_attestation_price = oracle_data_contract_setup.attested_price();
+    let initial_price =
+        Price::new(Decimal::from(future_attestation_price * 8)).expect("positive price");
+
+    let (order_id, _) = open_cfd(
+        &mut taker,
+        &mut maker,
+        OpenCfdArgs {
+            initial_price,
+            oracle_data: oracle_data_contract_setup,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    assert!(
+        is_attestation_price_in_any_interval_of_all_liquidation_events(
+            &taker.latest_dlc(),
+            future_attestation_price
+        )
+    );
+
+    let oracle_data_rollover = OliviaData::example_1();
+    mock_oracle_announcements(&mut maker, &mut taker, oracle_data_rollover.announcements()).await;
+
+    taker
+        .trigger_rollover_with_latest_dlc_params(order_id)
+        .await;
+
+    taker.system.commit(order_id).await.unwrap();
+    confirm!(commit transaction, order_id, maker, taker);
+    wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
+
+    expire!(cet timelock, order_id, maker, taker);
+
+    let first_liquidation_event = taker.latest_dlc().liquidation_event_ids()[0];
+    let attestation = oracle_data_rollover
+        .attestation_for_event(first_liquidation_event)
+        .unwrap();
+
+    simulate_attestation!(taker, maker, order_id, attestation.clone());
+    wait_next_state!(order_id, maker, taker, CfdState::PendingCet);
+
+    confirm!(cet, order_id, maker, taker);
+    wait_next_state!(order_id, maker, taker, CfdState::Closed);
+}
+
+/// Verify that the mocked attestation price plays nicely with the mocked initial price of the CFD.
+///
+/// Checking this ensures that all liquidation events are "active" after we mock the oracle
+/// attestations. By active we mean that at least one CET per liquidation event ID will be
+/// successfully decrypted in combination with the oracle attestation.
+fn is_attestation_price_in_any_interval_of_all_liquidation_events(
+    dlc: &Dlc,
+    attestation_price: u64,
+) -> bool {
+    let settlement_event_id = dlc.settlement_event_id;
+
+    let cets_per_event_id = &dlc.cets;
+    let mut liquidation_cets_per_event_id = cets_per_event_id
+        .iter()
+        .filter(|(id, _)| **id != settlement_event_id);
+
+    liquidation_cets_per_event_id.all(|(_, cets)| {
+        cets.iter()
+            .any(|cet| cet.range.contains(&attestation_price))
+    })
+}

--- a/daemon-tests/tests/liquidation.rs
+++ b/daemon-tests/tests/liquidation.rs
@@ -28,7 +28,7 @@ async fn given_open_cfd_when_oracle_attests_long_liquidation_price_can_liquidate
     let initial_price =
         Price::new(Decimal::from(future_attestation_price * 8)).expect("positive price");
 
-    let (order_id, _) = open_cfd(
+    let order_id = open_cfd(
         &mut taker,
         &mut maker,
         OpenCfdArgs {
@@ -77,7 +77,7 @@ async fn given_rollover_when_oracle_attests_long_liquidation_price_can_liquidate
     let initial_price =
         Price::new(Decimal::from(future_attestation_price * 8)).expect("positive price");
 
-    let (order_id, _) = open_cfd(
+    let order_id = open_cfd(
         &mut taker,
         &mut maker,
         OpenCfdArgs {

--- a/daemon-tests/tests/non_collaborative_settlement.rs
+++ b/daemon-tests/tests/non_collaborative_settlement.rs
@@ -32,7 +32,7 @@ async fn force_close_open_cfd(position_maker: Position) {
         ..Default::default()
     };
 
-    let (order_id, _) = open_cfd(&mut taker, &mut maker, open_cfd_args.clone()).await;
+    let order_id = open_cfd(&mut taker, &mut maker, open_cfd_args.clone()).await;
     // Taker initiates force-closing
     taker.system.commit(order_id).await.unwrap();
 

--- a/daemon-tests/tests/non_collaborative_settlement.rs
+++ b/daemon-tests/tests/non_collaborative_settlement.rs
@@ -1,18 +1,9 @@
-use daemon::projection::CfdState;
-use daemon_tests::confirm;
-use daemon_tests::expire;
-use daemon_tests::flow::next_with;
-use daemon_tests::flow::one_cfd_with_state;
-use daemon_tests::mocks::oracle::dummy_wrong_attestation;
 use daemon_tests::open_cfd;
-use daemon_tests::simulate_attestation;
+use daemon_tests::settle_non_collaboratively;
 use daemon_tests::start_both;
-use daemon_tests::wait_next_state;
 use daemon_tests::OpenCfdArgs;
 use model::Position;
 use otel_tests::otel_test;
-use std::time::Duration;
-use tokio_extras::time::sleep;
 
 #[otel_test]
 async fn force_close_an_open_cfd_maker_going_short() {
@@ -36,31 +27,11 @@ async fn force_close_open_cfd(position_maker: Position) {
     // Taker initiates force-closing
     taker.system.commit(order_id).await.unwrap();
 
-    confirm!(commit transaction, order_id, maker, taker);
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
-    wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
-
-    // After CetTimelockExpired, we're only waiting for attestation
-    expire!(cet timelock, order_id, maker, taker);
-
-    // Delivering the wrong attestation does not move state to `PendingCet`
-    simulate_attestation!(taker, maker, order_id, &dummy_wrong_attestation());
-
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
-    wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
-
-    // Delivering correct attestation moves the state `PendingCet`
-    simulate_attestation!(
-        taker,
-        maker,
+    settle_non_collaboratively(
+        &mut taker,
+        &mut maker,
         order_id,
-        &open_cfd_args.oracle_data.settlement_attestation()
-    );
-
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
-    wait_next_state!(order_id, maker, taker, CfdState::PendingCet);
-
-    confirm!(cet, order_id, maker, taker);
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
-    wait_next_state!(order_id, maker, taker, CfdState::Closed);
+        &open_cfd_args.oracle_data.settlement_attestation(),
+    )
+    .await;
 }

--- a/daemon-tests/tests/non_collaborative_settlement.rs
+++ b/daemon-tests/tests/non_collaborative_settlement.rs
@@ -44,7 +44,7 @@ async fn force_close_open_cfd(position_maker: Position) {
     expire!(cet timelock, order_id, maker, taker);
 
     // Delivering the wrong attestation does not move state to `PendingCet`
-    simulate_attestation!(taker, maker, order_id, dummy_wrong_attestation());
+    simulate_attestation!(taker, maker, order_id, &dummy_wrong_attestation());
 
     sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
@@ -54,7 +54,7 @@ async fn force_close_open_cfd(position_maker: Position) {
         taker,
         maker,
         order_id,
-        open_cfd_args.oracle_data.settlement_attestation()
+        &open_cfd_args.oracle_data.settlement_attestation()
     );
 
     sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition

--- a/daemon-tests/tests/non_collaborative_settlement.rs
+++ b/daemon-tests/tests/non_collaborative_settlement.rs
@@ -3,11 +3,12 @@ use daemon_tests::confirm;
 use daemon_tests::expire;
 use daemon_tests::flow::next_with;
 use daemon_tests::flow::one_cfd_with_state;
-use daemon_tests::maia::OliviaData;
 use daemon_tests::mocks::oracle::dummy_wrong_attestation;
+use daemon_tests::open_cfd;
 use daemon_tests::simulate_attestation;
-use daemon_tests::start_from_open_cfd_state;
+use daemon_tests::start_both;
 use daemon_tests::wait_next_state;
+use daemon_tests::OpenCfdArgs;
 use model::Position;
 use otel_tests::otel_test;
 use std::time::Duration;
@@ -23,10 +24,15 @@ async fn force_close_an_open_cfd_maker_going_long() {
     force_close_open_cfd(Position::Long).await;
 }
 
-async fn force_close_open_cfd(maker_position: Position) {
-    let oracle_data = OliviaData::example_0();
-    let (mut maker, mut taker, order_id, _) =
-        start_from_open_cfd_state(oracle_data.announcements(), maker_position).await;
+async fn force_close_open_cfd(position_maker: Position) {
+    let (mut maker, mut taker) = start_both().await;
+
+    let open_cfd_args = OpenCfdArgs {
+        position_maker,
+        ..Default::default()
+    };
+
+    let (order_id, _) = open_cfd(&mut taker, &mut maker, open_cfd_args.clone()).await;
     // Taker initiates force-closing
     taker.system.commit(order_id).await.unwrap();
 
@@ -44,7 +50,12 @@ async fn force_close_open_cfd(maker_position: Position) {
     wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
 
     // Delivering correct attestation moves the state `PendingCet`
-    simulate_attestation!(taker, maker, order_id, oracle_data.settlement_attestation());
+    simulate_attestation!(
+        taker,
+        maker,
+        order_id,
+        open_cfd_args.oracle_data.settlement_attestation()
+    );
 
     sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     wait_next_state!(order_id, maker, taker, CfdState::PendingCet);

--- a/daemon-tests/tests/offer.rs
+++ b/daemon-tests/tests/offer.rs
@@ -1,12 +1,11 @@
 use daemon::bdk::bitcoin::Amount;
 use daemon::projection::CfdOffer;
 use daemon::projection::MakerOffers;
-use daemon_tests::dummy_offer_params;
 use daemon_tests::flow::is_next_offers_none;
 use daemon_tests::flow::next_maker_offers;
 use daemon_tests::start_both;
+use daemon_tests::OfferParamsBuilder;
 use model::Leverage;
-use model::Position;
 use otel_tests::otel_test;
 
 #[otel_test]
@@ -16,7 +15,7 @@ async fn taker_receives_offer_from_maker_on_publication() {
     assert!(is_next_offers_none(taker.offers_feed()).await.unwrap());
 
     maker
-        .set_offer_params(dummy_offer_params(Position::Short))
+        .set_offer_params(OfferParamsBuilder::new().build())
         .await;
 
     let (published, received) = next_maker_offers(maker.offers_feed(), taker.offers_feed())

--- a/daemon-tests/tests/order.rs
+++ b/daemon-tests/tests/order.rs
@@ -1,6 +1,5 @@
 use daemon::projection::CfdState;
 use daemon_tests::confirm;
-use daemon_tests::dummy_offer_params;
 use daemon_tests::flow::cfd_with_state;
 use daemon_tests::flow::is_next_offers_none;
 use daemon_tests::flow::next_maker_offers;
@@ -10,10 +9,10 @@ use daemon_tests::start_both;
 use daemon_tests::wait_next_state;
 use daemon_tests::wait_next_state_multi_cfd;
 use daemon_tests::Maker;
+use daemon_tests::OfferParamsBuilder;
 use daemon_tests::Taker;
 use model::Leverage;
 use model::OrderId;
-use model::Position;
 use model::Usd;
 use otel_tests::otel_test;
 use rust_decimal_macros::dec;
@@ -27,7 +26,7 @@ async fn taker_places_order_and_maker_rejects() {
     is_next_offers_none(taker.offers_feed()).await.unwrap();
 
     maker
-        .set_offer_params(dummy_offer_params(Position::Short))
+        .set_offer_params(OfferParamsBuilder::new().build())
         .await;
 
     let (_, received) = next_maker_offers(maker.offers_feed(), taker.offers_feed())
@@ -58,7 +57,7 @@ async fn taker_places_order_and_maker_accepts_and_contract_setup() {
     is_next_offers_none(taker.offers_feed()).await.unwrap();
 
     maker
-        .set_offer_params(dummy_offer_params(Position::Short))
+        .set_offer_params(OfferParamsBuilder::new().build())
         .await;
 
     let (_, received) = next_maker_offers(maker.offers_feed(), taker.offers_feed())
@@ -86,7 +85,7 @@ async fn taker_places_order_for_same_offer_twice_results_in_two_cfds() {
     is_next_offers_none(taker.offers_feed()).await.unwrap();
 
     maker
-        .set_offer_params(dummy_offer_params(Position::Short))
+        .set_offer_params(OfferParamsBuilder::new().build())
         .await;
 
     let (_, received) = next_maker_offers(maker.offers_feed(), taker.offers_feed())

--- a/daemon-tests/tests/refund.rs
+++ b/daemon-tests/tests/refund.rs
@@ -3,19 +3,18 @@ use daemon_tests::confirm;
 use daemon_tests::expire;
 use daemon_tests::flow::next_with;
 use daemon_tests::flow::one_cfd_with_state;
-use daemon_tests::maia::OliviaData;
-use daemon_tests::start_from_open_cfd_state;
+use daemon_tests::open_cfd;
+use daemon_tests::start_both;
 use daemon_tests::wait_next_state;
-use model::Position;
+use daemon_tests::OpenCfdArgs;
 use otel_tests::otel_test;
 use std::time::Duration;
 use tokio_extras::time::sleep;
 
 #[otel_test]
 async fn open_cfd_is_refunded() {
-    let oracle_data = OliviaData::example_0();
-    let (mut maker, mut taker, order_id, _) =
-        start_from_open_cfd_state(oracle_data.announcements(), Position::Short).await;
+    let (mut maker, mut taker) = start_both().await;
+    let (order_id, _) = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
     confirm!(commit transaction, order_id, maker, taker);
 
     sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition

--- a/daemon-tests/tests/refund.rs
+++ b/daemon-tests/tests/refund.rs
@@ -14,7 +14,7 @@ use tokio_extras::time::sleep;
 #[otel_test]
 async fn open_cfd_is_refunded() {
     let (mut maker, mut taker) = start_both().await;
-    let (order_id, _) = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
+    let order_id = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
     confirm!(commit transaction, order_id, maker, taker);
 
     sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition

--- a/daemon-tests/tests/rollover.rs
+++ b/daemon-tests/tests/rollover.rs
@@ -1,7 +1,6 @@
 use daemon::bdk::bitcoin::SignedAmount;
 use daemon::bdk::bitcoin::Txid;
 use daemon::projection::CfdState;
-use daemon_tests::dummy_offer_params;
 use daemon_tests::flow::next_with;
 use daemon_tests::flow::one_cfd_with_state;
 use daemon_tests::maia::OliviaData;
@@ -11,6 +10,7 @@ use daemon_tests::start_both;
 use daemon_tests::wait_next_state;
 use daemon_tests::FeeCalculator;
 use daemon_tests::Maker;
+use daemon_tests::OfferParamsBuilder;
 use daemon_tests::OpenCfdArgs;
 use daemon_tests::Taker;
 use model::olivia::BitMexPriceEventId;
@@ -327,13 +327,14 @@ async fn prepare_rollover(
         OpenCfdArgs {
             position_maker,
             oracle_data,
+            ..Default::default()
         },
     )
     .await;
 
     // Maker needs to have an active offer in order to accept rollover
     maker
-        .set_offer_params(dummy_offer_params(position_maker))
+        .set_offer_params(OfferParamsBuilder::new().build())
         .await;
 
     let maker_cfd = maker.first_cfd();
@@ -347,7 +348,7 @@ async fn prepare_rollover(
     (maker, taker, order_id, fee_calculator)
 }
 
-async fn rollover(
+pub async fn rollover(
     maker: &mut Maker,
     taker: &mut Taker,
     order_id: OrderId,

--- a/daemon-tests/tests/rollover.rs
+++ b/daemon-tests/tests/rollover.rs
@@ -6,10 +6,12 @@ use daemon_tests::flow::next_with;
 use daemon_tests::flow::one_cfd_with_state;
 use daemon_tests::maia::OliviaData;
 use daemon_tests::mock_oracle_announcements;
-use daemon_tests::start_from_open_cfd_state;
+use daemon_tests::open_cfd;
+use daemon_tests::start_both;
 use daemon_tests::wait_next_state;
 use daemon_tests::FeeCalculator;
 use daemon_tests::Maker;
+use daemon_tests::OpenCfdArgs;
 use daemon_tests::Taker;
 use model::olivia::BitMexPriceEventId;
 use model::OrderId;
@@ -84,9 +86,8 @@ async fn double_rollover_an_open_cfd() {
 
 #[otel_test]
 async fn maker_rejects_rollover_of_open_cfd() {
-    let oracle_data = OliviaData::example_0();
-    let (mut maker, mut taker, order_id, _) =
-        start_from_open_cfd_state(oracle_data.announcements(), Position::Short).await;
+    let (mut maker, mut taker) = start_both().await;
+    let (order_id, _) = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
 
     let is_accepting_rollovers = false;
     maker
@@ -316,15 +317,23 @@ async fn given_contract_setup_completed_when_taker_fails_two_rollovers_can_retry
 /// up-to-date fee calculation.
 /// Asserts that initially both parties don't have funding costs.
 async fn prepare_rollover(
-    maker_position: Position,
+    position_maker: Position,
     oracle_data: OliviaData,
 ) -> (Maker, Taker, OrderId, FeeCalculator) {
-    let (mut maker, mut taker, order_id, fee_calculator) =
-        start_from_open_cfd_state(oracle_data.announcements(), maker_position).await;
+    let (mut maker, mut taker) = start_both().await;
+    let (order_id, fee_calculator) = open_cfd(
+        &mut taker,
+        &mut maker,
+        OpenCfdArgs {
+            position_maker,
+            oracle_data,
+        },
+    )
+    .await;
 
     // Maker needs to have an active offer in order to accept rollover
     maker
-        .set_offer_params(dummy_offer_params(maker_position))
+        .set_offer_params(dummy_offer_params(position_maker))
         .await;
 
     let maker_cfd = maker.first_cfd();

--- a/daemon-tests/tests/rollover.rs
+++ b/daemon-tests/tests/rollover.rs
@@ -87,7 +87,7 @@ async fn double_rollover_an_open_cfd() {
 #[otel_test]
 async fn maker_rejects_rollover_of_open_cfd() {
     let (mut maker, mut taker) = start_both().await;
-    let (order_id, _) = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
+    let order_id = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
 
     let is_accepting_rollovers = false;
     maker
@@ -321,16 +321,15 @@ async fn prepare_rollover(
     oracle_data: OliviaData,
 ) -> (Maker, Taker, OrderId, FeeCalculator) {
     let (mut maker, mut taker) = start_both().await;
-    let (order_id, fee_calculator) = open_cfd(
-        &mut taker,
-        &mut maker,
-        OpenCfdArgs {
-            position_maker,
-            oracle_data,
-            ..Default::default()
-        },
-    )
-    .await;
+
+    let open_cfd_args = OpenCfdArgs {
+        position_maker,
+        oracle_data,
+        ..Default::default()
+    };
+    let fee_calculator = open_cfd_args.fee_calculator();
+
+    let order_id = open_cfd(&mut taker, &mut maker, open_cfd_args).await;
 
     // Maker needs to have an active offer in order to accept rollover
     maker

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -44,7 +44,6 @@ use model::Usd;
 use model::SETTLEMENT_INTERVAL;
 use parse_display::Display;
 use parse_display::FromStr;
-use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde::Deserialize;
@@ -1035,8 +1034,7 @@ impl sqlite_db::FailedCfdAggregate for Cfd {
             FailedKind::ContractSetupFailed => CfdState::SetupFailed,
         };
 
-        let quantity_usd =
-            Usd::new(Decimal::from_u64(u64::from(n_contracts)).expect("u64 to fit into Decimal"));
+        let quantity_usd = Usd::new(Decimal::from(u64::from(n_contracts)));
 
         let (our_leverage, counterparty_leverage) = match role {
             Role::Maker => (Leverage::ONE, taker_leverage),

--- a/model/src/payouts.rs
+++ b/model/src/payouts.rs
@@ -17,6 +17,7 @@ mod payout_curve;
 
 /// Payout combinations associated with the oracle events that may
 /// trigger them.
+#[derive(Debug)]
 pub struct OraclePayouts(HashMap<Announcement, Vec<Payout>>);
 
 impl OraclePayouts {
@@ -24,21 +25,18 @@ impl OraclePayouts {
         let announcements = Announcements::new(announcements)?;
 
         let settlement = (announcements.settlement, payouts.settlement);
-        let long_liquidations = announcements
-            .liquidation
-            .clone()
-            .into_iter()
-            .map(|announcement| (announcement, vec![payouts.long_liquidation.clone()]));
-        let short_liquidations = announcements
-            .liquidation
-            .into_iter()
-            .map(|announcement| (announcement, vec![payouts.short_liquidation.clone()]));
+        let liquidations = announcements.liquidation.into_iter().map(|announcement| {
+            (
+                announcement,
+                vec![
+                    payouts.long_liquidation.clone(),
+                    payouts.short_liquidation.clone(),
+                ],
+            )
+        });
 
         Ok(Self(HashMap::from_iter(
-            [settlement]
-                .into_iter()
-                .chain(long_liquidations)
-                .chain(short_liquidations),
+            [settlement].into_iter().chain(liquidations),
         )))
     }
 }

--- a/model/src/payouts.rs
+++ b/model/src/payouts.rs
@@ -148,3 +148,77 @@ impl Announcements {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::olivia::Announcement;
+    use crate::olivia::BitMexPriceEventId;
+    use crate::payouts::payout_curve::prop_compose::arb_contracts;
+    use crate::payouts::payout_curve::prop_compose::arb_fee_flow;
+    use crate::payouts::payout_curve::prop_compose::arb_leverage;
+    use crate::payouts::payout_curve::prop_compose::arb_price;
+    use proptest::prelude::*;
+    use std::ops::Add;
+    use time::ext::NumericalDuration;
+    use time::macros::datetime;
+
+    proptest! {
+        #[test]
+        fn given_generated_payouts_then_can_build_oracle_payouts(
+            position in prop_oneof![Just(Position::Long), Just(Position::Short)],
+            role in prop_oneof![Just(Role::Maker), Just(Role::Taker)],
+            price in arb_price(1000.0, 100_000.0),
+            n_contracts in arb_contracts(100, 10_000_000),
+            short_leverage in arb_leverage(1, 100),
+            fee_flow in arb_fee_flow(-100_000_000, 100_000_000),
+        ) {
+            let payouts = Payouts::new(
+                position,
+                role,
+                price,
+                n_contracts,
+                Leverage::ONE,
+                short_leverage,
+                200,
+                fee_flow,
+            )
+                .unwrap();
+
+            let n_events = 24;
+            let announcements = (0..n_events)
+                .map(|i| {
+                    let timestamp = datetime!(2022-07-29 13:00:00).assume_utc().add(i.hours());
+
+                    Announcement {
+                        id: BitMexPriceEventId::new(timestamp, 1),
+                        expected_outcome_time: timestamp,
+                        nonce_pks: vec![
+                            "d02d163cf9623f567c4e3faf851a9266ac1ede13da4ca4141f3a7717fba9a739"
+                                .parse()
+                                .unwrap(),
+                        ],
+                    }
+                })
+                .collect_vec();
+
+            let mut oracle_payouts = OraclePayouts::new(payouts, announcements.clone()).unwrap();
+            assert_eq!(oracle_payouts.0.len() as i64, n_events);
+
+            {
+                let settlement_announcement = {
+                    let settlement_announcement = announcements.last().unwrap();
+                    maia_core::Announcement { id: settlement_announcement.id.to_string(), nonce_pks: settlement_announcement.nonce_pks.clone() }
+                };
+
+                oracle_payouts.0.remove(&settlement_announcement);
+            }
+
+            let has_long_and_short_liquidation_payouts = oracle_payouts
+                .0
+                .iter()
+                .all(|(_, payouts)| payouts.len() == 2);
+            assert!(has_long_and_short_liquidation_payouts)
+        }
+    }
+}

--- a/model/src/payouts/payout_curve.rs
+++ b/model/src/payouts/payout_curve.rs
@@ -890,7 +890,7 @@ mod tests {
 
     prop_compose! {
         fn arb_contracts(min: u64, max: u64)(contracts in min..max) -> Usd {
-            let contracts = Decimal::from_u64(contracts).unwrap();
+            let contracts = Decimal::from(contracts);
 
             Usd::new(contracts)
         }

--- a/model/src/payouts/payout_curve.rs
+++ b/model/src/payouts/payout_curve.rs
@@ -485,6 +485,10 @@ fn create_long_payout_function(
 
 #[cfg(test)]
 mod tests {
+    use super::prop_compose::arb_contracts;
+    use super::prop_compose::arb_fee_flow;
+    use super::prop_compose::arb_leverage;
+    use super::prop_compose::arb_price;
     use super::*;
     use bdk::bitcoin::Amount;
     use proptest::prelude::*;
@@ -880,28 +884,52 @@ mod tests {
         }
     }
 
+    fn payout(range: RangeInclusive<u64>, short: u64, long: u64) -> PayoutParameter {
+        PayoutParameter {
+            left_bound: *range.start(),
+            right_bound: *range.end(),
+            long_amount: long,
+            short_amount: short,
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod prop_compose {
+    use crate::CompleteFee;
+    use crate::Leverage;
+    use crate::Price;
+    use crate::Usd;
+    use bdk::bitcoin::Amount;
+    use num::FromPrimitive;
+    use proptest::prop_compose;
+    use rust_decimal::Decimal;
+
     prop_compose! {
-        fn arb_price(min: f64, max: f64)(price in min..max) -> Price {
+        pub fn arb_price(min: f64, max: f64)(price in min..max) -> Price {
             let price = Decimal::from_f64(price).unwrap();
 
             Price::new(price).unwrap()
         }
     }
 
+    #[cfg(test)]
     prop_compose! {
-        fn arb_contracts(min: u64, max: u64)(contracts in min..max) -> Usd {
+        pub fn arb_contracts(min: u64, max: u64)(contracts in min..max) -> Usd {
             let contracts = Decimal::from(contracts);
 
             Usd::new(contracts)
         }
     }
 
+    #[cfg(test)]
     prop_compose! {
-        fn arb_leverage(min: u8, max: u8)(leverage in min..max) -> Leverage {
+        pub fn arb_leverage(min: u8, max: u8)(leverage in min..max) -> Leverage {
             Leverage::new(leverage).unwrap()
         }
     }
 
+    #[cfg(test)]
     prop_compose! {
         /// Generate an arbitrary fee flow value, between the `lower`
         /// and `upper` bounds.
@@ -909,7 +937,7 @@ mod tests {
         /// A positive value represents a fee flow from long to short.
         /// Conversely, a negative valure represents a fee flow from
         /// short to long.
-        fn arb_fee_flow(lower: i64, upper: i64)(fee in lower..upper) -> CompleteFee {
+        pub fn arb_fee_flow(lower: i64, upper: i64)(fee in lower..upper) -> CompleteFee {
             let fee_amount = Amount::from_sat(fee.abs().try_into().unwrap());
             if fee.is_positive() {
                 CompleteFee::LongPaysShort(fee_amount)
@@ -918,15 +946,6 @@ mod tests {
             } else {
                 CompleteFee::None
             }
-        }
-    }
-
-    fn payout(range: RangeInclusive<u64>, short: u64, long: u64) -> PayoutParameter {
-        PayoutParameter {
-            left_bound: *range.start(),
-            right_bound: *range.end(),
-            long_amount: long,
-            short_amount: short,
         }
     }
 }

--- a/model/src/payouts/payout_curve.rs
+++ b/model/src/payouts/payout_curve.rs
@@ -913,6 +913,36 @@ mod tests {
         }
     }
 
+    proptest! {
+        #[test]
+        #[ignore = "Payout intervals are _not_ always monotonically increasing"]
+        fn payout_intervals_are_monotonically_increasing(
+            price in arb_price(500.0, 340_000.0),
+            n_contracts in arb_contracts(100, 10_000_000),
+            long_leverage in arb_leverage(1, 200),
+            short_leverage in arb_leverage(1, 200),
+            n_payouts in 10usize..2000,
+            fee_flow in arb_fee_flow(-100_000_000, 100_000_000),
+        ) {
+            let payouts = calculate_payout_parameters(
+                price,
+                n_contracts,
+                long_leverage,
+                short_leverage,
+                n_payouts,
+                fee_flow,
+            )
+                .unwrap();
+
+
+            let are_payout_intervals_monotonically_increasing = payouts
+                .iter()
+                .all(|a| a.left_bound <= a.right_bound);
+
+            prop_assert!(are_payout_intervals_monotonically_increasing)
+        }
+    }
+
     fn payout(range: RangeInclusive<u64>, short: u64, long: u64) -> PayoutParameter {
         PayoutParameter {
             left_bound: *range.start(),

--- a/xtra-libp2p-rollover/src/v_2_0_0/maker.rs
+++ b/xtra-libp2p-rollover/src/v_2_0_0/maker.rs
@@ -279,7 +279,7 @@ where
                         punish_params,
                         Role::Maker,
                     )
-                    .await?;
+                        .await?;
 
                     let msg1 = framed
                         .next()


### PR DESCRIPTION
After the introduction of the `itchysats/order` protocol we can also prove that the CFD includes liquidation events from the moment it is open (not the case when we first merged https://github.com/itchysats/itchysats/pull/2378).

When adding these tests we discovered and fixed a bug which was causing us to only generate _short_ liquidation events.

---

I'm gonna create an issue to add more tests based on the `maker_position`, because that determines the shape of the payout curve, which affects the liquidation intervals.

Interestingly, here (maker going short) I only check the _long_ liquidation events, because the short liquidation events are pretty useless and hard to test: we have CETs for one specific price (as opposed to an interval for long liquidation CETs). This is because of the way our payout curve is implemented.