### PR TITLE
Persist trading pair in the Cfd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce the `/itchysats/identify/0.3.0` protocol, running over libp2p.
   It allows a peer to share their contact details with others on request.
   It replaces a previous similar mechanism, which ran over a bespoke network stack.
+- Breaking change: renamed `trading_pair` to `contract_symbol` in Http API.
 
 ## [0.5.2] - 2022-07-26
 

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -35,6 +35,7 @@ use model::olivia::Announcement;
 use model::olivia::BitMexPriceEventId;
 use model::CfdEvent;
 use model::CompleteFee;
+use model::ContractSymbol;
 use model::Dlc;
 use model::EventKind;
 use model::FeeAccount;
@@ -723,6 +724,7 @@ impl Maker {
             funding_rate_short,
             opening_fee,
             leverage_choices,
+            contract_symbol,
         } = offer_params;
         self.system
             .set_offer_params(
@@ -735,6 +737,7 @@ impl Maker {
                 funding_rate_short,
                 opening_fee,
                 leverage_choices,
+                contract_symbol,
             )
             .await
             .unwrap();
@@ -996,6 +999,7 @@ impl OfferParamsBuilder {
             funding_rate_short: FundingRate::new(dec!(0.00024)).unwrap(),
             opening_fee: OpeningFee::new(Amount::from_sat(2)),
             leverage_choices: vec![Leverage::TWO],
+            contract_symbol: ContractSymbol::BtcUsd,
         })
     }
 

--- a/daemon/src/position_metrics.rs
+++ b/daemon/src/position_metrics.rs
@@ -74,7 +74,7 @@ impl Actor {
         self.state.cfds = Some(cfds);
         metrics::update_position_metrics(
             self.state.cfds.clone().expect("We've initialized it above"),
-            // TODO: once we have multiple trading pairs, this needs to come from the positions
+            // TODO: once we have multiple contract symbols, this needs to come from the positions
             BTCUSD_LABEL,
         );
     }
@@ -90,7 +90,7 @@ impl Actor {
                 .cfds
                 .clone()
                 .expect("updating metrics failed. Internal list has not been initialized yet"),
-            // TODO: once we have multiple trading pairs, this needs to come from the positions
+            // TODO: once we have multiple contract symbols, this needs to come from the positions
             BTCUSD_LABEL,
         );
     }

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -337,6 +337,7 @@ impl Cfd {
             role,
             opening_fee,
             initial_funding_rate,
+            contract_symbol,
             ..
         }: sqlite_db::Cfd,
         network: Network,
