### PR TITLE
Ignore failures to accept/reject rollovers on maker HTTP API

### DIFF
--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -172,15 +172,12 @@ pub async fn post_cfd_action(
         CfdAction::RejectRollover => maker.reject_rollover(order_id).await,
         CfdAction::Commit => maker.commit(order_id).await,
         CfdAction::Settle => {
-            let msg = "Collaborative settlement can only be triggered by taker";
-            tracing::error!(msg);
-            return Err(HttpApiProblem::new(StatusCode::BAD_REQUEST).detail(msg));
+            return Err(HttpApiProblem::new(StatusCode::BAD_REQUEST)
+                .detail("Collaborative settlement can only be triggered by taker"));
         }
     };
 
     result.map_err(|e| {
-        tracing::warn!(%order_id, %action, "Processing action failed: {e:#}");
-
         HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
             .title(action.to_string() + " failed")
             .detail(format!("{e:#}"))

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -150,27 +150,27 @@ pub async fn put_offer_params(
     Ok(())
 }
 
-#[rocket::post("/cfd/<id>/<action>")]
-#[instrument(name = "POST /cfd/<id>/<action>", skip(maker, _auth), err)]
+#[rocket::post("/cfd/<order_id>/<action>")]
+#[instrument(name = "POST /cfd/<order_id>/<action>", skip(maker, _auth), err)]
 pub async fn post_cfd_action(
-    id: Uuid,
+    order_id: Uuid,
     action: String,
     maker: &State<Maker>,
     _auth: Authenticated,
 ) -> Result<(), HttpApiProblem> {
-    let id = OrderId::from(id);
+    let order_id = OrderId::from(order_id);
     let action = action.parse().map_err(|_| {
         HttpApiProblem::new(StatusCode::BAD_REQUEST).detail(format!("Invalid action: {}", action))
     })?;
 
     let result = match action {
-        CfdAction::AcceptOrder => maker.accept_order(id).await,
-        CfdAction::RejectOrder => maker.reject_order(id).await,
-        CfdAction::AcceptSettlement => maker.accept_settlement(id).await,
-        CfdAction::RejectSettlement => maker.reject_settlement(id).await,
-        CfdAction::AcceptRollover => maker.accept_rollover(id).await,
-        CfdAction::RejectRollover => maker.reject_rollover(id).await,
-        CfdAction::Commit => maker.commit(id).await,
+        CfdAction::AcceptOrder => maker.accept_order(order_id).await,
+        CfdAction::RejectOrder => maker.reject_order(order_id).await,
+        CfdAction::AcceptSettlement => maker.accept_settlement(order_id).await,
+        CfdAction::RejectSettlement => maker.reject_settlement(order_id).await,
+        CfdAction::AcceptRollover => maker.accept_rollover(order_id).await,
+        CfdAction::RejectRollover => maker.reject_rollover(order_id).await,
+        CfdAction::Commit => maker.commit(order_id).await,
         CfdAction::Settle => {
             let msg = "Collaborative settlement can only be triggered by taker";
             tracing::error!(msg);
@@ -179,7 +179,7 @@ pub async fn post_cfd_action(
     };
 
     result.map_err(|e| {
-        tracing::warn!(order_id=%id, %action, "Processing action failed: {e:#}");
+        tracing::warn!(%order_id, %action, "Processing action failed: {e:#}");
 
         HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
             .title(action.to_string() + " failed")

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -168,8 +168,22 @@ pub async fn post_cfd_action(
         CfdAction::RejectOrder => maker.reject_order(order_id).await,
         CfdAction::AcceptSettlement => maker.accept_settlement(order_id).await,
         CfdAction::RejectSettlement => maker.reject_settlement(order_id).await,
-        CfdAction::AcceptRollover => maker.accept_rollover(order_id).await,
-        CfdAction::RejectRollover => maker.reject_rollover(order_id).await,
+        CfdAction::AcceptRollover => {
+            if let Err(e) = maker.accept_rollover(order_id).await {
+                // Only matters for legacy rollovers, which we won't investigate anyway
+                tracing::trace!("Failed to accept rollover: {e:#}")
+            };
+
+            Ok(())
+        }
+        CfdAction::RejectRollover => {
+            if let Err(e) = maker.reject_rollover(order_id).await {
+                // Only matters for legacy rollovers, which we won't investigate anyway
+                tracing::trace!("Failed to reject rollover: {e:#}")
+            };
+
+            Ok(())
+        }
         CfdAction::Commit => maker.commit(order_id).await,
         CfdAction::Settle => {
             return Err(HttpApiProblem::new(StatusCode::BAD_REQUEST)

--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -183,15 +183,15 @@ pub async fn post_order_request(
     Ok(())
 }
 
-#[rocket::post("/cfd/<id>/<action>")]
-#[instrument(name = "POST /cfd/<id>/<action>", skip(taker, _auth), err)]
+#[rocket::post("/cfd/<order_id>/<action>")]
+#[instrument(name = "POST /cfd/<order_id>/<action>", skip(taker, _auth), err)]
 pub async fn post_cfd_action(
-    id: Uuid,
+    order_id: Uuid,
     action: String,
     taker: &State<Taker>,
     _auth: Authenticated,
 ) -> Result<(), HttpApiProblem> {
-    let id = OrderId::from(id);
+    let order_id = OrderId::from(order_id);
     let action = action.parse().map_err(|_| {
         HttpApiProblem::new(StatusCode::BAD_REQUEST).detail(format!("Invalid action: {}", action))
     })?;
@@ -206,8 +206,8 @@ pub async fn post_cfd_action(
             return Err(HttpApiProblem::new(StatusCode::BAD_REQUEST)
                 .detail(format!("taker cannot invoke action {action}")));
         }
-        CfdAction::Commit => taker.commit(id).await,
-        CfdAction::Settle => taker.propose_settlement(id).await,
+        CfdAction::Commit => taker.commit(order_id).await,
+        CfdAction::Settle => taker.propose_settlement(order_id).await,
     };
 
     result.map_err(|e| {


### PR DESCRIPTION
These are only relevant for the legacy rollover protocol, which is no longer being developed.

But we still emit them for the new rollover protocol, because the `projection::Actor` creates `RolloverAccept` and `RolloverReject`
actions for CFDs that are _not_ legacy too.

Therefore downgrading them to trace and not returning a HTTP API Problem should do the job until we actually remove the legacy rollover protocol in a future release.