### PR TITLE
Change password to `dev` in dev setup

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@ linker = "aarch64-linux-gnu-gcc"
 
 [alias]
 dev-maker = "run --bin maker -- --instrumentation testnet"
-dev-taker = "run --bin taker -- --instrumentation --maker localhost:9999 --maker-id 10d4ba2ac3f7a22da4009d813ff1bc3f404dfe2cc93a32bedf1512aa9951c95e --maker-peer-id 12D3KooWDjzHna3pNi1Bt1DoRfrpsBREykJKXDRDxXvhJNAdDZEk testnet" # Maker ID matches seed found in `testnet/maker_seed`
+dev-taker = "run --bin taker -- --instrumentation --maker localhost:9999 --maker-id 10d4ba2ac3f7a22da4009d813ff1bc3f404dfe2cc93a32bedf1512aa9951c95e --maker-peer-id 12D3KooWDjzHna3pNi1Bt1DoRfrpsBREykJKXDRDxXvhJNAdDZEk --password dev testnet" # Maker ID matches seed found in `testnet/maker_seed`
 
 # Inspired by https://github.com/EmbarkStudios/rust-ecosystem/pull/68.
 # tokio_unstable enabled for tokio_console and tokio_metrics only


### PR DESCRIPTION
Makes it easier to use the `start_all` script.