### PR TITLE
Roll back if `rollover::overwrite` fails when appending events to the DB

### DIFF
--- a/sqlite-db/src/lib.rs
+++ b/sqlite-db/src/lib.rs
@@ -7,7 +7,6 @@ use chashmap_async::CHashMap;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use futures::Stream;
-use futures::StreamExt;
 use model::libp2p::PeerId;
 use model::CfdEvent;
 use model::ContractSymbol;
@@ -25,10 +24,9 @@ use model::TxFeeRate;
 use model::Usd;
 use sqlx::migrate::MigrateError;
 use sqlx::sqlite::SqliteConnectOptions;
-use sqlx::Connection as _;
-use sqlx::Sqlite;
+use sqlx::Acquire;
+use sqlx::SqliteConnection;
 use sqlx::SqlitePool;
-use sqlx::Transaction;
 use std::any::Any;
 use std::any::TypeId;
 use std::path::PathBuf;
@@ -335,7 +333,10 @@ impl Connection {
         Ok(cfd)
     }
 
-    pub fn load_all_cfds<C>(&self, args: C::CtorArgs) -> impl Stream<Item = Result<C>> + Unpin + '_
+    pub fn load_all_cfds<'a, C>(
+        &'a self,
+        args: C::CtorArgs,
+    ) -> impl Stream<Item = Result<C>> + Unpin + '_
     where
         C: CfdAggregate + ClosedCfdAggregate + FailedCfdAggregate,
         C::CtorArgs: Clone + Send + Sync,
@@ -371,7 +372,7 @@ impl Connection {
             }
         };
 
-        stream.boxed()
+        Box::pin(stream)
     }
 
     /// Loads all CFDs where we are still able to append events
@@ -384,8 +385,8 @@ impl Connection {
     ///     Cases: Collaborative settlement, CET, Refund
     /// 2. Event that fails the CFD early was recorded, meaning it becomes irrelevant for processing
     ///     Cases: Setup failed, Taker's take order rejected
-    pub fn load_all_open_cfds<C>(
-        &self,
+    pub fn load_all_open_cfds<'a, C>(
+        &'a self,
         args: C::CtorArgs,
     ) -> impl Stream<Item = Result<C>> + Unpin + '_
     where
@@ -412,7 +413,7 @@ impl Connection {
             }
         };
 
-        stream.boxed()
+        Box::pin(stream)
     }
 
     /// Load the IDs for all the CFDs found in the `cfds` table.
@@ -559,7 +560,7 @@ pub trait CfdAggregate: Clone + Send + Sync + 'static {
     fn version(&self) -> u32;
 }
 
