### PR TITLE
Log connection getting dropped without `ConnectionDropped` event

### DIFF
--- a/xtra-libp2p/src/endpoint.rs
+++ b/xtra-libp2p/src/endpoint.rs
@@ -354,7 +354,10 @@ impl Endpoint {
             },
         );
 
-        self.controls.insert(peer_id, (control, tasks));
+        if self.controls.insert(peer_id, (control, tasks)).is_some() {
+            tracing::warn!(%peer_id, "Missed drop event, replacing old connection")
+        }
+
         self.notify_connection_established(peer_id).await;
     }
 


### PR DESCRIPTION
This is not a problem, but it indicates that the system is unaware of a broken connection.
If this happens a lot it can lead to issues.