### PR TITLE
Move currency selector to trading screen

### DIFF
--- a/taker-frontend/package.json
+++ b/taker-frontend/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@chakra-ui/icons": "^2.0.4",
     "@chakra-ui/react": "^2.2.4",
-    "@emotion/react": "^11",
+    "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11",
     "@feedback-fish/react": "^1.2.1",
     "@react-hookz/web": "^15.0.1",
@@ -28,6 +28,7 @@
     "@vitejs/plugin-react": "^1.3.2",
     "@vitejs/plugin-react-refresh": "^1.3.1",
     "axios": "^0.27.2",
+    "chakra-react-select": "^4.1.4",
     "dayjs": "^1.11.4",
     "eslint": "^8.20.0",
     "eslint-config-react-app": "^7.0.1",

--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -43,7 +43,7 @@ export interface Offer {
 // TODO: Evaluate moving these globals into the theme to make them accessible through that
 export const VIEWPORT_WIDTH = 1000;
 export const FOOTER_HEIGHT = 50;
-export const HEADER_HEIGHT = 100;
+export const HEADER_HEIGHT = 50;
 export const VIEWPORT_WIDTH_PX = VIEWPORT_WIDTH + "px";
 export const BG_LIGHT = "gray.50";
 export const BG_DARK = "gray.800";

--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -228,7 +228,6 @@ export const App = () => {
                         githubVersion={githubVersion}
                         daemonVersion={daemonVersion}
                         onClose={onClose}
-                        walletInfo={walletInfo}
                         connectedToMaker={connectedToMaker}
                         nextFundingEvent={nextFundingEvent}
                         referencePrice={referencePrice}

--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -5,7 +5,7 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
 import * as React from "react";
 import { useEffect, useState } from "react";
-import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
+import { Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
 import useWebSocket from "react-use-websocket";
 import { SemVer } from "semver";
 import { MainPageLayout } from "./components/MainPageLayout";
@@ -49,10 +49,45 @@ export const BG_LIGHT = "gray.50";
 export const BG_DARK = "gray.800";
 export const FAQ_URL = "http://faq.itchysats.network";
 
+export enum Symbol {
+    BtcUsd = "btcusd",
+    EthUsd = "ethusd",
+}
+
+const parseSymbol = (symbol: Symbol) => {
+    switch (symbol) {
+        case undefined: {
+            // falling through to default
+        }
+        // eslint-disable-next-line no-fallthrough
+        case Symbol.EthUsd: {
+            // TODO: falling through because unimplemented at the moment
+        }
+        // eslint-disable-next-line no-fallthrough
+        case Symbol.BtcUsd: {
+            // falling through to default
+        }
+        // eslint-disable-next-line no-fallthrough
+        default:
+            return {
+                bitmexStream: "wss://www.bitmex.com/realtime?subscribe=instrument:.BXBT",
+                // TODO: make offer events symbol dependent becase we only want subscribe to those offers we are currently interested in.
+                daemon_long_offer: "long_offer",
+                daemon_short_offer: "short_offer",
+            };
+    }
+};
+
 export const App = () => {
     const toast = useToast();
     const navigate = useNavigate();
     const location = useLocation();
+
+    let { symbol: symbolString } = useParams();
+    // if no symbol was set, we default to BtcUsd
+    let symbol = symbolString ? Symbol[symbolString as keyof typeof Symbol] : Symbol.BtcUsd;
+
+    let { bitmexStream, daemon_long_offer, daemon_short_offer } = parseSymbol(symbol);
 
     let [referencePrice, setReferencePrice] = useState<number>();
     let [showExtraInfo, setExtraInfo] = useState(false);
@@ -64,7 +99,7 @@ export const App = () => {
         outdated = githubVersion > daemonVersion;
     }
 
-    useWebSocket("wss://www.bitmex.com/realtime?subscribe=instrument:.BXBT", {
+    useWebSocket(bitmexStream, {
         shouldReconnect: () => true,
         onMessage: (message) => {
             const data: BXBTData[] = JSON.parse(message.data).data;
@@ -82,8 +117,8 @@ export const App = () => {
     const [source, isConnected] = useEventSource("/api/feed");
     const walletInfo = useLatestEvent<WalletInfo>(source, "wallet");
 
-    const makerLong = useLatestEvent<MakerOffer>(source, "long_offer", intoMakerOffer);
-    const makerShort = useLatestEvent<MakerOffer>(source, "short_offer", intoMakerOffer);
+    const makerLong = useLatestEvent<MakerOffer>(source, daemon_long_offer, intoMakerOffer);
+    const makerShort = useLatestEvent<MakerOffer>(source, daemon_short_offer, intoMakerOffer);
 
     const identityOrUndefined = useLatestEvent<IdentityInfo>(source, "identity");
 
@@ -173,8 +208,9 @@ export const App = () => {
 
     const pathname = location.pathname;
     useEffect(() => {
-        if (pathname !== "/long" && pathname !== "/short" && pathname !== "/wallet") {
-            navigate("/long");
+        let btcusd: string = Symbol.BtcUsd;
+        if (!pathname.includes("long") && !pathname.includes("short") && !pathname.includes("wallet")) {
+            navigate(btcusd + "/long");
         }
     }, [navigate, pathname]);
 
@@ -212,7 +248,7 @@ export const App = () => {
                     }
                 >
                     <Route
-                        path="long"
+                        path=":symbol/long"
                         element={
                             <Trade
                                 offer={longOffer}
@@ -223,7 +259,7 @@ export const App = () => {
                         }
                     />
                     <Route
-                        path="short"
+                        path=":symbol/short"
                         element={
                             <Trade
                                 offer={shortOffer}

--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -5,7 +5,7 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
 import * as React from "react";
 import { useEffect, useState } from "react";
-import { Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
+import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import useWebSocket from "react-use-websocket";
 import { SemVer } from "semver";
 import { MainPageLayout } from "./components/MainPageLayout";
@@ -50,8 +50,9 @@ export const BG_DARK = "gray.800";
 export const FAQ_URL = "http://faq.itchysats.network";
 
 export enum Symbol {
-    BtcUsd = "btcusd",
-    EthUsd = "ethusd",
+    // we use lower case variant names because of react-router using lower-case routes by default and it is easier to match
+    btcusd = "btcusd",
+    ethusd = "ethusd",
 }
 
 const parseSymbol = (symbol: Symbol) => {
@@ -60,11 +61,11 @@ const parseSymbol = (symbol: Symbol) => {
             // falling through to default
         }
         // eslint-disable-next-line no-fallthrough
-        case Symbol.EthUsd: {
+        case Symbol.ethusd: {
             // TODO: falling through because unimplemented at the moment
         }
         // eslint-disable-next-line no-fallthrough
-        case Symbol.BtcUsd: {
+        case Symbol.btcusd: {
             // falling through to default
         }
         // eslint-disable-next-line no-fallthrough
@@ -83,9 +84,12 @@ export const App = () => {
     const navigate = useNavigate();
     const location = useLocation();
 
-    let { symbol: symbolString } = useParams();
-    // if no symbol was set, we default to BtcUsd
-    let symbol = symbolString ? Symbol[symbolString as keyof typeof Symbol] : Symbol.BtcUsd;
+    // ideally we could be using useParams() here but `App` is on the top level and is not aware of any params yet,
+    // hence we parse the location.
+    let symbol = Symbol.btcusd;
+    if (location.pathname.includes("ethusd")) {
+        symbol = Symbol.ethusd;
+    }
 
     let { bitmexStream, daemon_long_offer, daemon_short_offer } = parseSymbol(symbol);
 
@@ -208,9 +212,9 @@ export const App = () => {
 
     const pathname = location.pathname;
     useEffect(() => {
-        let btcusd: string = Symbol.BtcUsd;
-        if (!pathname.includes("long") && !pathname.includes("short") && !pathname.includes("wallet")) {
-            navigate(btcusd + "/long");
+        let btcusd = Symbol.btcusd;
+        if (!pathname.includes("trade") && !pathname.includes("wallet")) {
+            navigate(`/trade/${btcusd}/long`);
         }
     }, [navigate, pathname]);
 
@@ -248,7 +252,7 @@ export const App = () => {
                     }
                 >
                     <Route
-                        path=":symbol/long"
+                        path="/trade/:symbol/long"
                         element={
                             <Trade
                                 offer={longOffer}
@@ -259,7 +263,7 @@ export const App = () => {
                         }
                     />
                     <Route
-                        path=":symbol/short"
+                        path="/trade/:symbol/short/"
                         element={
                             <Trade
                                 offer={shortOffer}

--- a/taker-frontend/src/components/MainPageLayout.tsx
+++ b/taker-frontend/src/components/MainPageLayout.tsx
@@ -47,39 +47,35 @@ export function MainPageLayout(
                 connectedToMaker={connectedToMaker}
                 nextFundingEvent={nextFundingEvent}
                 referencePrice={referencePrice}
-            />
-            <Center>
-                <Box
-                    maxWidth={(VIEWPORT_WIDTH + 200) + "px"}
-                    width={"100%"}
-                    bgGradient={useColorModeValue(
-                        "linear(to-r, white 5%, gray.800, white 95%)",
-                        "linear(to-r, gray.800 5%, white, gray.800 95%)",
-                    )}
-                >
-                    <Center>
-                        <Box
-                            textAlign="center"
-                            padding={3}
-                            bg={useColorModeValue(BG_LIGHT, BG_DARK)}
-                            maxWidth={VIEWPORT_WIDTH_PX}
-                            marginTop={`${HEADER_HEIGHT}px`}
-                            minHeight={`calc(100vh - ${FOOTER_HEIGHT}px - ${HEADER_HEIGHT}px)`}
-                            width={"100%"}
-                        >
-                            <Outlet />
-                        </Box>
-                    </Center>
-                </Box>
-            </Center>
+            >
+                <Center>
+                    <Box
+                        maxWidth={(VIEWPORT_WIDTH + 200) + "px"}
+                        width={"100%"}
+                    >
+                        <Center>
+                            <Box
+                                textAlign="center"
+                                bg={useColorModeValue(BG_LIGHT, BG_DARK)}
+                                maxWidth={VIEWPORT_WIDTH_PX}
+                                marginTop={`${HEADER_HEIGHT}px`}
+                                minHeight={`calc(100vh - ${FOOTER_HEIGHT}px - ${HEADER_HEIGHT}px)`}
+                                width={"100%"}
+                            >
+                                <Outlet />
+                            </Box>
+                        </Center>
+                    </Box>
+                </Center>
 
-            <Footer
-                identityInfo={identityOrUndefined}
-                daemonVersion={daemonVersion?.version}
-                githubVersion={githubVersion?.version}
-                onExtraInfoToggle={setExtraInfo}
-                showExtraInfo={showExtraInfo}
-            />
+                <Footer
+                    identityInfo={identityOrUndefined}
+                    daemonVersion={daemonVersion?.version}
+                    githubVersion={githubVersion?.version}
+                    onExtraInfoToggle={setExtraInfo}
+                    showExtraInfo={showExtraInfo}
+                />
+            </Nav>
         </>
     );
 }

--- a/taker-frontend/src/components/MainPageLayout.tsx
+++ b/taker-frontend/src/components/MainPageLayout.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Outlet } from "react-router-dom";
 import { SemVer } from "semver";
 import { BG_DARK, BG_LIGHT, FOOTER_HEIGHT, HEADER_HEIGHT, VIEWPORT_WIDTH, VIEWPORT_WIDTH_PX } from "../App";
-import { ConnectionStatus, IdentityInfo, WalletInfo } from "../types";
+import { ConnectionStatus, IdentityInfo } from "../types";
 import Footer from "./Footer";
 import Nav from "./NavBar";
 import OutdatedWarning from "./OutdatedWarning";
@@ -13,7 +13,6 @@ type MainPageProps = {
     githubVersion: SemVer | null | undefined;
     daemonVersion: SemVer | null | undefined;
     onClose: () => void;
-    walletInfo: WalletInfo | null;
     connectedToMaker: ConnectionStatus;
     nextFundingEvent: string | null;
     referencePrice: number | undefined;
@@ -28,7 +27,6 @@ export function MainPageLayout(
         githubVersion,
         daemonVersion,
         onClose,
-        walletInfo,
         connectedToMaker,
         nextFundingEvent,
         referencePrice,
@@ -43,7 +41,6 @@ export function MainPageLayout(
                 && <OutdatedWarning githubVersion={githubVersion} daemonVersion={daemonVersion} onClose={onClose} />}
 
             <Nav
-                walletInfo={walletInfo}
                 connectedToMaker={connectedToMaker}
                 nextFundingEvent={nextFundingEvent}
                 referencePrice={referencePrice}

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -14,6 +14,7 @@ import {
     IconButton,
     Image,
     Link,
+    Select,
     Skeleton,
     Spacer,
     Text,
@@ -26,8 +27,8 @@ import React, { ReactNode } from "react";
 import { IconType } from "react-icons";
 import { FaWallet } from "react-icons/fa";
 import { FiHome, FiMenu } from "react-icons/fi";
-import { Link as ReachLink } from "react-router-dom";
-import { HEADER_HEIGHT } from "../App";
+import { Link as ReachLink, useNavigate, useParams } from "react-router-dom";
+import { HEADER_HEIGHT, Symbol } from "../App";
 import logoIcon from "../images/logo.svg";
 import logoBlack from "../images/logo_nav_bar_black.svg";
 import logoWhite from "../images/logo_nav_bar_white.svg";
@@ -109,6 +110,15 @@ const LogoWithoutText = () => {
 };
 
 const SidebarContent = ({ connectedToMaker, onClose, ...rest }: SidebarProps) => {
+    const navigate = useNavigate();
+    const { symbol: symbolString } = useParams();
+    let currentSymbol = symbolString ? Symbol[symbolString as keyof typeof Symbol] : Symbol.btcusd;
+
+    const onSymbolChange = (symbol: string) => {
+        onClose();
+        navigate(`/trade/${symbol}/long`);
+    };
+
     return (
         <Box
             transition="3s ease"
@@ -125,6 +135,18 @@ const SidebarContent = ({ connectedToMaker, onClose, ...rest }: SidebarProps) =>
                 <CloseButton display={{ base: "flex", md: "none" }} onClick={onClose} />
             </Flex>
 
+            <Flex
+                align="center"
+                // p="4"
+                // mx="4"
+                mt={"4"}
+                // mb={"4"}
+                borderRadius="lg"
+                role="group"
+                w={"100%"}
+            >
+                <SymbolSelector current={currentSymbol} onChange={onSymbolChange} />
+            </Flex>
             <Divider />
 
             {LinkItems.map((link) => (
@@ -230,6 +252,28 @@ interface MobileProps extends FlexProps {
     referencePrice: number | undefined;
     onOpen: () => void;
 }
+
+interface SymbolSelectorProps {
+    current: Symbol;
+    onChange: (val: string) => void;
+}
+
+const SymbolSelector = ({ current, onChange }: SymbolSelectorProps) => {
+    let btcUsd = Symbol.btcusd;
+    let ethUsd = Symbol.ethusd;
+
+    return (
+        <Select
+            w={"100%"}
+            placeholder="Select option"
+            defaultValue={current}
+            onChange={(value) => onChange(value.target.value)}
+        >
+            <option value={btcUsd}>BTCUSD</option>
+            <option value={ethUsd}>ETHUSD</option>
+        </Select>
+    );
+};
 
 const TopBar = ({ connectedToMaker, nextFundingEvent, referencePrice, onOpen, ...rest }: MobileProps) => {
     const { toggleColorMode } = useColorMode();

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -1,265 +1,304 @@
-import { Icon, MoonIcon, SunIcon, WarningIcon } from "@chakra-ui/icons";
+import { MoonIcon, SunIcon, WarningIcon } from "@chakra-ui/icons";
 import {
     Box,
+    BoxProps,
     Button,
-    ButtonGroup,
-    Center,
+    CloseButton,
     Divider,
+    Drawer,
+    DrawerContent,
     Flex,
-    Heading,
+    FlexProps,
     HStack,
+    Icon,
+    IconButton,
     Image,
-    Link,
-    Skeleton,
-    Stack,
     Text,
     Tooltip,
     useColorMode,
     useColorModeValue,
-    VStack,
+    useDisclosure,
 } from "@chakra-ui/react";
-import * as React from "react";
-import { FaHome, FaWallet } from "react-icons/all";
-import { Link as ReachLink, useLocation, useNavigate } from "react-router-dom";
-import { BG_DARK, BG_LIGHT, HEADER_HEIGHT, VIEWPORT_WIDTH_PX } from "../App";
+import React, { ReactNode } from "react";
+import { IconType } from "react-icons";
+import { FaWallet } from "react-icons/fa";
+import { FiHome, FiMenu } from "react-icons/fi";
+import { Link as ReachLink } from "react-router-dom";
+import { HEADER_HEIGHT } from "../App";
+import logoIcon from "../images/logo.svg";
 import logoBlack from "../images/logo_nav_bar_black.svg";
 import logoWhite from "../images/logo_nav_bar_white.svg";
 import { ConnectionCloseReason, ConnectionStatus, WalletInfo } from "../types";
-import DollarAmount from "./DollarAmount";
 
-interface NavProps {
+interface LinkItemProps {
+    name: string;
+    icon: IconType;
+    target: string;
+}
+const LinkItems: Array<LinkItemProps> = [
+    { name: "Home", icon: FiHome, target: "/" },
+    { name: "Wallet", icon: FaWallet, target: "/wallet" },
+];
+
+interface NavBarProps {
     walletInfo: WalletInfo | null;
     connectedToMaker: ConnectionStatus;
     nextFundingEvent: string | null;
     referencePrice: number | undefined;
+    children: ReactNode;
 }
 
-function TextDivider() {
-    return <Divider orientation={"vertical"} borderColor={useColorModeValue("black", "white")} height={"20px"} />;
+export default function Nav({ walletInfo, connectedToMaker, nextFundingEvent, referencePrice, children }: NavBarProps) {
+    const { isOpen, onOpen, onClose } = useDisclosure();
+    return (
+        <Box minH="100vh" bg={useColorModeValue("gray.100", "gray.900")}>
+            <SidebarContent
+                onClose={() => onClose}
+                display={{ base: "none", md: "block" }}
+                zIndex={101}
+                connectedToMaker={connectedToMaker}
+            />
+            <Drawer
+                autoFocus={false}
+                isOpen={isOpen}
+                placement="left"
+                onClose={onClose}
+                returnFocusOnClose={false}
+                onOverlayClick={onClose}
+                size="full"
+            >
+                <DrawerContent>
+                    <SidebarContent onClose={onClose} connectedToMaker={connectedToMaker} />
+                </DrawerContent>
+            </Drawer>
+            <TopBar connectedToMaker={connectedToMaker} onOpen={onOpen} />
+            <Box ml={{ base: 0, md: 60 }} p="4">
+                {children}
+            </Box>
+        </Box>
+    );
 }
 
-export default function Nav({ walletInfo, connectedToMaker, nextFundingEvent, referencePrice }: NavProps) {
-    const navigate = useNavigate();
+interface SidebarProps extends BoxProps {
+    connectedToMaker: ConnectionStatus;
+    onClose: () => void;
+}
 
-    const { toggleColorMode } = useColorMode();
-    const navBarLog = useColorModeValue(
+const LogoWithText = () => {
+    const logo = useColorModeValue(
         <Image src={logoBlack} w="128px" />,
         <Image src={logoWhite} w="128px" />,
     );
+    return <>{logo}</>;
+};
+const LogoWithoutText = () => {
+    return <>{<Image src={logoIcon} w="32px" />}</>;
+};
 
-    const toggleIcon = useColorModeValue(
-        <MoonIcon />,
-        <SunIcon />,
+const SidebarContent = ({ connectedToMaker, onClose, ...rest }: SidebarProps) => {
+    return (
+        <Box
+            transition="3s ease"
+            bg={useColorModeValue("white", "gray.900")}
+            borderRight="1px"
+            borderRightColor={useColorModeValue("gray.200", "gray.700")}
+            w={{ base: "full", md: 60 }}
+            pos="fixed"
+            h="full"
+            {...rest}
+        >
+            <Flex h="20" alignItems="center" mx="8" justifyContent="space-between">
+                <LogoWithText />
+                <CloseButton display={{ base: "flex", md: "none" }} onClick={onClose} />
+            </Flex>
+
+            <Divider />
+
+            {LinkItems.map((link) => (
+                <NavItem key={link.name} icon={link.icon} target={link.target} onClick={onClose}>
+                    {link.name}
+                </NavItem>
+            ))}
+            <Divider />
+            <Flex
+                align="center"
+                p="4"
+                mx="4"
+                borderRadius="lg"
+                role="group"
+            >
+                <MakerOnlineStatus connectedToMaker={connectedToMaker} />
+            </Flex>
+        </Box>
     );
+};
 
-    const connectionStatus = (connectedToMaker: ConnectionStatus) => {
-        if (connectedToMaker.connection_close_reason) {
-            switch (connectedToMaker.connection_close_reason) {
-                case ConnectionCloseReason.MAKER_VERSION_OUTDATED:
-                    return {
-                        warn: true,
-                        light: "yellow.800",
-                        dark: "yellow.200",
-                        tooltip: "The maker is running an outdated version, please reach out to ItchySats!",
-                    };
-                case ConnectionCloseReason.TAKER_VERSION_OUTDATED:
-                    return {
-                        warn: true,
-                        light: "yellow.800",
-                        dark: "yellow.200",
-                        tooltip: "You are running an incompatible version, please upgrade!",
-                    };
-            }
-        }
+interface NavItemProps extends FlexProps {
+    icon: IconType;
+    target: string;
+    onClick: () => void;
+    children: ReactNode;
+}
+const NavItem = ({ icon, target, onClick, children, ...rest }: NavItemProps) => {
+    return (
+        <ReachLink to={target} style={{ textDecoration: "none" }} onClick={onClick}>
+            <Flex
+                focus={{ boxShadow: "none" }}
+                align="center"
+                p="4"
+                mx="4"
+                borderRadius="lg"
+                role="group"
+                cursor="pointer"
+                _hover={{
+                    bg: "orange.400",
+                    color: "white",
+                }}
+                {...rest}
+            >
+                {icon && (
+                    <Icon
+                        mr="4"
+                        fontSize="16"
+                        _groupHover={{
+                            color: "white",
+                        }}
+                        as={icon}
+                    />
+                )}
+                {children}
+            </Flex>
+        </ReachLink>
+    );
+};
 
-        if (connectedToMaker.online) {
-            return {
-                warn: false,
-                light: "green.600",
-                dark: "green.400",
-                tooltip: "The maker is online",
-            };
-        }
+interface MakerOnlineStatusProps {
+    connectedToMaker: ConnectionStatus;
+}
 
-        return {
-            warn: false,
-            light: "red.600",
-            dark: "red.400",
-            tooltip: "The maker is offline",
-        };
-    };
-
+const MakerOnlineStatus = ({ connectedToMaker }: MakerOnlineStatusProps) => {
     const connectionStatusDisplay = connectionStatus(connectedToMaker);
-
     const connectionStatusIconColor = useColorModeValue(
         connectionStatusDisplay.light,
         connectionStatusDisplay.dark,
     );
 
     return (
-        <>
-            <VStack spacing={0} position={"fixed"} width={"100%"} zIndex={"100"} height={`${HEADER_HEIGHT}px`}>
-                <Box bg={useColorModeValue("gray.100", "gray.900")} width={"100%"}>
-                    <Center>
-                        <Box
-                            paddingBottom={2}
-                            bg={useColorModeValue("gray.100", "gray.900")}
-                            width={"100%"}
-                            maxWidth={VIEWPORT_WIDTH_PX}
+        <Tooltip label={connectionStatusDisplay.tooltip}>
+            <HStack>
+                {connectionStatusDisplay.warn
+                    ? (
+                        <WarningIcon
+                            color={connectionStatusIconColor}
+                            mr="1"
+                        />
+                    )
+                    : (
+                        <Icon
+                            viewBox="0 0 200 200"
+                            color={connectionStatusIconColor}
+                            mr="2"
                         >
-                            <Flex alignItems={"center"} justifyContent={"space-between"} padding={2}>
-                                <Flex justifyContent={"flex-left"}>
-                                    <NavigationButtons />
-                                </Flex>
-                                <Flex alignItems={"center"}>
-                                    <Stack direction={"row"} spacing={7}>
-                                        <Button onClick={toggleColorMode} variant={"unstyled"}>
-                                            {toggleIcon}
-                                        </Button>
-                                        <Box>
-                                            <Button bg={"transparent"} onClick={() => navigate("/")}>
-                                                {navBarLog}
-                                            </Button>
-                                        </Box>
-                                    </Stack>
-                                </Flex>
-                            </Flex>
-                        </Box>
-                    </Center>
-                </Box>
-
-                <Box
-                    paddingTop={2}
-                    bg={useColorModeValue(BG_LIGHT, BG_DARK)}
-                    width={"100%"}
-                    maxWidth={VIEWPORT_WIDTH_PX}
-                    height={"100%"}
-                >
-                    <Center>
-                        <HStack>
-                            <Tooltip label={connectionStatusDisplay.tooltip}>
-                                <HStack>
-                                    <Text>{"Maker "}</Text>
-                                    {connectionStatusDisplay.warn
-                                        ? (
-                                            <WarningIcon
-                                                color={connectionStatusIconColor}
-                                            />
-                                        )
-                                        : (
-                                            <Icon
-                                                viewBox="0 0 200 200"
-                                                color={connectionStatusIconColor}
-                                            >
-                                                <path
-                                                    fill="currentColor"
-                                                    d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0"
-                                                />
-                                            </Icon>
-                                        )}
-                                </HStack>
-                            </Tooltip>
-                            <TextDivider />
-                            <Text>{"Funding "}</Text>
-                            <Skeleton
-                                isLoaded={nextFundingEvent != null}
-                                height={"20px"}
-                                display={"flex"}
-                                alignItems={"center"}
-                            >
-                                <Tooltip
-                                    label={"The next time your CFDs will be extended and the funding fee will be collected based on the hourly rate."}
-                                    hasArrow
-                                >
-                                    <HStack minWidth={"80px"} maxWidth={["90px", "90px", "inherit"]}>
-                                        <Heading
-                                            size={"sm"}
-                                            textOverflow={"ellipsis"}
-                                            overflow={"hidden"}
-                                            whiteSpace={"nowrap"}
-                                        >
-                                            {nextFundingEvent}
-                                        </Heading>
-                                    </HStack>
-                                </Tooltip>
-                            </Skeleton>
-                            <TextDivider />
-                            <Text display={["inherit", "inherit", "none"]}>Ref</Text>
-                            <Text display={["none", "none", "inherit"]}>Reference Price</Text>
-                            <Skeleton
-                                isLoaded={referencePrice !== undefined}
-                                height={"20px"}
-                                display={"flex"}
-                                alignItems={"center"}
-                            >
-                                <Tooltip
-                                    label={"The price the Oracle attests to, the BitMEX BXBT index price"}
-                                    hasArrow
-                                >
-                                    <Link href={"https://outcome.observer/h00.ooo/x/BitMEX/BXBT"} target={"_blank"}>
-                                        {/* The minWidth helps with not letting the elements in Nav jump because the width changes*/}
-                                        <Heading size={"sm"} minWidth={"90px"}>
-                                            <DollarAmount amount={referencePrice || 0} />
-                                        </Heading>
-                                    </Link>
-                                </Tooltip>
-                            </Skeleton>
-                        </HStack>
-                    </Center>
-                </Box>
-            </VStack>
-        </>
+                            <path
+                                fill="currentColor"
+                                d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0"
+                            />
+                        </Icon>
+                    )}
+                <Text>{"Maker"}</Text>
+            </HStack>
+        </Tooltip>
     );
+};
+
+interface MobileProps extends FlexProps {
+    connectedToMaker: ConnectionStatus;
+    nextFundingEvent: string | null;
+    referencePrice: number | undefined;
+    onOpen: () => void;
 }
 
-function NavigationButtons() {
-    const location = useLocation();
-    const isWalletSelected = location.pathname.includes("wallet");
-    const isHomeSelected = !isWalletSelected;
+const TopBar = ({ connectedToMaker, nextFundingEvent, referencePrice, onOpen, ...rest }: MobileProps) => {
+    const { toggleColorMode } = useColorMode();
 
-    const unSelectedButton = "transparent";
-    const selectedButton = useColorModeValue("grey.400", "black.400");
-    const buttonBorder = useColorModeValue("grey.400", "black.400");
-    const buttonText = useColorModeValue("black", "white");
-
-    const width = "100px";
-    const borderWidth = 2;
+    const toggleIcon = useColorModeValue(
+        <MoonIcon />,
+        <SunIcon />,
+    );
 
     return (
-        <HStack>
-            <Center>
-                <ButtonGroup spacing="3">
-                    <Button
-                        as={ReachLink}
-                        to="/long"
-                        color={isHomeSelected ? selectedButton : unSelectedButton}
-                        bg={isHomeSelected ? selectedButton : unSelectedButton}
-                        border={buttonBorder}
-                        borderWidth={borderWidth}
-                        isActive={isHomeSelected}
-                        w={width}
-                        leftIcon={<FaHome color={buttonText} />}
-                        boxShadow={"md"}
-                    >
-                        <Text fontSize={"md"} color={buttonText}>Home</Text>
-                    </Button>
-                    <Button
-                        as={ReachLink}
-                        to="/wallet"
-                        color={isWalletSelected ? selectedButton : unSelectedButton}
-                        bg={isWalletSelected ? selectedButton : unSelectedButton}
-                        border={buttonBorder}
-                        borderWidth={borderWidth}
-                        isActive={isWalletSelected}
-                        w={width}
-                        leftIcon={<FaWallet color={buttonText} />}
-                        boxShadow={"md"}
-                        id={"walletSwitchButton"}
-                    >
-                        <Text fontSize={"md"} color={buttonText}>Wallet</Text>
-                    </Button>
-                </ButtonGroup>
-            </Center>
-        </HStack>
+        <Flex
+            position="fixed"
+            top="0rem"
+            align="center"
+            // The 85% is a hack, I did not know how to prevent overflow outside of viewport
+            w={{ base: "100%", md: "85%" }}
+            ml={{ base: 0, md: 60 }}
+            mr={{ base: 0, md: 60 }}
+            px={{ base: 4, md: 4 }}
+            height={`${HEADER_HEIGHT}px`}
+            alignItems="center"
+            bg={useColorModeValue("white", "gray.900")}
+            borderBottomWidth="1px"
+            borderBottomColor={useColorModeValue("gray.200", "gray.700")}
+            justifyContent={{ base: "space-between", md: "flex-end" }}
+            zIndex={102}
+            {...rest}
+        >
+            <IconButton
+                display={{ base: "flex", md: "none" }}
+                onClick={onOpen}
+                variant="outline"
+                aria-label="open menu"
+                icon={<FiMenu />}
+            />
+
+            <Box display={{ base: "flex", md: "none" }}>
+                <LogoWithoutText />
+            </Box>
+
+            <HStack spacing={{ base: "0", md: "-20" }} display={{ base: "none", md: "flex" }}>
+                <Button onClick={toggleColorMode} variant={"unstyled"}>
+                    {toggleIcon}
+                </Button>
+            </HStack>
+        </Flex>
     );
-}
+};
+
+const connectionStatus = (connectedToMaker: ConnectionStatus) => {
+    if (connectedToMaker.connection_close_reason) {
+        switch (connectedToMaker.connection_close_reason) {
+            case ConnectionCloseReason.MAKER_VERSION_OUTDATED:
+                return {
+                    warn: true,
+                    light: "yellow.800",
+                    dark: "yellow.200",
+                    tooltip: "The maker is running an outdated version, please reach out to ItchySats!",
+                };
+            case ConnectionCloseReason.TAKER_VERSION_OUTDATED:
+                return {
+                    warn: true,
+                    light: "yellow.800",
+                    dark: "yellow.200",
+                    tooltip: "You are running an incompatible version, please upgrade!",
+                };
+        }
+    }
+
+    if (connectedToMaker.online) {
+        return {
+            warn: false,
+            light: "green.600",
+            dark: "green.400",
+            tooltip: "The maker is online",
+        };
+    }
+
+    return {
+        warn: false,
+        light: "red.600",
+        dark: "red.400",
+        tooltip: "The maker is offline",
+    };
+};

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -245,13 +245,6 @@ const MakerOnlineStatus = ({ connectedToMaker }: MakerOnlineStatusProps) => {
     );
 };
 
-interface MobileProps extends FlexProps {
-    connectedToMaker: ConnectionStatus;
-    nextFundingEvent: string | null;
-    referencePrice: number | undefined;
-    onOpen: () => void;
-}
-
 interface SymbolSelectorProps {
     current: Symbol;
     onChange: (val: string) => void;
@@ -274,7 +267,14 @@ const SymbolSelector = ({ current, onChange }: SymbolSelectorProps) => {
     );
 };
 
-const TopBar = ({ connectedToMaker, nextFundingEvent, referencePrice, onOpen, ...rest }: MobileProps) => {
+interface TopBarProps extends FlexProps {
+    connectedToMaker: ConnectionStatus;
+    nextFundingEvent: string | null;
+    referencePrice: number | undefined;
+    onOpen: () => void;
+}
+
+const TopBar = ({ connectedToMaker, nextFundingEvent, referencePrice, onOpen, ...rest }: TopBarProps) => {
     const { toggleColorMode } = useColorMode();
 
     const toggleIcon = useColorModeValue(
@@ -283,96 +283,92 @@ const TopBar = ({ connectedToMaker, nextFundingEvent, referencePrice, onOpen, ..
     );
 
     return (
-        <Flex
-            position="fixed"
-            top="0rem"
-            align="center"
-            // The 85% is a hack, I did not know how to prevent overflow outside of viewport
-            w={{ base: "100%", md: "85%" }}
-            ml={{ base: 0, md: 60 }}
-            mr={{ base: 0, md: 60 }}
-            px={{ base: 4, md: 4 }}
-            height={`${HEADER_HEIGHT}px`}
-            alignItems="center"
-            bg={useColorModeValue("white", "gray.900")}
-            borderBottomWidth="1px"
-            borderBottomColor={useColorModeValue("gray.200", "gray.700")}
-            // justifyContent={{ base: "space-between", md: "flex-end" }}
-            justifyContent={{ base: "space-between", md: "flex" }}
-            zIndex={102}
-            {...rest}
-        >
-            <IconButton
-                display={{ base: "flex", md: "none" }}
-                onClick={onOpen}
-                variant="outline"
-                aria-label="open menu"
-                icon={<FiMenu />}
-            />
+        <Box w="100%" position={"fixed"} height={`${HEADER_HEIGHT}px`} top="0" p={0} zIndex={102}>
+            <Flex
+                ml={{ base: 0, md: 60 }}
+                px={{ base: 4, md: 4 }}
+                alignItems="center"
+                height={`${HEADER_HEIGHT}px`}
+                bg={useColorModeValue("white", "gray.900")}
+                borderBottomWidth="1px"
+                borderBottomColor={useColorModeValue("gray.200", "gray.700")}
+                justifyContent={{ base: "space-between", md: "flex-end" }}
+                {...rest}
+            >
+                <IconButton
+                    display={{ base: "flex", md: "none" }}
+                    onClick={onOpen}
+                    variant="outline"
+                    aria-label="open menu"
+                    icon={<FiMenu />}
+                />
 
-            <Spacer />
-            <Box>
-                <HStack>
-                    <Text fontSize={{ md: "sm", base: "xs" }}>{"Funding "}</Text>
-                    <Skeleton
-                        isLoaded={nextFundingEvent != null}
-                        // height={"20px"}
-                        display={"flex"}
-                        alignItems={"center"}
-                    >
-                        <Tooltip
-                            label={"The next time your CFDs will be extended and the funding fee will be collected based on the hourly rate."}
-                            hasArrow
+                <Spacer />
+                <Box>
+                    <HStack>
+                        <Text fontSize={{ md: "sm", base: "xs" }}>{"Funding "}</Text>
+                        <Skeleton
+                            isLoaded={nextFundingEvent != null}
+                            // height={"20px"}
+                            display={"flex"}
+                            alignItems={"center"}
                         >
-                            <HStack>
-                                <Text
-                                    as={"b"}
-                                    fontSize={{ md: "sm", base: "xs" }}
-                                    textOverflow={"ellipsis"}
-                                    overflow={"hidden"}
-                                    whiteSpace={"nowrap"}
-                                >
-                                    {nextFundingEvent}
-                                </Text>
-                            </HStack>
-                        </Tooltip>
-                    </Skeleton>
-                    <TextDivider />
-                    <Text display={["inherit", "inherit", "none"]} fontSize={{ md: "sm", base: "xs" }}>Ref. Price</Text>
-                    <Text display={["none", "none", "inherit"]} fontSize={{ md: "sm", base: "xs" }}>
-                        Reference Price
-                    </Text>
-                    <Skeleton
-                        isLoaded={referencePrice !== undefined}
-                        display={"flex"}
-                        alignItems={"center"}
-                    >
-                        <Tooltip
-                            label={"The price the Oracle attests to, the BitMEX BXBT index price"}
-                            hasArrow
+                            <Tooltip
+                                label={"The next time your CFDs will be extended and the funding fee will be collected based on the hourly rate."}
+                                hasArrow
+                            >
+                                <HStack>
+                                    <Text
+                                        as={"b"}
+                                        fontSize={{ md: "sm", base: "xs" }}
+                                        textOverflow={"ellipsis"}
+                                        overflow={"hidden"}
+                                        whiteSpace={"nowrap"}
+                                    >
+                                        {nextFundingEvent}
+                                    </Text>
+                                </HStack>
+                            </Tooltip>
+                        </Skeleton>
+                        <TextDivider />
+                        <Text display={["inherit", "inherit", "none"]} fontSize={{ md: "sm", base: "xs" }}>
+                            Ref. Price
+                        </Text>
+                        <Text display={["none", "none", "inherit"]} fontSize={{ md: "sm", base: "xs" }}>
+                            Index Price
+                        </Text>
+                        <Skeleton
+                            isLoaded={referencePrice !== undefined}
+                            display={"flex"}
+                            alignItems={"center"}
                         >
-                            <Link href={"https://outcome.observer/h00.ooo/x/BitMEX/BXBT"} target={"_blank"}>
-                                {/* The minWidth helps with not letting the elements in Nav jump because the width changes*/}
-                                <Text as={"b"} fontSize={{ md: "sm", base: "xs" }}>
-                                    <DollarAmount amount={referencePrice || 0} />
-                                </Text>
-                            </Link>
-                        </Tooltip>
-                    </Skeleton>
+                            <Tooltip
+                                label={"The price the Oracle attests to, the BitMEX BXBT index price"}
+                                hasArrow
+                            >
+                                <Link href={"https://outcome.observer/h00.ooo/x/BitMEX/BXBT"} target={"_blank"}>
+                                    {/* The minWidth helps with not letting the elements in Nav jump because the width changes*/}
+                                    <Text as={"b"} fontSize={{ md: "sm", base: "xs" }}>
+                                        <DollarAmount amount={referencePrice || 0} />
+                                    </Text>
+                                </Link>
+                            </Tooltip>
+                        </Skeleton>
+                    </HStack>
+                </Box>
+                <Spacer />
+
+                <Box display={{ base: "flex", md: "none" }}>
+                    <LogoWithoutText />
+                </Box>
+
+                <HStack spacing={{ base: "0", md: "0" }} display={{ base: "none", md: "flex" }}>
+                    <Button onClick={toggleColorMode} variant={"unstyled"}>
+                        {toggleIcon}
+                    </Button>
                 </HStack>
-            </Box>
-            <Spacer />
-
-            <Box display={{ base: "flex", md: "none" }}>
-                <LogoWithoutText />
-            </Box>
-
-            <HStack spacing={{ base: "0", md: "-20" }} display={{ base: "none", md: "flex" }}>
-                <Button onClick={toggleColorMode} variant={"unstyled"}>
-                    {toggleIcon}
-                </Button>
-            </HStack>
-        </Flex>
+            </Flex>
+        </Box>
     );
 };
 

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -32,7 +32,7 @@ import { HEADER_HEIGHT, Symbol } from "../App";
 import logoIcon from "../images/logo.svg";
 import logoBlack from "../images/logo_nav_bar_black.svg";
 import logoWhite from "../images/logo_nav_bar_white.svg";
-import { ConnectionCloseReason, ConnectionStatus, WalletInfo } from "../types";
+import { ConnectionCloseReason, ConnectionStatus } from "../types";
 import DollarAmount from "./DollarAmount";
 
 interface LinkItemProps {
@@ -46,14 +46,13 @@ const LinkItems: Array<LinkItemProps> = [
 ];
 
 interface NavBarProps {
-    walletInfo: WalletInfo | null;
     connectedToMaker: ConnectionStatus;
     nextFundingEvent: string | null;
     referencePrice: number | undefined;
     children: ReactNode;
 }
 
-export default function Nav({ walletInfo, connectedToMaker, nextFundingEvent, referencePrice, children }: NavBarProps) {
+export default function Nav({ connectedToMaker, nextFundingEvent, referencePrice, children }: NavBarProps) {
     const { isOpen, onOpen, onClose } = useDisclosure();
     return (
         <Box minH="100vh" bg={useColorModeValue("gray.100", "gray.900")}>

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -14,7 +14,6 @@ import {
     IconButton,
     Image,
     Link,
-    Select,
     Skeleton,
     Spacer,
     Text,
@@ -23,6 +22,7 @@ import {
     useColorModeValue,
     useDisclosure,
 } from "@chakra-ui/react";
+import { OnChangeValue, Select } from "chakra-react-select";
 import React, { ReactNode } from "react";
 import { IconType } from "react-icons";
 import { SiBitcoin } from "react-icons/all";
@@ -251,20 +251,40 @@ interface SymbolSelectorProps {
     onChange: (val: string) => void;
 }
 
+interface SelectOption {
+    value: String;
+    label: String;
+}
+
 const SymbolSelector = ({ current, onChange }: SymbolSelectorProps) => {
     let btcUsd = Symbol.btcusd;
     let ethUsd = Symbol.ethusd;
 
+    const onChangeInner = (value: OnChangeValue<SelectOption, boolean>) => {
+        if (value) {
+            // @ts-ignore: the field `value` exists but the linter complains
+            onChange(value.value);
+        }
+    };
+    const options = [
+        { value: btcUsd, label: btcUsd.toUpperCase() },
+        { value: ethUsd, label: ethUsd.toUpperCase() },
+    ];
+
     return (
-        <Select
-            w={"100%"}
-            placeholder="Select option"
-            defaultValue={current}
-            onChange={(value) => onChange(value.target.value)}
-        >
-            <option value={btcUsd}>BTCUSD</option>
-            <option value={ethUsd}>ETHUSD</option>
-        </Select>
+        <Box w={"100%"}>
+            <Select
+                defaultValue={options[0]}
+                value={{
+                    value: current,
+                    label: current.toUpperCase(),
+                }}
+                selectedOptionColor="orange"
+                selectedOptionStyle="color"
+                options={options}
+                onChange={(item) => onChangeInner(item)}
+            />
+        </Box>
     );
 };
 

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -25,8 +25,9 @@ import {
 } from "@chakra-ui/react";
 import React, { ReactNode } from "react";
 import { IconType } from "react-icons";
+import { SiBitcoin } from "react-icons/all";
 import { FaWallet } from "react-icons/fa";
-import { FiHome, FiMenu } from "react-icons/fi";
+import { FiMenu } from "react-icons/fi";
 import { Link as ReachLink, useNavigate, useParams } from "react-router-dom";
 import { HEADER_HEIGHT, Symbol } from "../App";
 import logoIcon from "../images/logo.svg";
@@ -41,7 +42,7 @@ interface LinkItemProps {
     target: string;
 }
 const LinkItems: Array<LinkItemProps> = [
-    { name: "Home", icon: FiHome, target: "/" },
+    { name: "Trade", icon: SiBitcoin, target: "/" },
     { name: "Wallet", icon: FaWallet, target: "/wallet" },
 ];
 

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -22,7 +22,6 @@ import {
     useColorModeValue,
     useDisclosure,
 } from "@chakra-ui/react";
-import { OnChangeValue, Select } from "chakra-react-select";
 import React, { ReactNode } from "react";
 import { IconType } from "react-icons";
 import { SiBitcoin } from "react-icons/all";
@@ -93,7 +92,7 @@ function TextDivider() {
     return <Divider orientation={"vertical"} borderColor={useColorModeValue("black", "white")} height={"20px"} />;
 }
 
-interface SidebarProps extends BoxProps {
+export interface SidebarProps extends BoxProps {
     connectedToMaker: ConnectionStatus;
     onClose: () => void;
 }
@@ -110,15 +109,6 @@ const LogoWithoutText = () => {
 };
 
 const SidebarContent = ({ connectedToMaker, onClose, ...rest }: SidebarProps) => {
-    const navigate = useNavigate();
-    const { symbol: symbolString } = useParams();
-    let currentSymbol = symbolString ? Symbol[symbolString as keyof typeof Symbol] : Symbol.btcusd;
-
-    const onSymbolChange = (symbol: string) => {
-        onClose();
-        navigate(`/trade/${symbol}/long`);
-    };
-
     return (
         <Box
             transition="3s ease"
@@ -134,20 +124,6 @@ const SidebarContent = ({ connectedToMaker, onClose, ...rest }: SidebarProps) =>
                 <LogoWithText />
                 <CloseButton display={{ base: "flex", md: "none" }} onClick={onClose} />
             </Flex>
-
-            <Flex
-                align="center"
-                // p="4"
-                // mx="4"
-                mt={"4"}
-                // mb={"4"}
-                borderRadius="lg"
-                role="group"
-                w={"100%"}
-            >
-                <SymbolSelector current={currentSymbol} onChange={onSymbolChange} />
-            </Flex>
-            <Divider />
 
             {LinkItems.map((link) => (
                 <NavItem key={link.name} icon={link.icon} target={link.target} onClick={onClose}>
@@ -243,48 +219,6 @@ const MakerOnlineStatus = ({ connectedToMaker }: MakerOnlineStatusProps) => {
                 <Text>{"Maker"}</Text>
             </HStack>
         </Tooltip>
-    );
-};
-
-interface SymbolSelectorProps {
-    current: Symbol;
-    onChange: (val: string) => void;
-}
-
-interface SelectOption {
-    value: String;
-    label: String;
-}
-
-const SymbolSelector = ({ current, onChange }: SymbolSelectorProps) => {
-    let btcUsd = Symbol.btcusd;
-    let ethUsd = Symbol.ethusd;
-
-    const onChangeInner = (value: OnChangeValue<SelectOption, boolean>) => {
-        if (value) {
-            // @ts-ignore: the field `value` exists but the linter complains
-            onChange(value.value);
-        }
-    };
-    const options = [
-        { value: btcUsd, label: btcUsd.toUpperCase() },
-        { value: ethUsd, label: ethUsd.toUpperCase() },
-    ];
-
-    return (
-        <Box w={"100%"}>
-            <Select
-                defaultValue={options[0]}
-                value={{
-                    value: current,
-                    label: current.toUpperCase(),
-                }}
-                selectedOptionColor="orange"
-                selectedOptionStyle="color"
-                options={options}
-                onChange={(item) => onChangeInner(item)}
-            />
-        </Box>
     );
 };
 

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -13,6 +13,9 @@ import {
     Icon,
     IconButton,
     Image,
+    Link,
+    Skeleton,
+    Spacer,
     Text,
     Tooltip,
     useColorMode,
@@ -29,6 +32,7 @@ import logoIcon from "../images/logo.svg";
 import logoBlack from "../images/logo_nav_bar_black.svg";
 import logoWhite from "../images/logo_nav_bar_white.svg";
 import { ConnectionCloseReason, ConnectionStatus, WalletInfo } from "../types";
+import DollarAmount from "./DollarAmount";
 
 interface LinkItemProps {
     name: string;
@@ -71,12 +75,21 @@ export default function Nav({ walletInfo, connectedToMaker, nextFundingEvent, re
                     <SidebarContent onClose={onClose} connectedToMaker={connectedToMaker} />
                 </DrawerContent>
             </Drawer>
-            <TopBar connectedToMaker={connectedToMaker} onOpen={onOpen} />
+            <TopBar
+                connectedToMaker={connectedToMaker}
+                onOpen={onOpen}
+                nextFundingEvent={nextFundingEvent}
+                referencePrice={referencePrice}
+            />
             <Box ml={{ base: 0, md: 60 }} p="4">
                 {children}
             </Box>
         </Box>
     );
+}
+
+function TextDivider() {
+    return <Divider orientation={"vertical"} borderColor={useColorModeValue("black", "white")} height={"20px"} />;
 }
 
 interface SidebarProps extends BoxProps {
@@ -241,7 +254,8 @@ const TopBar = ({ connectedToMaker, nextFundingEvent, referencePrice, onOpen, ..
             bg={useColorModeValue("white", "gray.900")}
             borderBottomWidth="1px"
             borderBottomColor={useColorModeValue("gray.200", "gray.700")}
-            justifyContent={{ base: "space-between", md: "flex-end" }}
+            // justifyContent={{ base: "space-between", md: "flex-end" }}
+            justifyContent={{ base: "space-between", md: "flex" }}
             zIndex={102}
             {...rest}
         >
@@ -252,6 +266,59 @@ const TopBar = ({ connectedToMaker, nextFundingEvent, referencePrice, onOpen, ..
                 aria-label="open menu"
                 icon={<FiMenu />}
             />
+
+            <Spacer />
+            <Box>
+                <HStack>
+                    <Text fontSize={{ md: "sm", base: "xs" }}>{"Funding "}</Text>
+                    <Skeleton
+                        isLoaded={nextFundingEvent != null}
+                        // height={"20px"}
+                        display={"flex"}
+                        alignItems={"center"}
+                    >
+                        <Tooltip
+                            label={"The next time your CFDs will be extended and the funding fee will be collected based on the hourly rate."}
+                            hasArrow
+                        >
+                            <HStack>
+                                <Text
+                                    as={"b"}
+                                    fontSize={{ md: "sm", base: "xs" }}
+                                    textOverflow={"ellipsis"}
+                                    overflow={"hidden"}
+                                    whiteSpace={"nowrap"}
+                                >
+                                    {nextFundingEvent}
+                                </Text>
+                            </HStack>
+                        </Tooltip>
+                    </Skeleton>
+                    <TextDivider />
+                    <Text display={["inherit", "inherit", "none"]} fontSize={{ md: "sm", base: "xs" }}>Ref. Price</Text>
+                    <Text display={["none", "none", "inherit"]} fontSize={{ md: "sm", base: "xs" }}>
+                        Reference Price
+                    </Text>
+                    <Skeleton
+                        isLoaded={referencePrice !== undefined}
+                        display={"flex"}
+                        alignItems={"center"}
+                    >
+                        <Tooltip
+                            label={"The price the Oracle attests to, the BitMEX BXBT index price"}
+                            hasArrow
+                        >
+                            <Link href={"https://outcome.observer/h00.ooo/x/BitMEX/BXBT"} target={"_blank"}>
+                                {/* The minWidth helps with not letting the elements in Nav jump because the width changes*/}
+                                <Text as={"b"} fontSize={{ md: "sm", base: "xs" }}>
+                                    <DollarAmount amount={referencePrice || 0} />
+                                </Text>
+                            </Link>
+                        </Tooltip>
+                    </Skeleton>
+                </HStack>
+            </Box>
+            <Spacer />
 
             <Box display={{ base: "flex", md: "none" }}>
                 <LogoWithoutText />

--- a/taker-frontend/src/components/SymbolSelector.tsx
+++ b/taker-frontend/src/components/SymbolSelector.tsx
@@ -1,0 +1,46 @@
+import { Box } from "@chakra-ui/react";
+import { OnChangeValue, Select } from "chakra-react-select";
+import React from "react";
+import { Symbol } from "../App";
+
+export interface SymbolSelectorProps {
+    current: Symbol;
+    onChange: (val: string) => void;
+}
+
+interface SelectOption {
+    value: String;
+    label: String;
+}
+
+export const SymbolSelector = ({ current, onChange }: SymbolSelectorProps) => {
+    let btcUsd = Symbol.btcusd;
+    let ethUsd = Symbol.ethusd;
+
+    const onChangeInner = (value: OnChangeValue<SelectOption, boolean>) => {
+        if (value) {
+            // @ts-ignore: the field `value` exists but the linter complains
+            onChange(value.value);
+        }
+    };
+    const options = [
+        { value: btcUsd, label: btcUsd.toUpperCase() },
+        { value: ethUsd, label: ethUsd.toUpperCase() },
+    ];
+
+    return (
+        <Box width={"100%"}>
+            <Select
+                defaultValue={options[0]}
+                value={{
+                    value: current,
+                    label: current.toUpperCase(),
+                }}
+                selectedOptionColor="orange"
+                selectedOptionStyle="color"
+                options={options}
+                onChange={(item) => onChangeInner(item)}
+            />
+        </Box>
+    );
+};

--- a/taker-frontend/src/components/TradePageLayout.tsx
+++ b/taker-frontend/src/components/TradePageLayout.tsx
@@ -11,13 +11,15 @@ import {
     HStack,
     Text,
     useColorModeValue,
+    useDisclosure,
     VStack,
 } from "@chakra-ui/react";
 import * as React from "react";
-import { Link as ReachLink, Outlet, useLocation, useParams } from "react-router-dom";
+import { Link as ReachLink, Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
 import { Symbol, VIEWPORT_WIDTH_PX } from "../App";
 import { Cfd, ConnectionStatus, isClosed } from "../types";
 import History from "./History";
+import { SymbolSelector } from "./SymbolSelector";
 
 interface TradePageLayoutProps {
     cfds: Cfd[];
@@ -82,6 +84,7 @@ function HistoryLayout({ cfds, connectedToMaker, showExtraInfo }: HistoryLayoutP
 function NavigationButtons() {
     const location = useLocation();
     let { symbol: symbolString } = useParams();
+    const navigate = useNavigate();
     let symbol = symbolString ? Symbol[symbolString as keyof typeof Symbol] : Symbol.btcusd;
 
     const isLongSelected = location.pathname.includes("long");
@@ -92,27 +95,19 @@ function NavigationButtons() {
     const buttonBorder = useColorModeValue("grey.400", "black.400");
     const buttonText = useColorModeValue("black", "white");
 
-    let buttonLabel;
-    switch (symbol) {
-        case Symbol.btcusd: {
-            buttonLabel = "BTC";
-            break;
-        }
-        case Symbol.ethusd: {
-            buttonLabel = "ETH";
-            break;
-        }
-        default: {
-            buttonLabel = "BTC";
-        }
-    }
+    let currentSymbol = symbolString ? Symbol[symbolString as keyof typeof Symbol] : Symbol.btcusd;
+    const { onClose } = useDisclosure();
+    const onSymbolChange = (symbol: string) => {
+        onClose();
+        navigate(`/trade/${symbol}/long`);
+    };
 
     return (
         <HStack>
             <Center>
                 <ButtonGroup
                     padding="3"
-                    spacing="6"
+                    spacing={{ base: "3", md: "6" }}
                     id={"longShortButtonSwitch"}
                 >
                     <Button
@@ -121,25 +116,30 @@ function NavigationButtons() {
                         color={isLongSelected ? selectedButton : unSelectedButton}
                         bg={isLongSelected ? selectedButton : unSelectedButton}
                         border={buttonBorder}
+                        borderWidth={isLongSelected ? "0px" : "2px"}
                         isActive={isLongSelected}
                         size="lg"
                         h={10}
-                        w={"40"}
+                        w={{ base: "30", md: "40" }}
                     >
-                        <Text fontSize={"md"} color={buttonText}>Long {buttonLabel}</Text>
+                        <Text fontSize={"md"} color={buttonText}>Long</Text>
                     </Button>
+                    <Box minWidth={{ base: "150", md: "170" }}>
+                        <SymbolSelector current={currentSymbol} onChange={onSymbolChange} />
+                    </Box>
                     <Button
                         as={ReachLink}
                         to={"/trade/" + symbolString + "/short/"}
                         color={isShortSelected ? selectedButton : unSelectedButton}
                         bg={isShortSelected ? selectedButton : unSelectedButton}
                         border={buttonBorder}
+                        borderWidth={isShortSelected ? "0px" : "2px"}
                         isActive={isShortSelected}
                         size="lg"
                         h={10}
-                        w={"40"}
+                        w={{ base: "30", md: "40" }}
                     >
-                        <Text fontSize={"md"} color={buttonText}>Short {buttonLabel}</Text>
+                        <Text fontSize={"md"} color={buttonText}>Short</Text>
                     </Button>
                 </ButtonGroup>
             </Center>

--- a/taker-frontend/src/components/TradePageLayout.tsx
+++ b/taker-frontend/src/components/TradePageLayout.tsx
@@ -82,7 +82,7 @@ function HistoryLayout({ cfds, connectedToMaker, showExtraInfo }: HistoryLayoutP
 function NavigationButtons() {
     const location = useLocation();
     let { symbol: symbolString } = useParams();
-    let symbol = symbolString ? Symbol[symbolString as keyof typeof Symbol] : Symbol.BtcUsd;
+    let symbol = symbolString ? Symbol[symbolString as keyof typeof Symbol] : Symbol.btcusd;
 
     const isLongSelected = location.pathname.includes("long");
     const isShortSelected = !isLongSelected;
@@ -94,11 +94,11 @@ function NavigationButtons() {
 
     let buttonLabel;
     switch (symbol) {
-        case Symbol.BtcUsd: {
+        case Symbol.btcusd: {
             buttonLabel = "BTC";
             break;
         }
-        case Symbol.EthUsd: {
+        case Symbol.ethusd: {
             buttonLabel = "ETH";
             break;
         }
@@ -117,7 +117,7 @@ function NavigationButtons() {
                 >
                     <Button
                         as={ReachLink}
-                        to={symbolString + "/long"}
+                        to={"/trade/" + symbolString + "/long/"}
                         color={isLongSelected ? selectedButton : unSelectedButton}
                         bg={isLongSelected ? selectedButton : unSelectedButton}
                         border={buttonBorder}
@@ -130,7 +130,7 @@ function NavigationButtons() {
                     </Button>
                     <Button
                         as={ReachLink}
-                        to={symbolString + "/short"}
+                        to={"/trade/" + symbolString + "/short/"}
                         color={isShortSelected ? selectedButton : unSelectedButton}
                         bg={isShortSelected ? selectedButton : unSelectedButton}
                         border={buttonBorder}

--- a/taker-frontend/src/components/TradePageLayout.tsx
+++ b/taker-frontend/src/components/TradePageLayout.tsx
@@ -14,8 +14,8 @@ import {
     VStack,
 } from "@chakra-ui/react";
 import * as React from "react";
-import { Link as ReachLink, Outlet, useLocation } from "react-router-dom";
-import { VIEWPORT_WIDTH_PX } from "../App";
+import { Link as ReachLink, Outlet, useLocation, useParams } from "react-router-dom";
+import { Symbol, VIEWPORT_WIDTH_PX } from "../App";
 import { Cfd, ConnectionStatus, isClosed } from "../types";
 import History from "./History";
 
@@ -81,6 +81,9 @@ function HistoryLayout({ cfds, connectedToMaker, showExtraInfo }: HistoryLayoutP
 
 function NavigationButtons() {
     const location = useLocation();
+    let { symbol: symbolString } = useParams();
+    let symbol = symbolString ? Symbol[symbolString as keyof typeof Symbol] : Symbol.BtcUsd;
+
     const isLongSelected = location.pathname.includes("long");
     const isShortSelected = !isLongSelected;
 
@@ -88,6 +91,21 @@ function NavigationButtons() {
     const selectedButton = useColorModeValue("grey.400", "black.400");
     const buttonBorder = useColorModeValue("grey.400", "black.400");
     const buttonText = useColorModeValue("black", "white");
+
+    let buttonLabel;
+    switch (symbol) {
+        case Symbol.BtcUsd: {
+            buttonLabel = "BTC";
+            break;
+        }
+        case Symbol.EthUsd: {
+            buttonLabel = "ETH";
+            break;
+        }
+        default: {
+            buttonLabel = "BTC";
+        }
+    }
 
     return (
         <HStack>
@@ -99,7 +117,7 @@ function NavigationButtons() {
                 >
                     <Button
                         as={ReachLink}
-                        to="/long"
+                        to={symbolString + "/long"}
                         color={isLongSelected ? selectedButton : unSelectedButton}
                         bg={isLongSelected ? selectedButton : unSelectedButton}
                         border={buttonBorder}
@@ -108,11 +126,11 @@ function NavigationButtons() {
                         h={10}
                         w={"40"}
                     >
-                        <Text fontSize={"md"} color={buttonText}>Long BTC</Text>
+                        <Text fontSize={"md"} color={buttonText}>Long {buttonLabel}</Text>
                     </Button>
                     <Button
                         as={ReachLink}
-                        to="/short"
+                        to={symbolString + "/short"}
                         color={isShortSelected ? selectedButton : unSelectedButton}
                         bg={isShortSelected ? selectedButton : unSelectedButton}
                         border={buttonBorder}
@@ -121,7 +139,7 @@ function NavigationButtons() {
                         h={10}
                         w={"40"}
                     >
-                        <Text fontSize={"md"} color={buttonText}>Short BTC</Text>
+                        <Text fontSize={"md"} color={buttonText}>Short {buttonLabel}</Text>
                     </Button>
                 </ButtonGroup>
             </Center>

--- a/taker-frontend/yarn.lock
+++ b/taker-frontend/yarn.lock
@@ -1242,6 +1242,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.0.tgz#d16a35ebf4cd74e202083356fab21dd89363ddd6"
@@ -1986,7 +1993,7 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
-"@emotion/cache@^11.9.3":
+"@emotion/cache@^11.4.0", "@emotion/cache@^11.9.3":
   version "11.9.3"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.9.3.tgz#96638449f6929fd18062cfe04d79b29b44c0d6cb"
   integrity sha512-0dgkI/JKlCXa+lEXviaMtGBL0ynpx4osh7rjOXE71q9bIF8G+XhJgvi+wDu0B0IdCVx37BffiwXlN9I3UuzFvg==
@@ -2026,7 +2033,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
   integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
-"@emotion/react@^11":
+"@emotion/react@^11.8.1":
   version "11.9.3"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.9.3.tgz#f4f4f34444f6654a2e550f5dab4f2d360c101df9"
   integrity sha512-g9Q1GcTOlzOEjqwuLF/Zd9LC+4FljjPjDfxSM7KmEakm+hsHXk+bYZ2q+/hTJzr0OUNkujo72pXLQvXj6H+GJQ==
@@ -2646,6 +2653,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-transition-group@^4.4.0":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
+  integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^18.0.1", "@types/react@^18.0.15":
   version "18.0.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.15.tgz#d355644c26832dc27f3e6cbf0c4f4603fc4ab7fe"
@@ -3235,6 +3249,13 @@ caniuse-lite@^1.0.30001332:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz#899254a0b70579e5a957c32dced79f0727c61f2a"
   integrity sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==
 
+chakra-react-select@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/chakra-react-select/-/chakra-react-select-4.1.4.tgz#27ad5cd2953dd93a7fb594454e73bd386304ebb3"
+  integrity sha512-zhLIGWxVZWYZv/EOxzrnVfIT+JmNdBgFEbRYR2H7I7ViLcR434KRV5Wz9zZByUmhVxID34WMOInDZYeLXAMkNg==
+  dependencies:
+    react-select "^5.4.0"
+
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -3571,6 +3592,14 @@ dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz#caa6d08f60388d0bb4539dd75fe458a9a1d0014c"
   integrity sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -5370,6 +5399,11 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
+memoize-one@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 meow@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-9.0.0.tgz#cd9510bc5cac9dee7d03c73ee1f9ad959f4ea364"
@@ -5824,6 +5858,15 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+prop-types@^15.6.0:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
@@ -5895,7 +5938,7 @@ react-icons@^4.4.0:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.4.0.tgz#a13a8a20c254854e1ec9aecef28a95cdf24ef703"
   integrity sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==
 
-react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -5949,6 +5992,19 @@ react-router@6.3.0:
   dependencies:
     history "^5.2.0"
 
+react-select@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.4.0.tgz#81f6ac73906126706f104751ee14437bd16798f4"
+  integrity sha512-CjE9RFLUvChd5SdlfG4vqxZd55AZJRrLrHzkQyTYeHlpOztqcgnyftYAolJ0SGsBev6zAs6qFrjm6KU3eo2hzg==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.8.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+
 react-style-singleton@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
@@ -5957,6 +6013,16 @@ react-style-singleton@^2.2.1:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
     tslib "^2.0.0"
+
+react-transition-group@^4.3.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react-use-websocket@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Just wanted to give this a quick crack to see how it would look, because after staring at @bonomat 's PR I felt the redundancy of the `symbol` in the buttons (`Long ETH` `Short ETH` ...) might be an indicator that we want the selector there. I gave it a try and found it not to bad. 
Still like the side bar and would keep it. @bonomat structured the selector really nice, so we could just move it if we want :)

Advantage:
- Easier to access
- More visible (especially on mobile)

Disadvantage:
- Always present on screen, users that are only interested in one pair might not want to see it at all times

---

<details>
<summary style="font-size:14px">Screenshot</summary>
<p>
<img width="100%" alt="image" src="https://user-images.githubusercontent.com/5557790/181728055-dd1c2a66-3877-4764-a181-76f4d1b7042f.png">
</p></details>

<details>
<summary style="font-size:14px">Screenshot</summary>
<p>
<img width="100%" alt="image" src="https://user-images.githubusercontent.com/5557790/181727774-cbb94630-f8c7-41d2-9fed-d862dab329b0.png">
</p></details>

