### PR TITLE
Prepare release 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It replaces a previous similar mechanism, which ran over a bespoke network stack.
 - Breaking change: renamed `trading_pair` to `contract_symbol` in Http API.
 
+## [0.5.3] - 2022-08-01
+
+### Changed
+
+- Update `xtra` dependency to be able to ignore frequent trace spans added in 0.5.2
+
 ## [0.5.2] - 2022-07-26
 
 ### Added
@@ -272,7 +278,8 @@ Backport <https://github.com/itchysats/itchysats/pull/924> in an attempt to fix 
 
 Initial release for mainnet.
 
-[Unreleased]: https://github.com/itchysats/itchysats/compare/0.5.2...HEAD
+[Unreleased]: https://github.com/itchysats/itchysats/compare/0.5.3...HEAD
+[0.5.3]: https://github.com/itchysats/itchysats/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/itchysats/itchysats/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/itchysats/itchysats/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/itchysats/itchysats/compare/0.4.21...0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2022-08-05
+
 ### Added
 
 - Add dynamic liquidation to the DLC, enabling the CFD to be unilaterally closed every hour by either party if the oracle attests to a price close to the ends of the payout curve's domain.
@@ -278,7 +280,8 @@ Backport <https://github.com/itchysats/itchysats/pull/924> in an attempt to fix 
 
 Initial release for mainnet.
 
-[Unreleased]: https://github.com/itchysats/itchysats/compare/0.5.3...HEAD
+[Unreleased]: https://github.com/itchysats/itchysats/compare/0.5.4...HEAD
+[0.5.4]: https://github.com/itchysats/itchysats/compare/0.5.3...0.5.4
 [0.5.3]: https://github.com/itchysats/itchysats/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/itchysats/itchysats/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/itchysats/itchysats/compare/0.5.0...0.5.1

--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -164,7 +164,8 @@ export const App = () => {
 
     let incompatible = false;
     if (makerCompatibilityOrUndefined) {
-        incompatible = makerCompatibilityOrUndefined.unsupported_protocols !== undefined
+        incompatible = makerCompatibilityOrUndefined.unsupported_protocols !== null
+            && makerCompatibilityOrUndefined.unsupported_protocols !== undefined
             && makerCompatibilityOrUndefined.unsupported_protocols.length > 0;
     }
 

--- a/taker-frontend/src/components/NavBar.tsx
+++ b/taker-frontend/src/components/NavBar.tsx
@@ -301,17 +301,20 @@ const SymbolSelector = ({ current, onChange }: SymbolSelectorProps) => {
 
     return (
         <Box w={"100%"}>
-            <Select
-                defaultValue={options[0]}
-                value={{
-                    value: current,
-                    label: current.toUpperCase(),
-                }}
-                selectedOptionColor="orange"
-                selectedOptionStyle="color"
-                options={options}
-                onChange={(item) => onChangeInner(item)}
-            />
+            {false
+                && (
+                    <Select
+                        defaultValue={options[0]}
+                        value={{
+                            value: current,
+                            label: current.toUpperCase(),
+                        }}
+                        selectedOptionColor="orange"
+                        selectedOptionStyle="color"
+                        options={options}
+                        onChange={(item) => onChangeInner(item)}
+                    />
+                )}
         </Box>
     );
 };


### PR DESCRIPTION
- first commit fixes the changelog from 0.5.3
- second commit includes a fix which is part of this PR: https://github.com/itchysats/itchysats/pull/2615/commitsSigned-off-by: Philipp Hoenisch <philipp@coblox.tech>
- third commit removes the dropdown menu