### PR TITLE
Temporarily increase wait time for state changes

### DIFF
--- a/daemon-tests/src/flow.rs
+++ b/daemon-tests/src/flow.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use tokio::sync::watch;
 
 /// Waiting time for the time on the watch channel before returning error
-const NEXT_WAIT_TIME: Duration = Duration::from_secs(if cfg!(debug_assertions) { 90 } else { 30 });
+const NEXT_WAIT_TIME: Duration = Duration::from_secs(if cfg!(debug_assertions) { 120 } else { 30 });
 
 pub async fn next_maker_offers(
     rx_a: &mut watch::Receiver<MakerOffers>,


### PR DESCRIPTION
Same as 2f729695cf289ecd4189e1ff808367de427e8e25, but a bit more.

---

Our tests are too slow on macos for some reason. We already had to do this in the past, so let's crank it up further.

We should consider investing time into initialising the actor tests using static CFD data where possible (by modifying the DB directly).