### PR TITLE
Harmonize protocol variable

### DIFF
--- a/daemon/src/listen_protocols.rs
+++ b/daemon/src/listen_protocols.rs
@@ -10,25 +10,25 @@ use xtra_libp2p::NewInboundSubstream;
 use xtra_libp2p_ping::pong;
 
 pub const MAKER_LISTEN_PROTOCOLS: MakerListenProtocols = MakerListenProtocols::new(
-    xtra_libp2p_ping::PROTOCOL_NAME,
+    xtra_libp2p_ping::PROTOCOL,
     identify::PROTOCOL,
-    order::PROTOCOL_NAME,
+    order::PROTOCOL,
     rollover::v_1_0_0::PROTOCOL,
     rollover::v_2_0_0::PROTOCOL,
     collab_settlement::PROTOCOL,
 );
 
 pub const TAKER_LISTEN_PROTOCOLS: TakerListenProtocols = TakerListenProtocols::new(
-    xtra_libp2p_ping::PROTOCOL_NAME,
+    xtra_libp2p_ping::PROTOCOL,
     identify::PROTOCOL,
-    xtra_libp2p_offer::PROTOCOL_NAME,
+    xtra_libp2p_offer::PROTOCOL,
 );
 
 pub const REQUIRED_MAKER_LISTEN_PROTOCOLS: RequiredMakerListenProtocols =
     RequiredMakerListenProtocols::new(
-        xtra_libp2p_ping::PROTOCOL_NAME,
+        xtra_libp2p_ping::PROTOCOL,
         identify::PROTOCOL,
-        order::PROTOCOL_NAME,
+        order::PROTOCOL,
         rollover::v_2_0_0::PROTOCOL,
         collab_settlement::PROTOCOL,
     );
@@ -286,7 +286,7 @@ mod tests {
     fn given_maker_maker_does_not_support_required_protocol_then_error_with_protocol_diff() {
         let mut maker_protocols_as_hashset: HashSet<String> = MAKER_LISTEN_PROTOCOLS.into();
         // remove the ping protocol, we assume that it always is in there
-        maker_protocols_as_hashset.remove(xtra_libp2p_ping::PROTOCOL_NAME);
+        maker_protocols_as_hashset.remove(xtra_libp2p_ping::PROTOCOL);
 
         let err = does_maker_satisfy_taker_needs(
             &maker_protocols_as_hashset,
@@ -294,10 +294,7 @@ mod tests {
         )
         .unwrap_err();
 
-        assert_eq!(
-            err,
-            HashSet::from([xtra_libp2p_ping::PROTOCOL_NAME.to_string()])
-        )
+        assert_eq!(err, HashSet::from([xtra_libp2p_ping::PROTOCOL.to_string()]))
     }
 
     #[test]

--- a/daemon/src/order.rs
+++ b/daemon/src/order.rs
@@ -1,4 +1,4 @@
-pub const PROTOCOL_NAME: &str = "/itchysats/order/1.0.0";
+pub const PROTOCOL: &str = "/itchysats/order/1.0.0";
 
 pub mod maker;
 mod protocol;

--- a/daemon/src/order/taker.rs
+++ b/daemon/src/order/taker.rs
@@ -4,7 +4,7 @@ use crate::oracle::NoAnnouncement;
 use crate::order::protocol::Decision;
 use crate::order::protocol::MakerMessage;
 use crate::order::protocol::TakerMessage;
-use crate::order::PROTOCOL_NAME;
+use crate::order::PROTOCOL;
 use crate::process_manager;
 use crate::projection;
 use crate::setup_contract;
@@ -127,7 +127,7 @@ impl Actor {
                 projection.send(projection::CfdChanged(cfd.id())).await?;
 
                 let stream = endpoint
-                    .send(OpenSubstream::single_protocol(maker_peer_id, PROTOCOL_NAME))
+                    .send(OpenSubstream::single_protocol(maker_peer_id, PROTOCOL))
                     .await
                     .context("Endpoint is disconnected")?
                     .context("No connection to peer")?

--- a/xtra-libp2p-offer/src/lib.rs
+++ b/xtra-libp2p-offer/src/lib.rs
@@ -2,7 +2,7 @@ pub mod maker;
 mod protocol;
 pub mod taker;
 
-pub const PROTOCOL_NAME: &str = "/itchysats/offer/1.0.0";
+pub const PROTOCOL: &str = "/itchysats/offer/1.0.0";
 
 #[cfg(test)]
 mod tests {
@@ -140,7 +140,7 @@ mod tests {
             Box::new(MemoryTransport::default),
             Keypair::generate_ed25519(),
             Duration::from_secs(10),
-            [(PROTOCOL_NAME, offer_taker_addr.into())],
+            [(PROTOCOL, offer_taker_addr.into())],
             Subscribers::default(),
         )
         .create(None)

--- a/xtra-libp2p-offer/src/maker.rs
+++ b/xtra-libp2p-offer/src/maker.rs
@@ -1,5 +1,5 @@
 use crate::protocol;
-use crate::PROTOCOL_NAME;
+use crate::PROTOCOL;
 use async_trait::async_trait;
 use model::MakerOffers;
 use std::collections::HashSet;
@@ -35,7 +35,7 @@ impl Actor {
         let span = tracing::debug_span!("Send offers", %peer).or_current();
         let task = async move {
             let stream = endpoint
-                .send(OpenSubstream::single_protocol(peer, PROTOCOL_NAME))
+                .send(OpenSubstream::single_protocol(peer, PROTOCOL))
                 .await??
                 .await?;
 

--- a/xtra-libp2p-ping/src/lib.rs
+++ b/xtra-libp2p-ping/src/lib.rs
@@ -5,7 +5,7 @@ mod protocol;
 /// The name of the official ipfs/libp2p ping protocol.
 ///
 /// Using this indicates that we are wire-compatible with other libp2p/ipfs nodes.
-pub const PROTOCOL_NAME: &str = "/ipfs/ping/1.0.0";
+pub const PROTOCOL: &str = "/ipfs/ping/1.0.0";
 
 #[cfg(test)]
 mod tests {
@@ -93,7 +93,7 @@ mod tests {
             Box::new(MemoryTransport::default),
             id.clone(),
             Duration::from_secs(10),
-            [(PROTOCOL_NAME, pong_address.into())],
+            [(PROTOCOL, pong_address.into())],
             Subscribers::new(
                 vec![ping_address.clone().into()],
                 vec![ping_address.clone().into()],

--- a/xtra-libp2p-ping/src/ping.rs
+++ b/xtra-libp2p-ping/src/ping.rs
@@ -1,5 +1,5 @@
 use crate::protocol;
-use crate::PROTOCOL_NAME;
+use crate::PROTOCOL;
 use conquer_once::Lazy;
 use prometheus::register_histogram;
 use prometheus::Histogram;
@@ -116,7 +116,7 @@ impl Actor {
 
                 async move {
                     let stream = endpoint
-                        .send(OpenSubstream::single_protocol(peer, PROTOCOL_NAME))
+                        .send(OpenSubstream::single_protocol(peer, PROTOCOL))
                         .await??
                         .await?;
                     let latency = protocol::send(stream).await?;


### PR DESCRIPTION
It was annoying that we used `PROTOCOL` and PROTOCOL_NAME` for the same thing.

I think `PROTOCOL` is expressive enough and more concise.