### PR TITLE
Use structured field in fetching attestation log

### DIFF
--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -225,7 +225,7 @@ impl Actor {
                 async move {
                     let url = event_id.to_olivia_url();
 
-                    tracing::debug!("Fetching attestation for {event_id}");
+                    tracing::debug!(%event_id, "Fetching attestation");
 
                     let response = client
                         .get(url.clone())


### PR DESCRIPTION
It makes it easier to filter by the `event_id` when consuming these logs.