### PR TITLE
Configure test timeout in nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,6 @@
+[profile.default]
+slow-timeout = { period = "120s", terminate-after = 5 }
+
 [profile.ci]
 # Print out output for failing tests as soon as they fail, and also at the end
 # of the run (for easy scrollability).
@@ -6,3 +9,4 @@ failure-output = "immediate-final"
 fail-fast = false
 # Failing tests are retried up to 2 times
 retries = 2
+slow-timeout = { period = "120s", terminate-after = 5 }


### PR DESCRIPTION
Warn about slow tests after 120s and terminate tests if they run for 5 minutes.

These values apply both when run locally and on the CI.