### PR TITLE
Replace confusing helper text

### DIFF
--- a/taker-frontend/src/components/Trade.tsx
+++ b/taker-frontend/src/components/Trade.tsx
@@ -338,7 +338,7 @@ function Quantity({ min, max, onChange, quantity, lotSize, isLong }: QuantityPro
                     </NumberInputStepper>
                 </NumberInput>
             </InputGroup>
-            <FormHelperText>How much do you want to buy or sell?</FormHelperText>
+            <FormHelperText>How many contract should your position contain?</FormHelperText>
         </FormControl>
     );
 }


### PR DESCRIPTION
We display buy/sell in the context of both long and short which is confusing.
We should generally avoid this terminology here.

--- 

Was noticed when looking at this with @holzeis 
I tried to come up with a better helper text, but am not super happy about it. If you have a better idea feel free to suggest it.