### PR TITLE
Remove unused error struct

### DIFF
--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -95,10 +95,6 @@ pub struct Actor<B, DB> {
     sender: watch::Sender<Option<WalletInfo>>,
 }
 
-#[derive(thiserror::Error, Debug, Clone, Copy)]
-#[error("The transaction is already in the blockchain")]
-pub struct TransactionAlreadyInBlockchain;
-
 impl Actor<ElectrumBlockchain, sled::Tree> {
     pub fn spawn(
         electrum_rpc_url: &str,


### PR DESCRIPTION
This isn't used anywhere in the workspace, so it should be safe to remove. It was not found by a lint as it is a public type in a library crate.