### PR TITLE
Bump Rocket to 0.5.0-rc.2

### DIFF
--- a/rocket-basicauth/Cargo.toml
+++ b/rocket-basicauth/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 base64 = "0.13"
 hex = "0.4"
-rocket = { version = "0.5.0-rc.1", features = ["json"] }
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
 void = "1"

--- a/rust-embed-rocket/Cargo.toml
+++ b/rust-embed-rocket/Cargo.toml
@@ -7,5 +7,5 @@ description = "First-class support for rocket in rust-embed."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rocket = { version = "0.5.0-rc.1" }
+rocket = { version = "0.5.0-rc.2" }
 rust-embed = "6.4"

--- a/shared-bin/Cargo.toml
+++ b/shared-bin/Cargo.toml
@@ -19,7 +19,7 @@ model = { path = "../model" }
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.10.0" }
 quiet-spans = { path = "../quiet-spans" }
-rocket = { version = "0.5.0-rc.1", features = ["json"] }
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
 rocket-basicauth = { path = "../rocket-basicauth" }
 serde = { version = "1", features = ["derive"] }
 time = "0.3.11"

--- a/taker/Cargo.toml
+++ b/taker/Cargo.toml
@@ -16,7 +16,7 @@ itertools = "0.10"
 libp2p-core = { version = "0.33", default-features = false }
 model = { path = "../model" }
 prometheus = { version = "0.13", default-features = false }
-rocket = { version = "0.5.0-rc.1", features = ["json", "uuid"] }
+rocket = { version = "0.5.0-rc.2", features = ["json", "uuid"] }
 rocket-basicauth = { path = "../rocket-basicauth" }
 rust-embed = "6.4"
 rust-embed-rocket = { path = "../rust-embed-rocket" }


### PR DESCRIPTION
It was bumped in some of the crates, but not all :(

This should reduce the amount of dependencies, because it seems that on maker side we had both rc1 and rc2 linked (with their deps...)