### PR TITLE
Fix outdated info alert

### DIFF
--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -84,7 +84,7 @@ export const App = () => {
         if (githubVersion && daemonVersion) {
             onOutdatedWarningOpen();
         }
-    }, [githubVersion, daemonVersion]);
+    }, [githubVersion, daemonVersion, onOutdatedWarningOpen]);
 
     const [source, isConnected] = useEventSource("/api/feed");
     const walletInfo = useLatestEvent<WalletInfo>(source, "wallet");

--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -59,11 +59,6 @@ export const App = () => {
     const [githubVersion, setGithubVersion] = useState<SemVer | null>();
     const [daemonVersion, setDaemonVersion] = useState<SemVer | null>();
 
-    let outdated = false;
-    if (githubVersion && daemonVersion) {
-        outdated = githubVersion > daemonVersion;
-    }
-
     useWebSocket("wss://www.bitmex.com/realtime?subscribe=instrument:.BXBT", {
         shouldReconnect: () => true,
         onMessage: (message) => {
@@ -78,6 +73,18 @@ export const App = () => {
         void fetchGithubVersion(setGithubVersion);
         void fetchDaemonVersion(setDaemonVersion);
     }, []);
+
+    const {
+        isOpen: outdatedWarningIsVisible,
+        onOpen: onOutdatedWarningOpen,
+        onClose: onOutdatedWarningClose,
+    } = useDisclosure();
+
+    useEffect(() => {
+        if (githubVersion && daemonVersion) {
+            onOutdatedWarningOpen();
+        }
+    }, [githubVersion, daemonVersion]);
 
     const [source, isConnected] = useEventSource("/api/feed");
     const walletInfo = useLatestEvent<WalletInfo>(source, "wallet");
@@ -166,11 +173,6 @@ export const App = () => {
         }
     }, [toast, connectedToMakerOrUndefined]);
 
-    const {
-        isOpen: outdatedWarningIsVisible,
-        onClose,
-    } = useDisclosure({ defaultIsOpen: outdated });
-
     const pathname = location.pathname;
     useEffect(() => {
         if (pathname !== "/long" && pathname !== "/short" && pathname !== "/wallet") {
@@ -187,7 +189,7 @@ export const App = () => {
                         outdatedWarningIsVisible={outdatedWarningIsVisible}
                         githubVersion={githubVersion}
                         daemonVersion={daemonVersion}
-                        onClose={onClose}
+                        onOutdatedWarningClose={onOutdatedWarningClose}
                         walletInfo={walletInfo}
                         connectedToMaker={connectedToMaker}
                         nextFundingEvent={nextFundingEvent}

--- a/taker-frontend/src/components/MainPageLayout.tsx
+++ b/taker-frontend/src/components/MainPageLayout.tsx
@@ -12,7 +12,7 @@ type MainPageProps = {
     outdatedWarningIsVisible: boolean;
     githubVersion: SemVer | null | undefined;
     daemonVersion: SemVer | null | undefined;
-    onClose: () => void;
+    onOutdatedWarningClose: () => void;
     walletInfo: WalletInfo | null;
     connectedToMaker: ConnectionStatus;
     nextFundingEvent: string | null;
@@ -27,7 +27,7 @@ export function MainPageLayout(
         outdatedWarningIsVisible,
         githubVersion,
         daemonVersion,
-        onClose,
+        onOutdatedWarningClose,
         walletInfo,
         connectedToMaker,
         nextFundingEvent,
@@ -40,7 +40,13 @@ export function MainPageLayout(
     return (
         <>
             {outdatedWarningIsVisible
-                && <OutdatedWarning githubVersion={githubVersion} daemonVersion={daemonVersion} onClose={onClose} />}
+                && (
+                    <OutdatedWarning
+                        githubVersion={githubVersion}
+                        daemonVersion={daemonVersion}
+                        onClose={onOutdatedWarningClose}
+                    />
+                )}
 
             <Nav
                 walletInfo={walletInfo}

--- a/taker-frontend/src/components/OutdatedWarning.tsx
+++ b/taker-frontend/src/components/OutdatedWarning.tsx
@@ -10,7 +10,7 @@ type OutdatedWarningProps = {
 
 export default function OutdatedWarning({ githubVersion, daemonVersion, onClose }: OutdatedWarningProps) {
     return (
-        <Alert status="info">
+        <Alert status="info" position={"sticky"} top={0} zIndex={100}>
             <AlertIcon />
             <AlertTitle>Your daemon is outdated!</AlertTitle>
             <AlertDescription>


### PR DESCRIPTION
When testing the new alertbox that I added for incompatibility for #2569 I noticed that this alerts were actually never shown due to the state not being updated as expected.
I reproduced this on master and fixed it, will rebase #2569 onto this work. 

Additionally applied layout fix to stick the alert to the top.

Before:

![2022-07-28 11 26 22](https://user-images.githubusercontent.com/5557790/181472444-52f75cb8-dcc2-427a-9342-1a3030112194.gif)

After:

![2022-07-28 11 26 58](https://user-images.githubusercontent.com/5557790/181472491-7d506836-6479-4e2a-8f2e-9febcb9c430c.gif)

---

Sidenote: I am actually not totally convinced we want this feature at the moment because our users will see this message as soon as we create a release. If we use this we should make sure that we only create a `taker` release if we are sure that it will go into Umbrel, otherwise users see this forever on Umbrel without being able to update 🤪
@bonomat thoughts?
