### PR TITLE
Remove contract symbol from feed api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Introduce path param to SSE event route for both maker and taker. The new route is `/<contract_symbol>/feed`.
 - Dropped support for all legacy network protocols.
 
 ## [0.5.4] - 2022-08-05

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -21,8 +21,7 @@ use daemon::projection;
 use daemon::projection::Cfd;
 use daemon::projection::CfdState;
 use daemon::projection::Feeds;
-use daemon::projection::OffersFeed;
-use daemon::projection::QuoteFeed;
+use daemon::projection::MakerOffers;
 use daemon::seed::RandomSeed;
 use daemon::seed::Seed;
 use daemon::Environment;
@@ -289,9 +288,7 @@ pub async fn open_cfd(taker: &mut Taker, maker: &mut Maker, args: OpenCfdArgs) -
         ..
     } = args;
 
-    is_next_offers_none(taker.offers_feed(), &ContractSymbol::BtcUsd)
-        .await
-        .unwrap();
+    is_next_offers_none(taker.offers_feed()).await.unwrap();
 
     tracing::debug!("Sending {offer_params:?}");
     maker.set_offer_params(offer_params).await;
@@ -622,7 +619,7 @@ impl Maker {
         self.first_cfd().accumulated_fees
     }
 
-    pub fn offers_feed(&mut self) -> &mut OffersFeed {
+    pub fn offers_feed(&mut self) -> &mut watch::Receiver<MakerOffers> {
         &mut self.feeds.offers
     }
 
@@ -819,11 +816,11 @@ impl Taker {
         self.first_cfd().accumulated_fees
     }
 
-    pub fn offers_feed(&mut self) -> &mut OffersFeed {
+    pub fn offers_feed(&mut self) -> &mut watch::Receiver<MakerOffers> {
         &mut self.feeds.offers
     }
 
-    pub fn quote_feed(&mut self) -> &mut QuoteFeed {
+    pub fn quote_feed(&mut self) -> &mut watch::Receiver<Option<projection::Quote>> {
         &mut self.feeds.quote
     }
 

--- a/daemon-tests/tests/main/collaborative_settlement.rs
+++ b/daemon-tests/tests/main/collaborative_settlement.rs
@@ -27,7 +27,7 @@ async fn maker_rejects_collab_settlement_after_commit_finality() {
 
     taker.mocks.mock_latest_quote(Some(dummy_quote())).await;
     maker.mocks.mock_latest_quote(Some(dummy_quote())).await;
-    let mut quote_receiver = taker.quote_feed().btc_usd.clone();
+    let mut quote_receiver = taker.quote_feed().clone();
     next_with(&mut quote_receiver, |q| q).await.unwrap(); // if quote is available on feed, it propagated through the system
 
     taker.system.propose_settlement(order_id).await.unwrap();
@@ -53,7 +53,7 @@ async fn maker_accepts_collab_settlement_after_commit_finality() {
 
     taker.mocks.mock_latest_quote(Some(dummy_quote())).await;
     maker.mocks.mock_latest_quote(Some(dummy_quote())).await;
-    let mut quote_receiver = taker.quote_feed().btc_usd.clone();
+    let mut quote_receiver = taker.quote_feed().clone();
     next_with(&mut quote_receiver, |q| q).await.unwrap(); // if quote is available on feed, it propagated through the system
 
     taker.system.propose_settlement(order_id).await.unwrap();
@@ -85,7 +85,7 @@ async fn collaboratively_close_an_open_cfd(position_maker: Position) {
     .await;
     taker.mocks.mock_latest_quote(Some(dummy_quote())).await;
     maker.mocks.mock_latest_quote(Some(dummy_quote())).await;
-    let mut quote_receiver = taker.quote_feed().btc_usd.clone();
+    let mut quote_receiver = taker.quote_feed().clone();
     next_with(&mut quote_receiver, |q| q).await.unwrap(); // if quote is available on feed, it propagated through the system
 
     taker.system.propose_settlement(order_id).await.unwrap();

--- a/daemon-tests/tests/main/offer.rs
+++ b/daemon-tests/tests/main/offer.rs
@@ -13,12 +13,7 @@ use otel_tests::otel_test;
 async fn taker_receives_offer_from_maker_on_publication() {
     let (mut maker, mut taker) = start_both().await;
 
-    assert!(
-        is_next_offers_none(taker.offers_feed(), &ContractSymbol::BtcUsd)
-            .await
-            .unwrap()
-    );
-
+    assert!(is_next_offers_none(taker.offers_feed()).await.unwrap());
     maker
         .set_offer_params(OfferParamsBuilder::new().build())
         .await;

--- a/daemon-tests/tests/main/order.rs
+++ b/daemon-tests/tests/main/order.rs
@@ -22,9 +22,7 @@ use rust_decimal_macros::dec;
 async fn taker_places_order_and_maker_rejects() {
     let (mut maker, mut taker) = start_both().await;
 
-    is_next_offers_none(taker.offers_feed(), &ContractSymbol::BtcUsd)
-        .await
-        .unwrap();
+    is_next_offers_none(taker.offers_feed()).await.unwrap();
 
     maker
         .set_offer_params(OfferParamsBuilder::new().build())
@@ -59,9 +57,7 @@ async fn taker_places_order_and_maker_rejects() {
 async fn taker_places_order_and_maker_accepts_and_contract_setup() {
     let (mut maker, mut taker) = start_both().await;
 
-    is_next_offers_none(taker.offers_feed(), &ContractSymbol::BtcUsd)
-        .await
-        .unwrap();
+    is_next_offers_none(taker.offers_feed()).await.unwrap();
 
     maker
         .set_offer_params(OfferParamsBuilder::new().build())
@@ -93,9 +89,7 @@ async fn taker_places_order_and_maker_accepts_and_contract_setup() {
 async fn taker_places_order_for_same_offer_twice_results_in_two_cfds() {
     let (mut maker, mut taker) = start_both().await;
 
-    is_next_offers_none(taker.offers_feed(), &ContractSymbol::BtcUsd)
-        .await
-        .unwrap();
+    is_next_offers_none(taker.offers_feed()).await.unwrap();
 
     maker
         .set_offer_params(OfferParamsBuilder::new().build())

--- a/daemon/src/taker_cfd.rs
+++ b/daemon/src/taker_cfd.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use model::libp2p::PeerId;
 use model::market_closing_price;
 use model::Cfd;
-use model::ContractSymbol;
 use model::Identity;
 use model::Leverage;
 use model::MakerOffers;
@@ -93,19 +92,11 @@ impl Actor {
         self.current_maker_offers = takers_perspective_of_maker_offers.clone();
         tracing::trace!("new maker offers {:?}", takers_perspective_of_maker_offers);
 
-        // If there's no offer, it might as well be hard-coded to BTC
-        let symbol = self
-            .current_maker_offers
-            .clone()
-            .and_then(|offer| offer.long.map(|offer| offer.contract_symbol))
-            .unwrap_or(ContractSymbol::BtcUsd);
-
         if let Err(e) = self
             .projection_actor
-            .send(projection::Update((
-                symbol,
+            .send(projection::Update(
                 takers_perspective_of_maker_offers.clone(),
-            )))
+            ))
             .await
         {
             tracing::warn!("Failed to send current offers to projection actor: {e:#}");

--- a/maker-frontend/src/MakerApp.tsx
+++ b/maker-frontend/src/MakerApp.tsx
@@ -63,14 +63,24 @@ export default function App() {
     const [symbol, setSymbol] = useState("btcusd");
     let symbolDefaults = Defaults[symbol];
 
-    let source = useEventSource({ source: `/api/${symbol}/feed`, options: { withCredentials: true } });
+    let source = useEventSource({ source: `/api/feed`, options: { withCredentials: true } });
 
     let [leverages, setLeverages] = useState(["1", "2", "3"]);
 
     const cfdsOrUndefined = useLatestEvent<Cfd[]>(source, "cfds", intoCfd);
     let cfds = cfdsOrUndefined ? cfdsOrUndefined! : [];
-    const makerLongOrder = useLatestEvent<MakerOffer>(source, "long_offer");
-    const makerShortOrder = useLatestEvent<MakerOffer>(source, "short_offer");
+    const makerLongOrder = useLatestEvent<MakerOffer>(
+        source,
+        "long_offer",
+        undefined,
+        (data: any) => data && data.contract_symbol.toLowerCase() === symbol,
+    );
+    const makerShortOrder = useLatestEvent<MakerOffer>(
+        source,
+        "short_offer",
+        undefined,
+        (data: any) => data && data.contract_symbol.toLowerCase() === symbol,
+    );
     const walletInfo = useLatestEvent<WalletInfo>(source, "wallet");
     const priceInfo = useLatestEvent<PriceInfo>(source, "quote");
 

--- a/maker-frontend/src/components/Hooks.tsx
+++ b/maker-frontend/src/components/Hooks.tsx
@@ -5,6 +5,7 @@ export default function useLatestEvent<T,>(
     source: EventSource,
     event_name: string,
     mapping: (key: string, value: any) => any = (key, value) => value,
+    filter?: (event: Event) => boolean,
 ): T | null {
     const [state, setState] = useState<T | null>(null);
 
@@ -16,7 +17,11 @@ export default function useLatestEvent<T,>(
                 name: event_name,
                 listener: ({ event }) => {
                     // @ts-ignore - yes, there is a data field on event
-                    setState(JSON.parse(event.data, mapping));
+                    const data = JSON.parse(event.data, mapping);
+                    if (filter !== undefined && !filter(data)) {
+                        return;
+                    }
+                    setState(data);
                 },
             },
         },

--- a/maker/src/cfd.rs
+++ b/maker/src/cfd.rs
@@ -240,10 +240,7 @@ impl Actor {
 
         // 2. Notify UI via feed
         self.projection
-            .send(projection::Update((
-                msg.contract_symbol,
-                Some(maker_offers.clone()),
-            )))
+            .send(projection::Update(Some(maker_offers.clone())))
             .await?;
 
         if let Err(e) = self

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -42,10 +42,9 @@ use uuid::Uuid;
 pub type Maker = ActorSystem<oracle::Actor, wallet::Actor<ElectrumBlockchain, sled::Tree>>;
 
 #[allow(clippy::too_many_arguments)]
-#[rocket::get("/<symbol>/feed")]
-#[instrument(name = "GET /<symbol>/feed", skip_all)]
+#[rocket::get("/feed")]
+#[instrument(name = "GET /feed", skip_all)]
 pub async fn maker_feed(
-    symbol: ContractSymbol,
     rx: &State<Feeds>,
     rx_wallet: &State<watch::Receiver<Option<WalletInfo>>>,
     _auth: Authenticated,
@@ -53,10 +52,8 @@ pub async fn maker_feed(
     let rx = rx.inner();
     let mut rx_cfds = rx.cfds.clone();
     let mut rx_wallet = rx_wallet.inner().clone();
-    let (mut rx_offers, mut rx_quote) = match symbol {
-        ContractSymbol::BtcUsd => (rx.offers.btc_usd.clone(), rx.quote.btc_usd.clone()),
-        ContractSymbol::EthUsd => (rx.offers.eth_usd.clone(), rx.quote.eth_usd.clone()),
-    };
+    let mut rx_offers = rx.offers.clone();
+    let mut rx_quote = rx.quote.clone();
 
     EventStream! {
         let wallet_info = rx_wallet.borrow().clone();

--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -119,11 +119,21 @@ export const App = () => {
         void fetchDaemonVersion(setDaemonVersion);
     }, []);
 
-    const [source, isConnected] = useEventSource(`/api/${symbol}/feed`);
+    const [source, isConnected] = useEventSource(`/api/feed`);
     const walletInfo = useLatestEvent<WalletInfo>(source, "wallet");
 
-    const makerLong = useLatestEvent<MakerOffer>(source, daemon_long_offer, intoMakerOffer);
-    const makerShort = useLatestEvent<MakerOffer>(source, daemon_short_offer, intoMakerOffer);
+    const makerLong = useLatestEvent<MakerOffer>(
+        source,
+        daemon_long_offer,
+        intoMakerOffer,
+        (data: any) => data && data.contract_symbol.toLowerCase() === symbol,
+    );
+    const makerShort = useLatestEvent<MakerOffer>(
+        source,
+        daemon_short_offer,
+        intoMakerOffer,
+        (data: any) => data && data.contract_symbol.toLowerCase() === symbol,
+    );
 
     const identityOrUndefined = useLatestEvent<IdentityInfo>(source, "identity");
 

--- a/taker-frontend/src/useLatestEvent.ts
+++ b/taker-frontend/src/useLatestEvent.ts
@@ -4,20 +4,25 @@ export default function useLatestEvent<T>(
     source: EventSource | null,
     eventName: string,
     mapping: (key: string, value: any) => any = (_, value) => value,
+    filter?: (data: any) => boolean,
 ): T | null {
     const [state, setState] = useState<T | null>(null);
 
     useEffect(() => {
         if (source) {
             const listener = (event: Event) => {
-                setState(JSON.parse((event as EventSourceEvent).data, mapping));
+                const data = JSON.parse((event as EventSourceEvent).data, mapping);
+                if (filter !== undefined && !filter(data)) {
+                    return;
+                }
+                setState(data);
             };
 
             source.addEventListener(eventName, listener);
             return () => source.removeEventListener(eventName, listener);
         }
         return undefined;
-    }, [source, eventName, mapping]);
+    }, [source, eventName, mapping, filter]);
 
     return state;
 }

--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -22,7 +22,6 @@ use model::Usd;
 use model::WalletInfo;
 use rocket::http::ContentType;
 use rocket::http::Status;
-use rocket::request::FromParam;
 use rocket::response::stream::Event;
 use rocket::response::stream::EventStream;
 use rocket::response::Responder;
@@ -57,37 +56,9 @@ pub struct IdentityInfo {
     pub(crate) taker_peer_id: String,
 }
 
-#[derive(Debug, Copy, Clone, strum_macros::Display)]
-pub enum ContractSymbol {
-    BtcUsd,
-    EthUsd,
-}
-
-impl From<ContractSymbol> for model::ContractSymbol {
-    fn from(symbol: ContractSymbol) -> Self {
-        match symbol {
-            ContractSymbol::BtcUsd => model::ContractSymbol::BtcUsd,
-            ContractSymbol::EthUsd => model::ContractSymbol::EthUsd,
-        }
-    }
-}
-
-impl<'r> FromParam<'r> for ContractSymbol {
-    type Error = anyhow::Error;
-
-    fn from_param(param: &'r str) -> Result<Self, Self::Error> {
-        match param.to_lowercase().as_str() {
-            "btcusd" => Ok(ContractSymbol::BtcUsd),
-            "ethusd" => Ok(ContractSymbol::EthUsd),
-            _ => anyhow::bail!("Unknown contract symbol provided: {param}"),
-        }
-    }
-}
-
-#[rocket::get("/<symbol>/feed")]
-#[instrument(name = "GET /<symbol>/feed", skip_all)]
+#[rocket::get("/feed")]
+#[instrument(name = "GET /feed", skip_all)]
 pub async fn feed(
-    symbol: ContractSymbol,
     rx: &State<Feeds>,
     rx_wallet: &State<watch::Receiver<Option<WalletInfo>>>,
     rx_maker_status: &State<watch::Receiver<ConnectionStatus>>,
@@ -97,10 +68,8 @@ pub async fn feed(
 ) -> EventStream![] {
     let rx = rx.inner();
     let mut rx_cfds = rx.cfds.clone();
-    let (mut rx_offers, mut rx_quote) = match symbol {
-        ContractSymbol::BtcUsd => (rx.offers.btc_usd.clone(), rx.quote.btc_usd.clone()),
-        ContractSymbol::EthUsd => (rx.offers.eth_usd.clone(), rx.quote.eth_usd.clone()),
-    };
+    let mut rx_offers = rx.offers.clone();
+    let mut rx_quote = rx.quote.clone();
 
     let mut rx_wallet = rx_wallet.inner().clone();
     let mut rx_maker_status = rx_maker_status.inner().clone();


### PR DESCRIPTION
Proposes to remove the symbol from the feed api - allowing the consumer to filter for the events interested on the client side. This reduces a lot of complexity in the implementation as well as in the consumption of the API. 

This PR does not yet include the event filtering through a query parameter yet, but should be added in following PRs if we decide to go with that approach.

- [x] Upon connecting to the feed api the latest sent events will be resent, resulting into an issue that either btcusd or ethusd will be sent as the last sent could be either. This results into a delay for btcusd or ethusd to get the latest quote, offer.

Resolves #2673