### PR TITLE
Remove needless sleeps in `daemon-tests`

### DIFF
--- a/daemon-tests/tests/collaborative_settlement.rs
+++ b/daemon-tests/tests/collaborative_settlement.rs
@@ -9,8 +9,6 @@ use daemon_tests::wait_next_state;
 use daemon_tests::OpenCfdArgs;
 use model::Position;
 use otel_tests::otel_test;
-use std::time::Duration;
-use tokio_extras::time::sleep;
 
 #[otel_test]
 async fn collaboratively_close_an_open_cfd_maker_going_short() {
@@ -44,8 +42,6 @@ async fn maker_rejects_collab_settlement_after_commit_finality() {
     confirm!(commit transaction, order_id, maker, taker);
 
     maker.system.reject_settlement(order_id).await.unwrap();
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
-
     wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
 }
 
@@ -71,8 +67,6 @@ async fn maker_accepts_collab_settlement_after_commit_finality() {
     confirm!(commit transaction, order_id, maker, taker);
 
     maker.system.accept_settlement(order_id).await.unwrap();
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
-
     wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
 }
 
@@ -102,12 +96,8 @@ async fn collaboratively_close_an_open_cfd(position_maker: Position) {
     );
 
     maker.system.accept_settlement(order_id).await.unwrap();
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
-
     wait_next_state!(order_id, maker, taker, CfdState::PendingClose);
+
     confirm!(close transaction, order_id, maker, taker);
-
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
-
     wait_next_state!(order_id, maker, taker, CfdState::Closed);
 }

--- a/daemon-tests/tests/connectivity.rs
+++ b/daemon-tests/tests/connectivity.rs
@@ -1,12 +1,10 @@
 use daemon::online_status::ConnectionStatus;
-use daemon_tests::flow::next;
+use daemon_tests::flow::next_with;
 use daemon_tests::Maker;
 use daemon_tests::MakerConfig;
 use daemon_tests::Taker;
 use daemon_tests::TakerConfig;
 use otel_tests::otel_test;
-use std::time::Duration;
-use tokio_extras::time::sleep;
 
 #[otel_test]
 async fn taker_notices_lack_of_maker() {
@@ -24,30 +22,27 @@ async fn taker_notices_lack_of_maker() {
     )
     .await;
 
-    sleep(Duration::from_secs(5)).await; // wait a bit until taker notices change
-
-    assert_eq!(
-        ConnectionStatus::Online,
-        next(taker.maker_status_feed()).await.unwrap()
-    );
+    wait_next_connection_status_to_maker(&mut taker, ConnectionStatus::Online).await;
 
     drop(maker);
 
-    sleep(Duration::from_secs(5)).await; // wait a bit until taker notices change
-
-    assert_eq!(
-        ConnectionStatus::Offline,
-        next(taker.maker_status_feed()).await.unwrap(),
-    );
+    wait_next_connection_status_to_maker(&mut taker, ConnectionStatus::Offline).await;
 
     let _maker = Maker::start(&maker_config).await;
 
-    sleep(Duration::from_secs(5)).await; // wait a bit until taker notices change
+    wait_next_connection_status_to_maker(&mut taker, ConnectionStatus::Online).await;
+}
 
-    assert_eq!(
-        ConnectionStatus::Online,
-        next(taker.maker_status_feed()).await.unwrap(),
-    );
+/// Wait indefinitely until the `taker`'s connection status to the maker is the one `expected` by
+/// the caller.
+async fn wait_next_connection_status_to_maker(taker: &mut Taker, expected: ConnectionStatus) {
+    let is_expected = next_with(taker.maker_status_feed(), |actual| {
+        (actual == expected).then_some(())
+    })
+    .await
+    .is_ok();
+
+    assert!(is_expected)
 }
 
 // TODO: Reinstate maker_notices_lack_of_taker by allowing to query Endpoint

--- a/daemon-tests/tests/order.rs
+++ b/daemon-tests/tests/order.rs
@@ -16,8 +16,6 @@ use model::OrderId;
 use model::Usd;
 use otel_tests::otel_test;
 use rust_decimal_macros::dec;
-use std::time::Duration;
-use tokio_extras::time::sleep;
 
 #[otel_test]
 async fn taker_places_order_and_maker_rejects() {
@@ -192,7 +190,6 @@ async fn first_contract_setup(maker: &mut Maker, taker: &mut Taker, order_id: Or
     maker.system.accept_order(order_id).await.unwrap();
     wait_next_state!(order_id, maker, taker, CfdState::ContractSetup);
 
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     wait_next_state!(order_id, maker, taker, CfdState::PendingOpen);
 
     confirm!(lock transaction, order_id, maker, taker);
@@ -214,7 +211,6 @@ async fn additional_contract_setup(maker: &mut Maker, taker: &mut Taker, order_i
     maker.system.accept_order(order_id).await.unwrap();
     wait_next_state_multi_cfd!(order_id, maker, taker, CfdState::ContractSetup);
 
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     wait_next_state_multi_cfd!(order_id, maker, taker, CfdState::PendingOpen);
 
     confirm!(lock transaction, order_id, maker, taker);

--- a/daemon-tests/tests/refund.rs
+++ b/daemon-tests/tests/refund.rs
@@ -8,8 +8,6 @@ use daemon_tests::start_both;
 use daemon_tests::wait_next_state;
 use daemon_tests::OpenCfdArgs;
 use otel_tests::otel_test;
-use std::time::Duration;
-use tokio_extras::time::sleep;
 
 #[otel_test]
 async fn open_cfd_is_refunded() {
@@ -17,14 +15,11 @@ async fn open_cfd_is_refunded() {
     let order_id = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
     confirm!(commit transaction, order_id, maker, taker);
 
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
 
     expire!(refund timelock, order_id, maker, taker);
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     wait_next_state!(order_id, maker, taker, CfdState::PendingRefund);
 
     confirm!(refund transaction, order_id, maker, taker);
-    sleep(Duration::from_secs(5)).await; // need to wait a bit until both transition
     wait_next_state!(order_id, maker, taker, CfdState::Refunded);
 }


### PR DESCRIPTION
These sleeps always precede a call to `wait_next_state`, which already waits until the CFD reaches a particular state.

---

I've always been confused by this. If I understand it correctly, `wait_next_state` will wait until the given state is reached (even if there are other states in between!), so the sleeps should be superfluous.