-async fn load_cfd_row(conn: &mut Transaction<'_, Sqlite>, id: OrderId) -> Result<Cfd, Error> {
+async fn load_cfd_row(conn: &mut SqliteConnection, id: OrderId) -> Result<Cfd, Error> {
     let id = models::OrderId::from(id);
 
     let cfd_row = sqlx::query!(
@@ -653,7 +654,7 @@ fn derive_known_peer_id(legacy_network_identity: Identity, role: Role) -> Option
 ///
 /// Events will be sorted in chronological order.
 async fn load_cfd_events(
-    conn: &mut Transaction<'_, Sqlite>,
+    conn: &mut SqliteConnection,
     id: OrderId,
     from_version: u32,
 ) -> Result<Vec<CfdEvent>> {
@@ -700,7 +701,7 @@ async fn load_cfd_events(
     for (cfd_row_id, event_row_id, event) in events.iter_mut() {
         if let RolloverCompleted { .. } = event.event {
             if let Some((dlc, funding_fee, complete_fee)) =
-                rollover::load(conn, *cfd_row_id, *event_row_id).await?
+                rollover::load(&mut *conn, *cfd_row_id, *event_row_id).await?
             {
                 event.event = RolloverCompleted {
                     dlc: Some(dlc),
@@ -719,7 +720,7 @@ async fn load_cfd_events(
     Ok(events)
 }
 
-async fn delete_from_cfds_table(conn: &mut Transaction<'_, Sqlite>, id: OrderId) -> Result<()> {
+async fn delete_from_cfds_table(conn: &mut SqliteConnection, id: OrderId) -> Result<()> {
     let id = models::OrderId::from(id);
     let query_result = sqlx::query!(
         r#"
@@ -740,7 +741,7 @@ async fn delete_from_cfds_table(conn: &mut Transaction<'_, Sqlite>, id: OrderId)
     Ok(())
 }
 
-async fn delete_from_events_table(conn: &mut Transaction<'_, Sqlite>, id: OrderId) -> Result<()> {
+async fn delete_from_events_table(conn: &mut SqliteConnection, id: OrderId) -> Result<()> {
     let id = models::OrderId::from(id);
 
     let query_result = sqlx::query!(
@@ -781,11 +782,10 @@ mod tests {
     #[tokio::test]
     async fn test_insert_and_load_cfd() {
         let db = memory().await.unwrap();
+        let mut conn = db.inner.acquire().await.unwrap();
 
         let cfd = dummy_cfd();
         db.insert_cfd(&cfd).await.unwrap();
-        let mut conn = db.inner.acquire().await.unwrap();
-        let mut db_tx = conn.begin().await.unwrap();
 
         let super::Cfd {
             id,
@@ -802,9 +802,7 @@ mod tests {
             initial_funding_rate,
             initial_tx_fee_rate,
             contract_symbol,
-        } = load_cfd_row(&mut db_tx, cfd.id()).await.unwrap();
-
-        db_tx.commit().await.unwrap();
+        } = load_cfd_row(&mut *conn, cfd.id()).await.unwrap();
 
         assert_eq!(cfd.id(), id);
         assert_eq!(cfd.offer_id(), offer_id);
@@ -828,6 +826,7 @@ mod tests {
     #[tokio::test]
     async fn test_append_events() {
         let db = memory().await.unwrap();
+        let mut conn = db.inner.acquire().await.unwrap();
 
         let cfd = dummy_cfd();
         db.insert_cfd(&cfd).await.unwrap();
@@ -842,11 +841,7 @@ mod tests {
 
         db.append_event(event1.clone()).await.unwrap();
 
-        let mut conn = db.inner.acquire().await.unwrap();
-
-        let mut db_tx = conn.begin().await.unwrap();
-        let events = load_cfd_events(&mut db_tx, cfd.id(), 0).await.unwrap();
-        db_tx.commit().await.unwrap();
+        let events = load_cfd_events(&mut *conn, cfd.id(), 0).await.unwrap();
         assert_eq!(events, vec![event1.clone()]);
 
         let event2 = CfdEvent {
@@ -857,28 +852,22 @@ mod tests {
 
         db.append_event(event2.clone()).await.unwrap();
 
-        // let mut conn = db.inner.acquire().await.unwrap();
-        let mut db_tx = conn.begin().await.unwrap();
-        let events = load_cfd_events(&mut db_tx, cfd.id(), 0).await.unwrap();
-        db_tx.commit().await.unwrap();
+        let events = load_cfd_events(&mut *conn, cfd.id(), 0).await.unwrap();
         assert_eq!(events, vec![event1, event2])
     }
 
     #[tokio::test]
     async fn given_insert_cfd_with_peer_id_then_peer_id_loaded() {
         let db = memory().await.unwrap();
+        let mut conn = db.inner.acquire().await.unwrap();
 
         let cfd = dummy_taker_with_counterparty_peer_id();
         db.insert_cfd(&cfd).await.unwrap();
-        let mut conn = db.inner.acquire().await.unwrap();
-        let mut db_tx = conn.begin().await.unwrap();
 
         let super::Cfd {
             counterparty_peer_id,
             ..
-        } = load_cfd_row(&mut db_tx, cfd.id()).await.unwrap();
-
-        db_tx.commit().await.unwrap();
+        } = load_cfd_row(&mut *conn, cfd.id()).await.unwrap();
 
         assert_eq!(cfd.counterparty_peer_id(), counterparty_peer_id);
     }
@@ -886,20 +875,17 @@ mod tests {
     #[tokio::test]
     async fn given_insert_cfd_without_peer_id_when_known_mainnet_maker_then_peer_id_loaded() {
         let db = memory().await.unwrap();
+        let mut conn = db.inner.acquire().await.unwrap();
 
         let cfd = dummy_taker_with_legacy_identity(
             "7e35e34801e766a6a29ecb9e22810ea4e3476c2b37bf75882edf94a68b1d9607",
         );
         db.insert_cfd(&cfd).await.unwrap();
-        let mut conn = db.inner.acquire().await.unwrap();
-        let mut db_tx = conn.begin().await.unwrap();
 
         let super::Cfd {
             counterparty_peer_id,
             ..
-        } = load_cfd_row(&mut db_tx, cfd.id()).await.unwrap();
-
-        db_tx.commit().await.unwrap();
+        } = load_cfd_row(&mut *conn, cfd.id()).await.unwrap();
 
         assert_eq!(
             "12D3KooWP3BN6bq9jPy8cP7Grj1QyUBfr7U6BeQFgMwfTTu12wuY",
@@ -910,20 +896,17 @@ mod tests {
     #[tokio::test]
     async fn given_insert_cfd_without_peer_id_when_known_testnet_maker_then_peer_id_loaded() {
         let db = memory().await.unwrap();
+        let mut conn = db.inner.acquire().await.unwrap();
 
         let cfd = dummy_taker_with_legacy_identity(
             "69a42aa90da8b065b9532b62bff940a3ba07dbbb11d4482c7db83a7e049a9f1e",
         );
         db.insert_cfd(&cfd).await.unwrap();
-        let mut conn = db.inner.acquire().await.unwrap();
-        let mut db_tx = conn.begin().await.unwrap();
 
         let super::Cfd {
             counterparty_peer_id,
             ..
-        } = load_cfd_row(&mut db_tx, cfd.id()).await.unwrap();
-
-        db_tx.commit().await.unwrap();
+        } = load_cfd_row(&mut *conn, cfd.id()).await.unwrap();
 
         assert_eq!(
             "12D3KooWEsK2X8Tp24XtyWh7DM65VfwXtNH2cmfs2JsWmkmwKbV1",
@@ -934,18 +917,15 @@ mod tests {
     #[tokio::test]
     async fn given_insert_cfd_without_peer_id_when_unknown_maker_then_no_peer_id_loaded() {
         let db = memory().await.unwrap();
+        let mut conn = db.inner.acquire().await.unwrap();
 
         let cfd = dummy_cfd();
         db.insert_cfd(&cfd).await.unwrap();
-        let mut conn = db.inner.acquire().await.unwrap();
-        let mut db_tx = conn.begin().await.unwrap();
 
         let super::Cfd {
             counterparty_peer_id,
             ..
-        } = load_cfd_row(&mut db_tx, cfd.id()).await.unwrap();
-
-        db_tx.commit().await.unwrap();
+        } = load_cfd_row(&mut *conn, cfd.id()).await.unwrap();
 
         assert_eq!(None, counterparty_peer_id);
     }

--- a/sqlite-db/src/lib.rs
+++ b/sqlite-db/src/lib.rs
@@ -224,6 +224,7 @@ impl Connection {
     /// implements `Into<Option>` event.
     pub async fn append_event(&self, event: impl Into<Option<CfdEvent>>) -> Result<()> {
         let mut conn = self.inner.acquire().await?;
+        let mut db_tx = conn.begin().await?;
 
         let event = match event.into() {
             Some(event) => event,
@@ -250,7 +251,7 @@ impl Connection {
         .bind(&event_name)
         .bind(&event_data)
         .bind(&timestamp)
-        .execute(&mut conn)
+        .execute(&mut db_tx)
         .await?;
 
         if query_result.rows_affected() != 1 {
@@ -265,7 +266,7 @@ impl Connection {
                 complete_fee,
             } => {
                 rollover::overwrite(
-                    &mut conn,
+                    &mut db_tx,
                     query_result.last_insert_rowid(),
                     order_id,
                     dlc,
@@ -281,6 +282,8 @@ impl Connection {
             }
             _ => {}
         }
+
+        db_tx.commit().await?;
 
         tracing::info!(event = %event_name, %order_id, "Appended event to database");
 

--- a/sqlite-db/src/time_to_first_position.rs
+++ b/sqlite-db/src/time_to_first_position.rs
@@ -74,11 +74,10 @@ impl Connection {
 #[allow(dead_code)]
 mod sqlx_test_utils {
     use super::*;
-    use sqlx::pool::PoolConnection;
-    use sqlx::Sqlite;
+    use sqlx::SqliteConnection;
 
     pub(crate) async fn load_first_seen_timestamp(
-        conn: &mut PoolConnection<Sqlite>,
+        conn: &mut SqliteConnection,
         taker_id: Identity,
     ) -> Result<Option<OffsetDateTime>> {
         let taker_id = models::Identity::from(taker_id);
@@ -109,7 +108,7 @@ mod sqlx_test_utils {
     }
 
     pub(crate) async fn load_first_position_timestamp(
-        conn: &mut PoolConnection<Sqlite>,
+        conn: &mut SqliteConnection,
         taker_id: Identity,
     ) -> Result<Option<OffsetDateTime>> {
         let taker_id = models::Identity::from(taker_id);
@@ -151,6 +150,7 @@ mod tests {
     async fn given_inserted_first_seen_when_trying_to_insert_second_seen_then_timestamp_does_not_change(
     ) {
         let db = memory().await.unwrap();
+        let mut conn = db.inner.acquire().await.unwrap();
 
         let taker_id = dummy_identity();
 
@@ -159,8 +159,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut conn = db.inner.acquire().await.unwrap();
-        let first_loaded_timestamp = load_first_seen_timestamp(&mut conn, taker_id)
+        let first_loaded_timestamp = load_first_seen_timestamp(&mut *conn, taker_id)
             .await
             .unwrap();
 
@@ -169,7 +168,7 @@ mod tests {
             .await
             .unwrap();
 
-        let second_loaded_timestamp = load_first_seen_timestamp(&mut conn, taker_id)
+        let second_loaded_timestamp = load_first_seen_timestamp(&mut *conn, taker_id)
             .await
             .unwrap();
 
@@ -183,6 +182,7 @@ mod tests {
     async fn given_inserted_first_position_when_trying_to_insert_second_position_then_timestamp_does_not_change(
     ) {
         let db = memory().await.unwrap();
+        let mut conn = db.inner.acquire().await.unwrap();
 
         let taker_id = dummy_identity();
 
@@ -195,8 +195,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut conn = db.inner.acquire().await.unwrap();
-        let first_loaded_timestamp = load_first_position_timestamp(&mut conn, taker_id)
+        let first_loaded_timestamp = load_first_position_timestamp(&mut *conn, taker_id)
             .await
             .unwrap();
 
@@ -205,7 +204,7 @@ mod tests {
             .await
             .unwrap();
 
-        let second_loaded_timestamp = load_first_position_timestamp(&mut conn, taker_id)
+        let second_loaded_timestamp = load_first_position_timestamp(&mut *conn, taker_id)
             .await
             .unwrap();
 


### PR DESCRIPTION
Previously we were allowing the following scenario:

- `RolloverCompleted` event is appended to the `events` table.
- `RolloverCompleted` event data fails to be appended to `rollover_completed_event_data` for whatever reason.

That scenario would leave us in a situation where the state between the two tables would be inconsistent.

To fix it, we ensure that the rollback logic doesn't just cover `rollover::overwrite::overwrite`, but rather the entirety of `append_event`.

Fixes https://github.com/itchysats/itchysats/issues/2662.