### PR TITLE
Improve logs around network communication

### DIFF
--- a/daemon/src/collab_settlement/maker.rs
+++ b/daemon/src/collab_settlement/maker.rs
@@ -200,16 +200,13 @@ impl Actor {
                 let executor = self.executor.clone();
                 move |failed| async move {
                     match failed {
-                        Failed::BeforeReceiving { source } => {
-                            emit_failed(order_id, source, &executor).await;
+                        e @ Failed::BeforeReceiving { .. } => {
+                            emit_failed(order_id, anyhow!(e), &executor).await;
                         }
-                        Failed::AfterReceiving { source, settlement } => {
-                            // TODO: proceed with the transaction when taker will be able to handle that case.
-                            tracing::trace!(
-                        ?settlement,
-                        "Failed after receiving. Ideally, we should be able to act upon this settlement"
-                    );
-                            emit_failed(order_id, source, &executor).await;
+                        e @ Failed::AfterReceiving { .. } => {
+                            // TODO: proceed with the transaction when taker will be able to handle
+                            // that case.
+                            emit_failed(order_id, anyhow!(e), &executor).await;
                         }
                     }
                 }

--- a/daemon/src/collab_settlement/maker.rs
+++ b/daemon/src/collab_settlement/maker.rs
@@ -155,7 +155,9 @@ impl Actor {
 
                     let DialerSignature { dialer_signature } = framed
                         .next()
-                        .timeout(SETTLEMENT_MSG_TIMEOUT, || tracing::debug_span!("receive dialer signature"))
+                        .timeout(SETTLEMENT_MSG_TIMEOUT, || {
+                            tracing::debug_span!("receive dialer signature")
+                        })
                         .await
                         .with_context(|| {
                             format!(
@@ -181,7 +183,9 @@ impl Actor {
                     );
 
                     framed
-                        .send(ListenerMessage::ListenerSignature(ListenerSignature { listener_signature }))
+                        .send(ListenerMessage::ListenerSignature(ListenerSignature {
+                            listener_signature,
+                        }))
                         .await
                         .map_err(|source| Failed::AfterReceiving {
                             source: anyhow!(source),
@@ -233,7 +237,7 @@ impl Actor {
                     .await
             },
             move |e| async move {
-                tracing::debug!(%order_id, "Failed to reject collaborative settlement: {e:#}")
+                tracing::warn!(%order_id, "Failed to reject collaborative settlement: {e:#}")
             },
         );
         self.protocol_tasks.insert(order_id, tasks);

--- a/daemon/src/collab_settlement/maker.rs
+++ b/daemon/src/collab_settlement/maker.rs
@@ -120,7 +120,6 @@ impl Actor {
         let (transaction, proposal) = match result {
             Ok((transaction, proposal)) => (transaction, proposal),
             Err(e) => {
-                tracing::debug!(%order_id, %peer, "Failed to start collab settlement protocol: {e:#}");
                 emit_failed(order_id, e, &self.executor).await;
                 return;
             }

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1328,7 +1328,7 @@ impl Cfd {
     }
 
     pub fn fail_collaborative_settlement(self, error: anyhow::Error) -> CfdEvent {
-        tracing::error!(order_id=%self.id(), "Collaborative settlement failed: {:#}", error);
+        tracing::warn!(order_id = %self.id(), peer_id=?self.counterparty_peer_id, "Collaborative settlement failed: {error:#}");
 
         self.event(EventKind::CollaborativeSettlementFailed)
     }

--- a/xtra-libp2p-offer/src/maker.rs
+++ b/xtra-libp2p-offer/src/maker.rs
@@ -45,7 +45,7 @@ impl Actor {
         };
 
         let err_handler =
-            move |e| async move { tracing::debug!(%peer, "Failed to send offers: {e:#}") };
+            move |e| async move { tracing::warn!(%peer, "Failed to send offers: {e:#}") };
 
         let this = ctx.address().expect("self to be alive");
         spawn_fallible(&this, task.instrument(span), err_handler);

--- a/xtra-libp2p-offer/src/taker.rs
+++ b/xtra-libp2p-offer/src/taker.rs
@@ -36,7 +36,7 @@ impl Actor {
         };
 
         let err_handler =
-            move |e| async move { tracing::debug!(%peer, "Failed to process maker offers: {e:#}") };
+            move |e| async move { tracing::warn!(%peer, "Failed to process maker offers: {e:#}") };
 
         tokio_extras::spawn_fallible(&this, task, err_handler);
     }

--- a/xtra-libp2p-ping/src/pong.rs
+++ b/xtra-libp2p-ping/src/pong.rs
@@ -18,7 +18,7 @@ impl Actor {
             &ctx.address().expect("self to be alive"),
             future,
             move |e| async move {
-                tracing::debug!(%peer, "Inbound ping protocol failed: {e}");
+                tracing::warn!(%peer, "Inbound ping protocol failed: {e}");
             },
         );
     }

--- a/xtra-libp2p-rollover/src/v_1_0_0/maker.rs
+++ b/xtra-libp2p-rollover/src/v_1_0_0/maker.rs
@@ -341,8 +341,11 @@ where
                                 revocation_sk: base_dlc_params.revocation_sk_ours(),
                             },
                         ))))
-                        .await {
-                        tracing::warn!(%order_id, "Failed to last rollover message to taker, this rollover will likely be retried by the taker: {e:#}");
+                        .await
+                    {
+                        // If the taker tries to rollover again, they will do so from a previous
+                        // commit TXID compared to the maker's.
+                        tracing::warn!(%order_id, "Failed to send revocation keys to taker: {e:#}");
                     }
 
                     let revocation_sk_theirs = msg2.revocation_sk;

--- a/xtra-libp2p-rollover/src/v_1_0_0/maker.rs
+++ b/xtra-libp2p-rollover/src/v_1_0_0/maker.rs
@@ -138,8 +138,6 @@ where
         {
             Ok(base_dlc_params) => base_dlc_params,
             Err(e) => {
-                tracing::warn!(%order_id, "Rollover failed after handling taker proposal: {e:#}");
-
                 // We have to append failed to ensure that we can rollover in the future
                 // The cfd logic might otherwise prevent us from starting a rollover if there is
                 // still one ongoing that was not properly ended.
@@ -179,7 +177,7 @@ where
             {
                 let executor = self.executor.clone();
                 let oracle = self.oracle.clone();
-                let rates =  self.rates.clone();
+                let rates = self.rates.clone();
                 let oracle_pk = self.oracle_pk;
                 let n_payouts = self.n_payouts;
                 async move {
@@ -187,10 +185,7 @@ where
                         funding_rate_long,
                         funding_rate_short,
                         tx_fee_rate,
-                    } = rates
-                        .get_rates()
-                        .await
-                        .context("Failed to get rates")?;
+                    } = rates.get_rates().await.context("Failed to get rates")?;
 
                     let (rollover_params, dlc, position, oracle_event_id, funding_rate) = executor
                         .execute(order_id, |cfd| {
@@ -203,7 +198,10 @@ where
                                 .accept_rollover_proposal_single_event(
                                     tx_fee_rate,
                                     funding_rate,
-                                    Some((base_dlc_params.settlement_event_id(), base_dlc_params.complete_fee())),
+                                    Some((
+                                        base_dlc_params.settlement_event_id(),
+                                        base_dlc_params.complete_fee(),
+                                    )),
                                     RolloverVersion::V3,
                                 )?;
 
@@ -244,7 +242,12 @@ where
                         .next()
                         .timeout(ROLLOVER_MSG_TIMEOUT, next_rollover_span)
                         .await
-                        .with_context(|| format!("Expected Msg0 within {} seconds", ROLLOVER_MSG_TIMEOUT.as_secs()))?
+                        .with_context(|| {
+                            format!(
+                                "Expected Msg0 within {} seconds",
+                                ROLLOVER_MSG_TIMEOUT.as_secs()
+                            )
+                        })?
                         .context("Empty stream instead of Msg0")?
                         .context("Unable to decode dialer Msg0")?
                         .into_rollover_msg()?
@@ -285,7 +288,12 @@ where
                         .next()
                         .timeout(ROLLOVER_MSG_TIMEOUT, next_rollover_span)
                         .await
-                        .with_context(|| format!("Expected Msg1 within {} seconds", ROLLOVER_MSG_TIMEOUT.as_secs()))?
+                        .with_context(|| {
+                            format!(
+                                "Expected Msg1 within {} seconds",
+                                ROLLOVER_MSG_TIMEOUT.as_secs()
+                            )
+                        })?
                         .context("Empty stream instead of Msg1")?
                         .context("Unable to decode dialer Msg1")?
                         .into_rollover_msg()?
@@ -315,7 +323,12 @@ where
                         .next()
                         .timeout(ROLLOVER_MSG_TIMEOUT, next_rollover_span)
                         .await
-                        .with_context(|| format!("Expected Msg2 within {} seconds", ROLLOVER_MSG_TIMEOUT.as_secs()))?
+                        .with_context(|| {
+                            format!(
+                                "Expected Msg2 within {} seconds",
+                                ROLLOVER_MSG_TIMEOUT.as_secs()
+                            )
+                        })?
                         .context("Empty stream instead of Msg2")?
                         .context("Unable to decode dialer Msg2")?
                         .into_rollover_msg()?

--- a/xtra-libp2p-rollover/src/v_1_0_0/maker.rs
+++ b/xtra-libp2p-rollover/src/v_1_0_0/maker.rs
@@ -162,7 +162,7 @@ where
                         .await
                 },
                 move |e| async move {
-                    tracing::debug!(%order_id, "Failed to send reject rollover to the taker: {e:#}")
+                    tracing::warn!(%order_id, "Failed to send reject rollover to the taker: {e:#}")
                 },
             );
             self.protocol_tasks.insert(order_id, tasks);

--- a/xtra-libp2p-rollover/src/v_1_0_0/protocol.rs
+++ b/xtra-libp2p-rollover/src/v_1_0_0/protocol.rs
@@ -293,8 +293,6 @@ pub(crate) async fn emit_failed<E>(order_id: OrderId, e: anyhow::Error, executor
 where
     E: ExecuteOnCfd,
 {
-    tracing::error!(%order_id, "Rollover failed: {e:#}");
-
     if let Err(e) = executor
         .execute(order_id, |cfd| Ok(cfd.fail_rollover(e)))
         .await

--- a/xtra-libp2p-rollover/src/v_1_0_0/taker.rs
+++ b/xtra-libp2p-rollover/src/v_1_0_0/taker.rs
@@ -107,10 +107,13 @@ where
             from_settlement_event_id,
         } = msg;
 
-        let substream = match self.open_substream(maker_peer_id).await {
+        let substream = match self
+            .open_substream(maker_peer_id)
+            .await
+            .context("Failed to start rollover")
+        {
             Ok(substream) => substream,
             Err(e) => {
-                tracing::error!(%order_id, "Failed to start rollover: {e:#}");
                 emit_failed(order_id, e, &self.executor).await;
                 return;
             }

--- a/xtra-libp2p-rollover/src/v_2_0_0/maker.rs
+++ b/xtra-libp2p-rollover/src/v_2_0_0/maker.rs
@@ -135,11 +135,10 @@ where
                 cfd.start_rollover_maker(propose.from_commit_txid)
             })
             .await
+            .context("Rollover failed after handling taker proposal")
         {
             Ok(base_dlc_params) => base_dlc_params,
             Err(e) => {
-                tracing::warn!(%order_id, "Rollover failed after handling taker proposal: {e:#}");
-
                 // We have to append failed to ensure that we can rollover in the future
                 // The cfd logic might otherwise prevent us from starting a rollover if there is
                 // still one ongoing that was not properly ended.

--- a/xtra-libp2p-rollover/src/v_2_0_0/maker.rs
+++ b/xtra-libp2p-rollover/src/v_2_0_0/maker.rs
@@ -342,8 +342,11 @@ where
                                 revocation_sk: base_dlc_params.revocation_sk_ours(),
                             },
                         ))))
-                        .await {
-                        tracing::warn!(%order_id, "Failed to last rollover message to taker, this rollover will likely be retried by the taker: {e:#}");
+                        .await
+                    {
+                        // If the taker tries to rollover again, they will do so from a previous
+                        // commit TXID compared to the maker's.
+                        tracing::warn!(%order_id, "Failed to send revocation keys to taker: {e:#}");
                     }
 
                     let revocation_sk_theirs = msg2.revocation_sk;
@@ -355,9 +358,7 @@ where
                         identity: dlc.identity,
                         identity_counterparty: dlc.identity_counterparty,
                         revocation: rev_sk,
-                        revocation_pk_counterparty: punish_params
-                            .taker
-                            .revocation_pk,
+                        revocation_pk_counterparty: punish_params.taker.revocation_pk,
                         publish: publish_sk,
                         publish_pk_counterparty: punish_params.taker.publish_pk,
                         maker_address: dlc.maker_address,

--- a/xtra-libp2p-rollover/src/v_2_0_0/protocol.rs
+++ b/xtra-libp2p-rollover/src/v_2_0_0/protocol.rs
@@ -267,8 +267,6 @@ pub(crate) async fn emit_completed<E>(
     {
         tracing::error!(%order_id, "Failed to execute rollover completed: {e:#}")
     }
-
-    tracing::info!(%order_id, "Rollover completed");
 }
 
 pub(crate) async fn emit_rejected<E>(order_id: OrderId, executor: &E)
@@ -283,16 +281,12 @@ where
     {
         tracing::error!(%order_id, "Failed to execute rollover rejected: {e:#}")
     }
-
-    tracing::info!(%order_id, "Rollover rejected");
 }
 
 pub(crate) async fn emit_failed<E>(order_id: OrderId, e: anyhow::Error, executor: &E)
 where
     E: ExecuteOnCfd,
 {
-    tracing::error!(%order_id, "Rollover failed: {e:#}");
-
     if let Err(e) = executor
         .execute(order_id, |cfd| Ok(cfd.fail_rollover(e)))
         .await

--- a/xtra-libp2p-rollover/src/v_2_0_0/taker.rs
+++ b/xtra-libp2p-rollover/src/v_2_0_0/taker.rs
@@ -107,10 +107,13 @@ where
             from_settlement_event_id,
         } = msg;
 
-        let substream = match self.open_substream(maker_peer_id).await {
+        let substream = match self
+            .open_substream(maker_peer_id)
+            .await
+            .context("Failed to start rollover")
+        {
             Ok(substream) => substream,
             Err(e) => {
-                tracing::error!(%order_id, "Failed to start rollover: {e:#}");
                 emit_failed(order_id, e, &self.executor).await;
                 return;
             }


### PR DESCRIPTION
We have several instances were we are:

- Logging the same thing more than once (objective).
- Logging at the wrong level (subjective).

I've stated several times that I believe we should be more selective with our usage of the `ERROR` level. In my mind, if I see an error log I should immediately understand that there's something to investigate. If I see a single warning I should be able to safely ignore it. And if I see many warnings of the same kind, I should start to suspect that there's a real problem.