### PR TITLE
Set `rustfmt` max comment and line width to 100

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -5,7 +5,8 @@
   "rustfmt": {
     "imports_granularity": "item",
     "wrap_comments": true,
-    "comment_width": 120
+    "comment_width": 100,
+    "max_width": 100
   },
   "sql": {
     "uppercase": true


### PR DESCRIPTION
It was a bit weird that the `comment_width` was configured to be _longer_ than the `max_width` which sets the maximum width of each line.

I choose to explicitly set `max_width` to its default value of 100 for clarity.

The reason why we don't see any other changes to the diff should be obvious: setting `comment_width` to more than `max_width` was useless!

Inspired by: https://github.com/rust-lang/rustfmt/issues/3349#issuecomment-622522913.