### PR TITLE
Log error if `Cfd::decrypt_cet` fails 

### DIFF
--- a/daemon/src/oracle.rs
+++ b/daemon/src/oracle.rs
@@ -319,7 +319,7 @@ impl Actor {
                 .execute(id, |cfd| cfd.decrypt_cet(&attestation.0))
                 .await
             {
-                tracing::warn!(order_id = %id, "Failed to decrypt CET using attestation: {err:#}")
+                tracing::error!(order_id = %id, "Failed to decrypt CET using attestation: {err:#}")
             }
         }
 


### PR DESCRIPTION
Fix #2634.

We were returning a triple `Result` (who wrote this? lol) from `Dlc::signed_cet`, with the outermost one being an `anyhow::Result`.

When using the `?` operator we assumed that the `PriceOutOfRange` error would be captured by the middle `Result`, but this assumption was wrong. It was being captured by the outermost one, converted into an `anyhow::Error`.

In `Cfd::decrypt_cet`, we were matching against the middle and innermost `Result`s returned by `Dlc::signed_cet` in order to filter out certain errors that can be ignored. Because the `PriceOutOfRange` error was wrongly placed in the outtermost `Result`, the filter was not working and the error was being emitted.

This is the reason why we were seeing these false positives: https://github.com/itchysats/itchysats/issues/2634.

By combining all the errors returned by `Dlc::signed_cet` we can no longer make this mistake.