### PR TITLE
Use `rollover` function in liquidation test for rollover

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -72,6 +72,7 @@ use xtra_libp2p::multiaddress_ext::MultiaddrExt;
 pub mod flow;
 pub mod maia;
 pub mod mocks;
+pub mod rollover;
 
 #[macro_export]
 macro_rules! confirm {
@@ -620,6 +621,19 @@ impl Maker {
             .txid()
     }
 
+    pub fn latest_settlement_event_id(&mut self) -> BitMexPriceEventId {
+        self.first_cfd()
+            .aggregated()
+            .latest_dlc()
+            .as_ref()
+            .unwrap()
+            .settlement_event_id
+    }
+
+    pub fn latest_accumulated_fees(&mut self) -> SignedAmount {
+        self.first_cfd().accumulated_fees
+    }
+
     pub fn offers_feed(&mut self) -> &mut watch::Receiver<MakerOffers> {
         &mut self.feeds.offers
     }
@@ -812,8 +826,14 @@ impl Taker {
             .clone()
     }
 
-    pub fn latest_fees(&mut self) -> CompleteFee {
+    /// Exposes the `CompleteFee` as stored in the aggregate
+    pub fn latest_complete_fee(&mut self) -> CompleteFee {
         self.first_cfd().aggregated().latest_fees()
+    }
+
+    /// Exposes the accumulated fees as exposed on the projection API
+    pub fn latest_accumulated_fees(&mut self) -> SignedAmount {
+        self.first_cfd().accumulated_fees
     }
 
     pub fn offers_feed(&mut self) -> &mut watch::Receiver<MakerOffers> {

--- a/daemon-tests/src/rollover.rs
+++ b/daemon-tests/src/rollover.rs
@@ -1,0 +1,115 @@
+use crate::flow::next_with;
+use crate::flow::one_cfd_with_state;
+use crate::maia::OliviaData;
+use crate::mock_oracle_announcements;
+use crate::wait_next_state;
+use crate::Maker;
+use crate::Taker;
+use daemon::bdk::bitcoin::SignedAmount;
+use daemon::bdk::bitcoin::Txid;
+use daemon::projection::CfdState;
+use model::olivia::BitMexPriceEventId;
+use model::OrderId;
+
+pub async fn rollover(
+    maker: &mut Maker,
+    taker: &mut Taker,
+    order_id: OrderId,
+    oracle_data: OliviaData,
+) {
+    do_rollover(maker, taker, order_id, oracle_data, None).await
+}
+
+pub async fn rollover_from_commit_tx(
+    maker: &mut Maker,
+    taker: &mut Taker,
+    order_id: OrderId,
+    oracle_data: OliviaData,
+    from_params_taker: Option<(Txid, BitMexPriceEventId)>,
+) {
+    do_rollover(maker, taker, order_id, oracle_data, from_params_taker).await
+}
+
+async fn do_rollover(
+    maker: &mut Maker,
+    taker: &mut Taker,
+    order_id: OrderId,
+    oracle_data: OliviaData,
+    from_params_taker: Option<(Txid, BitMexPriceEventId)>,
+) {
+    // make sure the expected oracle data is mocked
+    mock_oracle_announcements(maker, taker, oracle_data.announcements()).await;
+
+    let commit_tx_id_before_rollover_maker = maker.latest_commit_txid();
+    let commit_tx_id_before_rollover_taker = taker.latest_commit_txid();
+
+    match from_params_taker {
+        None => {
+            taker
+                .trigger_rollover_with_latest_dlc_params(order_id)
+                .await;
+        }
+        Some((from_commit_txid, from_settlement_event_id)) => {
+            taker
+                .trigger_rollover_with_specific_params(
+                    order_id,
+                    from_commit_txid,
+                    from_settlement_event_id,
+                )
+                .await;
+        }
+    }
+
+    wait_next_state!(order_id, maker, taker, CfdState::RolloverSetup);
+    wait_next_state!(order_id, maker, taker, CfdState::Open);
+
+    assert_ne!(
+        commit_tx_id_before_rollover_maker,
+        maker.latest_commit_txid(),
+        "The commit_txid of the taker should have changed after the rollover"
+    );
+
+    assert_ne!(
+        commit_tx_id_before_rollover_taker,
+        taker.latest_commit_txid(),
+        "The commit_txid of the maker should have changed after the rollover"
+    );
+
+    assert_eq!(
+        taker.latest_commit_txid(),
+        maker.latest_commit_txid(),
+        "The maker and taker should have the same commit_txid after the rollover"
+    );
+
+    // Ensure that the event ID of the latest dlc is the event ID used for rollover
+    assert_eq!(
+        oracle_data.settlement_announcement().id,
+        maker.latest_settlement_event_id(),
+        "Taker's latest event-id does not match given event-id after rollover"
+    );
+    assert_eq!(
+        oracle_data.settlement_announcement().id,
+        taker.latest_settlement_event_id(),
+        "Taker's latest event-id does not match given event-id after rollover"
+    );
+}
+
+pub fn assert_rollover_fees(
+    maker: &mut Maker,
+    taker: &mut Taker,
+    (expected_fees_after_rollover_maker, expected_fees_after_rollover_taker): (
+        SignedAmount,
+        SignedAmount,
+    ),
+) {
+    assert_eq!(
+        expected_fees_after_rollover_maker,
+        maker.latest_accumulated_fees(),
+        "Maker's fees don't match predicted fees after rollover"
+    );
+    assert_eq!(
+        expected_fees_after_rollover_taker,
+        taker.latest_accumulated_fees(),
+        "Taker's fees don't match predicted fees after rollover"
+    );
+}

--- a/daemon-tests/tests/liquidation.rs
+++ b/daemon-tests/tests/liquidation.rs
@@ -1,6 +1,6 @@
 use daemon_tests::maia::OliviaData;
-use daemon_tests::mock_oracle_announcements;
 use daemon_tests::open_cfd;
+use daemon_tests::rollover::rollover;
 use daemon_tests::settle_non_collaboratively;
 use daemon_tests::start_both;
 use daemon_tests::OpenCfdArgs;
@@ -80,11 +80,13 @@ async fn given_rollover_when_oracle_attests_long_liquidation_price_can_liquidate
     );
 
     let oracle_data_rollover = OliviaData::example_1();
-    mock_oracle_announcements(&mut maker, &mut taker, oracle_data_rollover.announcements()).await;
-
-    taker
-        .trigger_rollover_with_latest_dlc_params(order_id)
-        .await;
+    rollover(
+        &mut maker,
+        &mut taker,
+        order_id,
+        oracle_data_rollover.clone(),
+    )
+    .await;
 
     let first_liquidation_event = taker.latest_dlc().liquidation_event_ids()[0];
     let attestation = oracle_data_rollover


### PR DESCRIPTION
Fixes https://github.com/itchysats/itchysats/issues/2606

This makes it easier to avoid problems with awaiting states (...).
I think the functionality of the test did not change.

We could additionally opt to adapt/split-up `prepare_rollover` so we can re-use it. So far I have not done so.