@@ -384,7 +385,7 @@ impl Cfd {
             initial_price,
             accumulated_fees: fee_account.balance(),
             leverage_taker: taker_leverage,
-            contract_symbol: ContractSymbol::BtcUsd,
+            contract_symbol,
             position,
             liquidation_price,
             quantity_usd,
@@ -886,6 +887,7 @@ impl sqlite_db::ClosedCfdAggregate for Cfd {
             lock,
             settlement,
             creation_timestamp,
+            contract_symbol,
             ..
         } = closed_cfd;
 
@@ -987,7 +989,7 @@ impl sqlite_db::ClosedCfdAggregate for Cfd {
             initial_price,
             accumulated_fees: fees.into(),
             leverage_taker: taker_leverage,
-            contract_symbol: ContractSymbol::BtcUsd,
+            contract_symbol,
             position,
             liquidation_price,
             quantity_usd,
@@ -1026,6 +1028,7 @@ impl sqlite_db::FailedCfdAggregate for Cfd {
             fees,
             kind,
             creation_timestamp,
+            contract_symbol,
             ..
         } = failed_cfd;
 
@@ -1063,7 +1066,7 @@ impl sqlite_db::FailedCfdAggregate for Cfd {
             initial_price,
             accumulated_fees: fees.into(),
             leverage_taker: taker_leverage,
-            contract_symbol: ContractSymbol::BtcUsd,
+            contract_symbol,
             position,
             liquidation_price,
             quantity_usd,
@@ -1672,6 +1675,7 @@ mod tests {
             OpeningFee::new(Amount::from_sat(2000)),
             FundingRate::default(),
             TxFeeRate::default(),
+            ContractSymbol::BtcUsd,
         )
     }
 
@@ -1712,6 +1716,7 @@ mod tests {
             OpeningFee::new(Amount::ZERO),
             FundingRate::default(),
             TxFeeRate::default(),
+            ContractSymbol::BtcUsd,
         );
 
         let contract_setup_completed =

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -23,6 +23,7 @@ use model::long_and_short_leverage;
 use model::market_closing_price;
 use model::CfdEvent;
 use model::ClosedCfd;
+use model::ContractSymbol;
 use model::Dlc;
 use model::EventKind;
 use model::FailedCfd;
@@ -39,7 +40,6 @@ use model::Price;
 use model::Role;
 use model::Settlement;
 use model::Timestamp;
-use model::TradingPair;
 use model::Usd;
 use model::SETTLEMENT_INTERVAL;
 use parse_display::Display;
@@ -140,7 +140,7 @@ pub struct Cfd {
     /// The taker leverage
     #[serde(rename = "leverage")]
     pub leverage_taker: Leverage,
-    pub trading_pair: TradingPair,
+    pub contract_symbol: ContractSymbol,
     pub position: Position,
     #[serde(with = "round_to_two_dp")]
     pub liquidation_price: Price,
@@ -384,7 +384,7 @@ impl Cfd {
             initial_price,
             accumulated_fees: fee_account.balance(),
             leverage_taker: taker_leverage,
-            trading_pair: TradingPair::BtcUsd,
+            contract_symbol: ContractSymbol::BtcUsd,
             position,
             liquidation_price,
             quantity_usd,
@@ -987,7 +987,7 @@ impl sqlite_db::ClosedCfdAggregate for Cfd {
             initial_price,
             accumulated_fees: fees.into(),
             leverage_taker: taker_leverage,
-            trading_pair: TradingPair::BtcUsd,
+            contract_symbol: ContractSymbol::BtcUsd,
             position,
             liquidation_price,
             quantity_usd,
@@ -1063,7 +1063,7 @@ impl sqlite_db::FailedCfdAggregate for Cfd {
             initial_price,
             accumulated_fees: fees.into(),
             leverage_taker: taker_leverage,
-            trading_pair: TradingPair::BtcUsd,
+            contract_symbol: ContractSymbol::BtcUsd,
             position,
             liquidation_price,
             quantity_usd,
@@ -1254,7 +1254,7 @@ pub struct MakerOffers {
 pub struct CfdOffer {
     pub id: OfferId,
 
-    pub trading_pair: TradingPair,
+    pub contract_symbol: ContractSymbol,
 
     #[serde(rename = "position")]
     pub position_maker: Position,
@@ -1375,7 +1375,7 @@ impl TryFrom<Offer> for CfdOffer {
 
         Ok(Self {
             id: offer.id,
-            trading_pair: offer.trading_pair,
+            contract_symbol: offer.contract_symbol,
             position_maker: offer.position_maker,
             price: offer.price,
             min_quantity: offer.min_quantity,

--- a/daemon/src/wire.rs
+++ b/daemon/src/wire.rs
@@ -17,6 +17,7 @@ use maia_core::CfdTransactions;
 use maia_core::PartyParams;
 use maia_core::PunishParams;
 use model::libp2p::PeerId;
+use model::ContractSymbol;
 use model::FundingRate;
 use model::Leverage;
 use model::MakerOffers;
@@ -26,7 +27,6 @@ use model::Origin;
 use model::Position;
 use model::Price;
 use model::Timestamp;
-use model::TradingPair;
 use model::TxFeeRate;
 use model::Usd;
 use serde::de::DeserializeOwned;
@@ -266,7 +266,8 @@ impl From<CompleteFee> for model::CompleteFee {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct DeprecatedOrder047 {
     pub id: OrderId,
-    pub trading_pair: TradingPair,
+    #[serde(rename = "trading_pair")]
+    pub contract_symbol: ContractSymbol,
     #[serde(rename = "position")]
     pub position_maker: Position,
     pub price: Price,

--- a/maker-frontend/src/components/OrderTile.tsx
+++ b/maker-frontend/src/components/OrderTile.tsx
@@ -25,8 +25,8 @@ function OrderTile(
                     <Text width={labelWidth}>ID</Text>
                     <Text whiteSpace="nowrap">{maker_offer.id}</Text>
 
-                    <Text width={labelWidth}>Trading Pair</Text>
-                    <Text>{maker_offer.trading_pair}</Text>
+                    <Text width={labelWidth}>Symbol</Text>
+                    <Text>{maker_offer.contract_symbol}</Text>
 
                     <Text width={labelWidth}>Price</Text>
                     <Text>{maker_offer.price}</Text>

--- a/maker-frontend/src/components/Types.tsx
+++ b/maker-frontend/src/components/Types.tsx
@@ -1,6 +1,6 @@
 export interface MakerOffer {
     id: string;
-    trading_pair: string;
+    contract_symbol: string;
     // this is the maker's position
     position: Position;
     price: number;
@@ -44,7 +44,7 @@ export interface Cfd {
     initial_price: number;
 
     leverage: number;
-    trading_pair: string;
+    contract_symbol: string;
     position: Position;
     liquidation_price: number;
     closing_price?: number;

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -26,6 +26,7 @@ use libp2p_tcp::TokioTcpConfig;
 use maia_core::secp256k1_zkp::XOnlyPublicKey;
 use maia_core::PartyParams;
 use model::olivia::Announcement;
+use model::ContractSymbol;
 use model::FundingRate;
 use model::Leverage;
 use model::OpeningFee;
@@ -353,6 +354,7 @@ where
         funding_rate_short: FundingRate,
         opening_fee: OpeningFee,
         leverage_choices: Vec<Leverage>,
+        contract_symbol: ContractSymbol,
     ) -> Result<()> {
         self.cfd_actor
             .send(cfd::OfferParams {
@@ -365,6 +367,7 @@ where
                 funding_rate_short,
                 opening_fee,
                 leverage_choices,
+                contract_symbol,
             })
             .await??;
 

--- a/maker/src/cfd.rs
+++ b/maker/src/cfd.rs
@@ -25,6 +25,7 @@ use model::olivia;
 use model::olivia::Announcement;
 use model::olivia::BitMexPriceEventId;
 use model::Cfd;
+use model::ContractSymbol;
 use model::FundingRate;
 use model::Identity;
 use model::Leverage;
@@ -114,6 +115,7 @@ pub struct OfferParams {
     pub funding_rate_short: FundingRate,
     pub opening_fee: OpeningFee,
     pub leverage_choices: Vec<Leverage>,
+    pub contract_symbol: ContractSymbol,
 }
 
 impl OfferParams {
@@ -135,6 +137,7 @@ impl OfferParams {
                 self.funding_rate_long,
                 self.opening_fee,
                 self.leverage_choices.clone(),
+                self.contract_symbol,
             )
         })
     }
@@ -153,6 +156,7 @@ impl OfferParams {
                 self.funding_rate_short,
                 self.opening_fee,
                 self.leverage_choices.clone(),
+                self.contract_symbol,
             )
         })
     }

--- a/maker/src/connection.rs
+++ b/maker/src/connection.rs
@@ -167,7 +167,7 @@ impl Connection {
                             let leverage = Leverage::TWO;
                             wire::DeprecatedOrder047 {
                                 id: order.id,
-                                trading_pair: order.trading_pair,
+                                contract_symbol: order.contract_symbol,
                                 position_maker: order.position_maker,
                                 price: order.price,
                                 min_quantity: order.min_quantity,

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -10,6 +10,7 @@ use daemon::projection::Feeds;
 use daemon::wallet;
 use http_api_problem::HttpApiProblem;
 use http_api_problem::StatusCode;
+use model::ContractSymbol;
 use model::FundingRate;
 use model::Leverage;
 use model::OpeningFee;
@@ -137,6 +138,7 @@ pub async fn put_offer_params(
             offer_params.daily_funding_rate_short,
             offer_params.opening_fee,
             offer_params.leverage_choices.clone(),
+            ContractSymbol::BtcUsd, // TODO: Allow choosing different TradingPairs
         )
         .await
         .map_err(|e| {

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -255,6 +255,7 @@ impl Offer {
         funding_rate: FundingRate,
         opening_fee: OpeningFee,
         leverage_choices: Vec<Leverage>,
+        contract_symbol: ContractSymbol,
     ) -> Self {
         // allowing deprecated use of field `leverage_taker` here for backwards compatibility.
         #[allow(deprecated)]
@@ -265,7 +266,7 @@ impl Offer {
             max_quantity,
             leverage_taker: Leverage::TWO,
             leverage_choices,
-            contract_symbol: ContractSymbol::BtcUsd,
+            contract_symbol,
             position_maker,
             creation_timestamp_maker: Timestamp::now(),
             settlement_interval,
@@ -291,6 +292,7 @@ impl Offer {
             self.funding_rate,
             self.opening_fee,
             self.leverage_choices.clone(),
+            self.contract_symbol,
         )
     }
 
@@ -573,6 +575,7 @@ pub struct Cfd {
     role: Role,
     opening_fee: OpeningFee,
     initial_tx_fee_rate: TxFeeRate,
+    contract_symbol: ContractSymbol,
     // dynamic (based on events)
     fee_account: FeeAccount,
 
@@ -627,6 +630,7 @@ impl Cfd {
         opening_fee: OpeningFee,
         initial_funding_rate: FundingRate,
         initial_tx_fee_rate: TxFeeRate,
+        contract_symbol: ContractSymbol,
     ) -> Self {
         let (long_leverage, short_leverage) =
             long_and_short_leverage(taker_leverage, role, position);
@@ -657,6 +661,7 @@ impl Cfd {
             initial_funding_rate,
             opening_fee,
             initial_tx_fee_rate,
+            contract_symbol,
             dlc: None,
             cet: None,
             commit_tx: None,
@@ -707,6 +712,7 @@ impl Cfd {
             offer.opening_fee,
             offer.funding_rate,
             offer.tx_fee_rate,
+            offer.contract_symbol,
         )
     }
 
@@ -1530,6 +1536,10 @@ impl Cfd {
 
     pub fn initial_tx_fee_rate(&self) -> TxFeeRate {
         self.initial_tx_fee_rate
+    }
+
+    pub fn contract_symbol(&self) -> ContractSymbol {
+        self.contract_symbol
     }
 
     pub fn opening_fee(&self) -> OpeningFee {
@@ -4359,6 +4369,7 @@ mod tests {
                 FundingRate::default(),
                 OpeningFee::default(),
                 vec![Leverage::TWO],
+                ContractSymbol::BtcUsd,
             )
         }
 

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -8,6 +8,7 @@ use crate::rollover;
 use crate::rollover::BaseDlcParams;
 use crate::rollover::RolloverParams;
 use crate::CompleteFee;
+use crate::ContractSymbol;
 use crate::FeeAccount;
 use crate::FundingFee;
 use crate::FundingRate;
@@ -19,7 +20,6 @@ use crate::Percent;
 use crate::Position;
 use crate::Price;
 use crate::Timestamp;
-use crate::TradingPair;
 use crate::TxFeeRate;
 use crate::Usd;
 use crate::SETTLEMENT_INTERVAL;
@@ -196,7 +196,8 @@ impl From<Origin> for Role {
 pub struct Offer {
     pub id: OfferId,
 
-    pub trading_pair: TradingPair,
+    #[serde(rename = "trading_pair")]
+    pub contract_symbol: ContractSymbol,
 
     /// The maker's position
     ///
@@ -264,7 +265,7 @@ impl Offer {
             max_quantity,
             leverage_taker: Leverage::TWO,
             leverage_choices,
-            trading_pair: TradingPair::BtcUsd,
+            contract_symbol: ContractSymbol::BtcUsd,
             position_maker,
             creation_timestamp_maker: Timestamp::now(),
             settlement_interval,

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -455,7 +455,7 @@ impl From<Decimal> for Percent {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
-pub enum TradingPair {
+pub enum ContractSymbol {
     BtcUsd,
 }
 

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1071,6 +1071,7 @@ pub struct FailedCfd {
     pub fees: Fees,
     pub kind: FailedKind,
     pub creation_timestamp: Timestamp,
+    pub contract_symbol: ContractSymbol,
 }
 
 /// The type of failed CFD.
@@ -1125,6 +1126,7 @@ pub struct ClosedCfd {
     pub lock: Lock,
     pub settlement: Settlement,
     pub creation_timestamp: Timestamp,
+    pub contract_symbol: ContractSymbol,
 }
 
 /// Data loaded from the database about the lock transaction of a

--- a/sqlite-db/migrations/20220728115915_add_contract_setup.sql
+++ b/sqlite-db/migrations/20220728115915_add_contract_setup.sql
@@ -1,0 +1,16 @@
+-- Introduce contract_symbol field for all cfd tables.
+--
+-- Default to BTCUSD for all old already opened CFDs, as this is the only
+-- contract symbol active for now.
+ALTER TABLE
+    cfds
+ADD
+    COLUMN contract_symbol NOT NULL DEFAULT 'BtcUsd';
+ALTER TABLE
+    closed_cfds
+ADD
+    COLUMN contract_symbol NOT NULL DEFAULT 'BtcUsd';
+ALTER TABLE
+    failed_cfds
+ADD
+    COLUMN contract_symbol NOT NULL DEFAULT 'BtcUsd';

--- a/sqlite-db/sqlx-data.json
+++ b/sqlite-db/sqlx-data.json
@@ -52,6 +52,16 @@
     },
     "query": "\n            select\n                id as cfd_id,\n                order_id as \"order_id: models::OrderId\"\n            from\n                cfds\n            where exists (\n                select id from EVENTS as events\n                where events.cfd_id = cfds.id and\n                (\n                    events.name = $1 or\n                    events.name = $2\n                )\n            )\n            "
   },
+  "0859464e9b1d6758efeced4abf74ad440a3128611856a72ba22c0234fca37e81": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 14
+      }
+    },
+    "query": "\n        INSERT INTO closed_cfds\n        (\n            order_id,\n            offer_id,\n            position,\n            initial_price,\n            taker_leverage,\n            n_contracts,\n            counterparty_network_identity,\n            counterparty_peer_id,\n            role,\n            fees,\n            expiry_timestamp,\n            lock_txid,\n            lock_dlc_vout,\n            contract_symbol\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)\n        "
+  },
   "138cd0bf1974ccc90c52024796a8e81e5d61413261d4bba6073504379e67cdeb": {
     "describe": {
       "columns": [
@@ -244,36 +254,6 @@
     },
     "query": "\n        INSERT INTO closed_cets\n        (\n            cfd_id,\n            txid,\n            vout,\n            payout,\n            price\n        )\n        VALUES\n        (\n            (SELECT id FROM closed_cfds WHERE closed_cfds.order_id = $1),\n            $2, $3, $4, $5\n        )\n        "
   },
-  "375bcb24b5a899520f76cd2f07ed5f14d4e862ef76a680de4d43350866260baa": {
-    "describe": {
-      "columns": [
-        {
-          "name": "rollovers",
-          "ordinal": 0,
-          "type_info": "Int"
-        },
-        {
-          "name": "revokes",
-          "ordinal": 1,
-          "type_info": "Int"
-        },
-        {
-          "name": "cets",
-          "ordinal": 2,
-          "type_info": "Int"
-        }
-      ],
-      "nullable": [
-        false,
-        null,
-        null
-      ],
-      "parameters": {
-        "Right": 0
-      }
-    },
-    "query": "\n            SELECT \n                COUNT(DISTINCT rollover_completed_event_data.id) as rollovers, \n                COUNT(DISTINCT revoked_commit_transactions.id) as revokes, \n                COUNT(DISTINCT open_cets.id) as cets\n            FROM \n                rollover_completed_event_data, \n                revoked_commit_transactions, \n                open_cets;\n            "
-  },
   "496c2ab5814811e176bff90b7129179c7946d106d47bebf6baa78ee3b35268a7": {
     "describe": {
       "columns": [
@@ -308,6 +288,16 @@
     },
     "query": "\n            delete from rollover_completed_event_data where cfd_id = (select id from cfds where cfds.order_id = $1)\n        "
   },
+  "4b94879e91cdbbb2614c1f71119fb653d345cabe3b5f3b703960770c9b896659": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 12
+      }
+    },
+    "query": "\n        INSERT INTO failed_cfds\n        (\n            order_id,\n            offer_id,\n            position,\n            initial_price,\n            taker_leverage,\n            n_contracts,\n            counterparty_network_identity,\n            counterparty_peer_id,\n            role,\n            fees,\n            kind,\n            contract_symbol\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)\n        "
+  },
   "4cd8f8d0b36f353b61783243db9f888bf1ba698c1d2a1c53aeeb573ce7b1eab8": {
     "describe": {
       "columns": [],
@@ -328,16 +318,6 @@
     },
     "query": "\n            INSERT INTO event_log_failed (\n                cfd_id,\n                name,\n                created_at\n            )\n            VALUES\n            (\n                (SELECT id FROM failed_cfds WHERE failed_cfds.order_id = $1),\n                $2, $3\n            )\n            "
   },
-  "54a137ff1c5d3b785023c9382662730fbc161ee4290777e9754a8313887f8ca1": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 11
-      }
-    },
-    "query": "\n        INSERT INTO failed_cfds\n        (\n            order_id,\n            offer_id,\n            position,\n            initial_price,\n            taker_leverage,\n            n_contracts,\n            counterparty_network_identity,\n            counterparty_peer_id,\n            role,\n            fees,\n            kind\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n        "
-  },
   "56e8ce89f0072ac7c451c2a6314f4c22664ccd48e345255ca61319a8040f7626": {
     "describe": {
       "columns": [
@@ -355,102 +335,6 @@
       }
     },
     "query": "select id from cfds where order_id = $1"
-  },
-  "702549323c4c22903b4e030456ce5214611521dbf7560e0900fda9a06ca554a4": {
-    "describe": {
-      "columns": [
-        {
-          "name": "cfd_id",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "order_id: models::OrderId",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "offer_id: models::OfferId",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "position: models::Position",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "initial_price: models::Price",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "leverage: models::Leverage",
-          "ordinal": 5,
-          "type_info": "Int64"
-        },
-        {
-          "name": "settlement_time_interval_hours",
-          "ordinal": 6,
-          "type_info": "Int64"
-        },
-        {
-          "name": "quantity_usd: models::Usd",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "counterparty_network_identity: models::Identity",
-          "ordinal": 8,
-          "type_info": "Text"
-        },
-        {
-          "name": "counterparty_peer_id: models::PeerId",
-          "ordinal": 9,
-          "type_info": "Text"
-        },
-        {
-          "name": "role: models::Role",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "opening_fee: models::OpeningFee",
-          "ordinal": 11,
-          "type_info": "Null"
-        },
-        {
-          "name": "initial_funding_rate: models::FundingRate",
-          "ordinal": 12,
-          "type_info": "Null"
-        },
-        {
-          "name": "initial_tx_fee_rate: models::TxFeeRate",
-          "ordinal": 13,
-          "type_info": "Null"
-        }
-      ],
-      "nullable": [
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n            select\n                id as cfd_id,\n                order_id as \"order_id: models::OrderId\",\n                offer_id as \"offer_id: models::OfferId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                leverage as \"leverage: models::Leverage\",\n                settlement_time_interval_hours,\n                quantity_usd as \"quantity_usd: models::Usd\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                opening_fee as \"opening_fee: models::OpeningFee\",\n                initial_funding_rate as \"initial_funding_rate: models::FundingRate\",\n                initial_tx_fee_rate as \"initial_tx_fee_rate: models::TxFeeRate\"\n            from\n                cfds\n            where\n                cfds.order_id = $1\n            "
   },
   "76e71ec93cb68fc2a917844dd8ea20d307326f215d0a4b0356393b0d2f5067bc": {
     "describe": {
@@ -488,17 +372,91 @@
     },
     "query": "\n        SELECT\n            closed_commit_txs.txid as \"commit_txid!: models::Txid\",\n            closed_refund_txs.txid as \"txid: models::Txid\",\n            closed_refund_txs.vout as \"vout: models::Vout\",\n            closed_refund_txs.payout as \"payout: models::Payout\"\n        FROM\n            closed_refund_txs\n        JOIN\n            closed_commit_txs on closed_commit_txs.cfd_id = closed_refund_txs.cfd_id\n        JOIN\n            closed_cfds on closed_cfds.id = closed_refund_txs.cfd_id\n        WHERE\n            closed_cfds.order_id = $1\n        "
   },
-  "779a2aa25040b646788075c279cb97e26f3eb233f25f426642ed32d423008f96": {
+  "7c46e2a000874491ba1731cca17b2ccaffa214a311af65384fbbd546d79fecc3": {
     "describe": {
-      "columns": [],
-      "nullable": [],
+      "columns": [
+        {
+          "name": "order_id: models::OrderId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "offer_id: models::OfferId",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: models::Position",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price: models::Price",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "taker_leverage: models::Leverage",
+          "ordinal": 4,
+          "type_info": "Int64"
+        },
+        {
+          "name": "n_contracts: models::Contracts",
+          "ordinal": 5,
+          "type_info": "Int64"
+        },
+        {
+          "name": "counterparty_network_identity: models::Identity",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "counterparty_peer_id: models::PeerId",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "role: models::Role",
+          "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "fees: models::Fees",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "kind: models::FailedKind",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "contract_symbol: models::ContractSymbol",
+          "ordinal": 11,
+          "type_info": "Null"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
       "parameters": {
-        "Right": 13
+        "Right": 1
       }
     },
-    "query": "\n        INSERT INTO closed_cfds\n        (\n            order_id,\n            offer_id,\n            position,\n            initial_price,\n            taker_leverage,\n            n_contracts,\n            counterparty_network_identity,\n            counterparty_peer_id,\n            role,\n            fees,\n            expiry_timestamp,\n            lock_txid,\n            lock_dlc_vout\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)\n        "
+    "query": "\n            SELECT\n                order_id as \"order_id: models::OrderId\",\n                offer_id as \"offer_id: models::OfferId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                taker_leverage as \"taker_leverage: models::Leverage\",\n                n_contracts as \"n_contracts: models::Contracts\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                fees as \"fees: models::Fees\",\n                kind as \"kind: models::FailedKind\",\n                contract_symbol as \"contract_symbol: models::ContractSymbol\"\n            FROM\n                failed_cfds\n            WHERE\n                failed_cfds.order_id = $1\n            "
   },
-  "83e000677e6f83472de94228165ca54819d4c55bd16d89e9efa270b3f24b8ac6": {
+  "7d0a9f52e72ce425da0f86af11b98bee0d9166cec723f4bab8881477f75e6206": {
     "describe": {
       "columns": [
         {
@@ -565,9 +523,15 @@
           "name": "lock_dlc_vout: models::Vout",
           "ordinal": 12,
           "type_info": "Int64"
+        },
+        {
+          "name": "contract_symbol: models::ContractSymbol",
+          "ordinal": 13,
+          "type_info": "Null"
         }
       ],
       "nullable": [
+        false,
         false,
         false,
         false,
@@ -586,7 +550,7 @@
         "Right": 1
       }
     },
-    "query": "\n            SELECT\n                order_id as \"order_id: models::OrderId\",\n                offer_id as \"offer_id: models::OfferId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                taker_leverage as \"taker_leverage: models::Leverage\",\n                n_contracts as \"n_contracts: models::Contracts\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                fees as \"fees: models::Fees\",\n                expiry_timestamp,\n                lock_txid as \"lock_txid: models::Txid\",\n                lock_dlc_vout as \"lock_dlc_vout: models::Vout\"\n            FROM\n                closed_cfds\n            WHERE\n                closed_cfds.order_id = $1\n            "
+    "query": "\n            SELECT\n                order_id as \"order_id: models::OrderId\",\n                offer_id as \"offer_id: models::OfferId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                taker_leverage as \"taker_leverage: models::Leverage\",\n                n_contracts as \"n_contracts: models::Contracts\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                fees as \"fees: models::Fees\",\n                expiry_timestamp,\n                lock_txid as \"lock_txid: models::Txid\",\n                lock_dlc_vout as \"lock_dlc_vout: models::Vout\",\n                contract_symbol as \"contract_symbol: models::ContractSymbol\"\n            FROM\n                closed_cfds\n            WHERE\n                closed_cfds.order_id = $1\n            "
   },
   "89c4ffc05a97ee61f28ecb36e6e488991e24f72f58b161f624a2da08f9399c0a": {
     "describe": {
@@ -714,6 +678,36 @@
     },
     "query": "\n            delete from revoked_commit_transactions where cfd_id = (select id from cfds where cfds.order_id = $1)\n        "
   },
+  "9df788a4d4fdbb7dd146af6e13a7aa36e7c5b13e57b972a9148370bbe3118587": {
+    "describe": {
+      "columns": [
+        {
+          "name": "rollovers",
+          "ordinal": 0,
+          "type_info": "Int"
+        },
+        {
+          "name": "revokes",
+          "ordinal": 1,
+          "type_info": "Int"
+        },
+        {
+          "name": "cets",
+          "ordinal": 2,
+          "type_info": "Int"
+        }
+      ],
+      "nullable": [
+        false,
+        null,
+        null
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            SELECT\n                COUNT(DISTINCT rollover_completed_event_data.id) as rollovers,\n                COUNT(DISTINCT revoked_commit_transactions.id) as revokes,\n                COUNT(DISTINCT open_cets.id) as cets\n            FROM\n                rollover_completed_event_data,\n                revoked_commit_transactions,\n                open_cets;\n            "
+  },
   "9ee7e0229619689eed2c5f2e834d9449a732824bbeffed628d01abc1d1839319": {
     "describe": {
       "columns": [
@@ -762,6 +756,108 @@
     },
     "query": "\n            INSERT INTO event_log (\n                cfd_id,\n                name,\n                created_at\n            )\n            VALUES\n            (\n                (SELECT id FROM closed_cfds WHERE closed_cfds.order_id = $1),\n                $2, $3\n            )\n            "
   },
+  "cae8bdf8fa73fa170608b6608b335ada2d9ce6c95aeb0ea1293cb7970243f23a": {
+    "describe": {
+      "columns": [
+        {
+          "name": "cfd_id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "order_id: models::OrderId",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "offer_id: models::OfferId",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: models::Position",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "initial_price: models::Price",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "leverage: models::Leverage",
+          "ordinal": 5,
+          "type_info": "Int64"
+        },
+        {
+          "name": "settlement_time_interval_hours",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "quantity_usd: models::Usd",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "counterparty_network_identity: models::Identity",
+          "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "counterparty_peer_id: models::PeerId",
+          "ordinal": 9,
+          "type_info": "Text"
+        },
+        {
+          "name": "role: models::Role",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "opening_fee: models::OpeningFee",
+          "ordinal": 11,
+          "type_info": "Null"
+        },
+        {
+          "name": "initial_funding_rate: models::FundingRate",
+          "ordinal": 12,
+          "type_info": "Null"
+        },
+        {
+          "name": "initial_tx_fee_rate: models::TxFeeRate",
+          "ordinal": 13,
+          "type_info": "Null"
+        },
+        {
+          "name": "contract_symbol: models::ContractSymbol",
+          "ordinal": 14,
+          "type_info": "Null"
+        }
+      ],
+      "nullable": [
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "\n            select\n                id as cfd_id,\n                order_id as \"order_id: models::OrderId\",\n                offer_id as \"offer_id: models::OfferId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                leverage as \"leverage: models::Leverage\",\n                settlement_time_interval_hours,\n                quantity_usd as \"quantity_usd: models::Usd\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                opening_fee as \"opening_fee: models::OpeningFee\",\n                initial_funding_rate as \"initial_funding_rate: models::FundingRate\",\n                initial_tx_fee_rate as \"initial_tx_fee_rate: models::TxFeeRate\",\n                contract_symbol as \"contract_symbol: models::ContractSymbol\"\n            from\n                cfds\n            where\n                cfds.order_id = $1\n            "
+  },
   "d2574386cb16c2ee01fded3c8d025e46a034efa3d5878e03879dc911bf61b749": {
     "describe": {
       "columns": [],
@@ -781,84 +877,6 @@
       }
     },
     "query": "\n            INSERT OR IGNORE INTO time_to_first_position\n            (\n                taker_id,\n                first_seen_timestamp\n            )\n            VALUES ($1, $2)\n            "
-  },
-  "df128e7111bba8e0bdefc5b921da4cba171a0426ed121f30c1ec6b1084017226": {
-    "describe": {
-      "columns": [
-        {
-          "name": "order_id: models::OrderId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "offer_id: models::OfferId",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "position: models::Position",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "initial_price: models::Price",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "taker_leverage: models::Leverage",
-          "ordinal": 4,
-          "type_info": "Int64"
-        },
-        {
-          "name": "n_contracts: models::Contracts",
-          "ordinal": 5,
-          "type_info": "Int64"
-        },
-        {
-          "name": "counterparty_network_identity: models::Identity",
-          "ordinal": 6,
-          "type_info": "Text"
-        },
-        {
-          "name": "counterparty_peer_id: models::PeerId",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "role: models::Role",
-          "ordinal": 8,
-          "type_info": "Text"
-        },
-        {
-          "name": "fees: models::Fees",
-          "ordinal": 9,
-          "type_info": "Int64"
-        },
-        {
-          "name": "kind: models::FailedKind",
-          "ordinal": 10,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 1
-      }
-    },
-    "query": "\n            SELECT\n                order_id as \"order_id: models::OrderId\",\n                offer_id as \"offer_id: models::OfferId\",\n                position as \"position: models::Position\",\n                initial_price as \"initial_price: models::Price\",\n                taker_leverage as \"taker_leverage: models::Leverage\",\n                n_contracts as \"n_contracts: models::Contracts\",\n                counterparty_network_identity as \"counterparty_network_identity: models::Identity\",\n                counterparty_peer_id as \"counterparty_peer_id: models::PeerId\",\n                role as \"role: models::Role\",\n                fees as \"fees: models::Fees\",\n                kind as \"kind: models::FailedKind\"\n            FROM\n                failed_cfds\n            WHERE\n                failed_cfds.order_id = $1\n            "
   },
   "e6fc0695967aae232e12dd135f89e021ccd46a79ab4d99265992ce8eddcc0d89": {
     "describe": {

--- a/sqlite-db/src/failed.rs
+++ b/sqlite-db/src/failed.rs
@@ -104,7 +104,8 @@ impl Connection {
                 counterparty_peer_id as "counterparty_peer_id: models::PeerId",
                 role as "role: models::Role",
                 fees as "fees: models::Fees",
-                kind as "kind: models::FailedKind"
+                kind as "kind: models::FailedKind",
+                contract_symbol as "contract_symbol: models::ContractSymbol"
             FROM
                 failed_cfds
             WHERE
@@ -130,6 +131,7 @@ impl Connection {
             fees: cfd.fees.into(),
             kind: cfd.kind.into(),
             creation_timestamp,
+            contract_symbol: cfd.contract_symbol.into(),
         };
 
         Ok(C::new_failed(args, cfd))
@@ -210,6 +212,7 @@ async fn insert_failed_cfd(
     let position = models::Position::from(cfd.position);
     let counterparty_network_identity = models::Identity::from(cfd.counterparty_network_identity);
     let counterparty_peer_id = models::PeerId::from(counterparty_peer_id);
+    let contract_symbol = models::ContractSymbol::from(cfd.contract_symbol);
 
     let query_result = sqlx::query!(
         r#"
@@ -225,9 +228,10 @@ async fn insert_failed_cfd(
             counterparty_peer_id,
             role,
             fees,
-            kind
+            kind,
+            contract_symbol
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
         "#,
         id,
         offer_id,
@@ -240,6 +244,7 @@ async fn insert_failed_cfd(
         role,
         fees,
         kind,
+        contract_symbol,
     )
     .execute(&mut *conn)
     .await?;

--- a/sqlite-db/src/impls.rs
+++ b/sqlite-db/src/impls.rs
@@ -19,6 +19,7 @@ impl crate::CfdAggregate for model::Cfd {
             opening_fee,
             initial_funding_rate,
             initial_tx_fee_rate,
+            contract_symbol,
         }: crate::Cfd,
     ) -> Self {
         model::Cfd::new(
@@ -35,6 +36,7 @@ impl crate::CfdAggregate for model::Cfd {
             opening_fee,
             initial_funding_rate,
             initial_tx_fee_rate,
+            contract_symbol,
         )
     }
 

--- a/sqlite-db/src/models.rs
+++ b/sqlite-db/src/models.rs
@@ -954,6 +954,28 @@ pub fn into_complete_fee_and_flow(
     }
 }
 
+/// Trading pair of the Cfd
+#[derive(Debug, Copy, Clone, PartialEq, sqlx::Type)]
+pub enum ContractSymbol {
+    BtcUsd,
+}
+
+impl From<model::ContractSymbol> for ContractSymbol {
+    fn from(contract_symbol: model::ContractSymbol) -> Self {
+        match contract_symbol {
+            model::ContractSymbol::BtcUsd => ContractSymbol::BtcUsd,
+        }
+    }
+}
+
+impl From<ContractSymbol> for model::ContractSymbol {
+    fn from(contract_symbol: ContractSymbol) -> Self {
+        match contract_symbol {
+            ContractSymbol::BtcUsd => model::ContractSymbol::BtcUsd,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sqlite-db/src/rollover/mod.rs
+++ b/sqlite-db/src/rollover/mod.rs
@@ -17,6 +17,7 @@ mod tests {
     use model::olivia::BitMexPriceEventId;
     use model::Cfd;
     use model::CfdEvent;
+    use model::ContractSymbol;
     use model::EventKind;
     use model::FundingRate;
     use model::Leverage;
@@ -54,6 +55,7 @@ mod tests {
             OpeningFee::new(Amount::from_sat(2000)),
             FundingRate::default(),
             TxFeeRate::default(),
+            ContractSymbol::BtcUsd,
         )
     }
 
@@ -253,13 +255,13 @@ mod tests {
     async fn count_table_entries(mut connection: PoolConnection<Sqlite>) -> (i32, i32, i32) {
         let row = sqlx::query!(
             r#"
-            SELECT 
-                COUNT(DISTINCT rollover_completed_event_data.id) as rollovers, 
-                COUNT(DISTINCT revoked_commit_transactions.id) as revokes, 
+            SELECT
+                COUNT(DISTINCT rollover_completed_event_data.id) as rollovers,
+                COUNT(DISTINCT revoked_commit_transactions.id) as revokes,
                 COUNT(DISTINCT open_cets.id) as cets
-            FROM 
-                rollover_completed_event_data, 
-                revoked_commit_transactions, 
+            FROM
+                rollover_completed_event_data,
+                revoked_commit_transactions,
                 open_cets;
             "#
         )

--- a/taker-frontend/src/types.ts
+++ b/taker-frontend/src/types.ts
@@ -18,7 +18,7 @@ export function unixTimestampToDate(unixTimestamp: number): Date {
 
 export interface MakerOffer {
     id: string;
-    trading_pair: string;
+    contract_symbol: string;
     // this is the maker's position
     position: Position;
     price: number;
@@ -63,7 +63,7 @@ export interface Cfd {
     initial_price: number;
 
     leverage: number;
-    trading_pair: string;
+    contract_symbol: string;
     position: Position;
     liquidation_price: number;
 

--- a/xtra-libp2p-offer/src/lib.rs
+++ b/xtra-libp2p-offer/src/lib.rs
@@ -12,6 +12,7 @@ mod tests {
     use futures::Future;
     use futures::FutureExt;
     use model::olivia::BitMexPriceEventId;
+    use model::ContractSymbol;
     use model::FundingRate;
     use model::Leverage;
     use model::MakerOffers;
@@ -220,6 +221,7 @@ mod tests {
             FundingRate::default(),
             OpeningFee::default(),
             vec![Leverage::TWO],
+            ContractSymbol::BtcUsd,
         )
     }
 }


### PR DESCRIPTION
Thankfully, TradingPair was part of the Offer, so this change should be fully backwards-compatible.

- remove hardcoded BtcUsd in projection,
- persist trading_pair received from the Offer in all Cfd tables,
- default to TradingPair::BtcUsd in already created CFDs.

Fixes #2458