### PR TITLE
Remove database cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,7 +4258,6 @@ dependencies = [
  "anyhow",
  "async-stream",
  "bdk",
- "chashmap-async",
  "futures",
  "hex",
  "libp2p-core",

--- a/sqlite-db/Cargo.toml
+++ b/sqlite-db/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 anyhow = "1"
 async-stream = "0.3"
 bdk = "0.19.0"
-chashmap-async = "0.1"
 futures = { version = "0.3", default-features = false }
 hex = "0.4"
 libp2p-core = { version = "0.33", default-features = false }


### PR DESCRIPTION
We initially had the cache because we had such a big db. Ever since we are pruning old event data this is not the case anymore. Hence, the cache should not be needed anymore.

This is an attempt at fixing #2631. But we have no way of verifying that it does unless the error never happens again.