### PR TITLE
Extend actor tests to test `ethusd`

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -515,6 +515,13 @@ impl FeeCalculator {
 
         (maker_fee_account.balance(), taker_fee_account.balance())
     }
+
+    pub fn complete_fee_for_expired_settlement_event(&self) -> (SignedAmount, SignedAmount) {
+        // The expected to be charged for 24h because we only charge one full term
+        // This is due to the rollover falling back to charging one full term if the event is
+        // already past expiry.
+        self.complete_fee_for_rollover_hours(24)
+    }
 }
 
 fn oracle_pk() -> XOnlyPublicKey {

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -26,6 +26,7 @@ use daemon::seed::RandomSeed;
 use daemon::seed::Seed;
 use daemon::Environment;
 use daemon::N_PAYOUTS;
+use maia::olivia::btc_example_0;
 use maia::OliviaData;
 use maker::cfd::OfferParams;
 use model::libp2p::PeerId;
@@ -276,7 +277,7 @@ impl Default for OpenCfdArgs {
             initial_price: Price::new(dummy_price()).unwrap(),
             quantity: Contracts::new(100),
             taker_leverage: Leverage::TWO,
-            oracle_data: OliviaData::example_0(),
+            oracle_data: btc_example_0(),
         }
     }
 }

--- a/daemon-tests/src/maia.rs
+++ b/daemon-tests/src/maia.rs
@@ -8,6 +8,7 @@ use time::ext::NumericalDuration;
 
 pub mod olivia {
     use super::btc;
+    use super::eth;
     use super::OliviaData;
 
     pub fn btc_example_0() -> OliviaData {
@@ -25,6 +26,16 @@ pub mod olivia {
             btc::PRICE_1,
             &btc::NONCE_PKS_1,
             &btc::ATTESTATIONS_1,
+        )
+    }
+
+    // TODO: Use real-world ETH oracle data.
+    pub fn eth_example_0() -> OliviaData {
+        OliviaData::example(
+            eth::EVENT_ID_0,
+            btc::PRICE_0,
+            &btc::NONCE_PKS_0,
+            &btc::ATTESTATIONS_0,
         )
     }
 }
@@ -211,4 +222,8 @@ mod btc {
         "d65a4c71062fc0b0210bb3e239f60d826a37d28caadfc52edd7afde6e91ff818",
         "ea5dfd972784808a15543f850c7bc86bff2b51cff81ec68fc4c3977d5e7d38de",
     ];
+}
+
+mod eth {
+    pub const EVENT_ID_0: &str = "/x/BitMEX/BETH/2022-08-24T01:08:00.price?n=20";
 }

--- a/daemon-tests/src/maia.rs
+++ b/daemon-tests/src/maia.rs
@@ -1,47 +1,49 @@
 use daemon::maia_core::secp256k1_zkp::SecretKey;
 use daemon::maia_core::secp256k1_zkp::XOnlyPublicKey;
 use daemon::oracle;
-use model::olivia;
+use model::olivia::Announcement;
 use model::olivia::BitMexPriceEventId;
 use std::str::FromStr;
 use time::ext::NumericalDuration;
+
+pub mod olivia {
+    use super::btc;
+    use super::OliviaData;
+
+    pub fn btc_example_0() -> OliviaData {
+        OliviaData::example(
+            btc::EVENT_ID_0,
+            btc::PRICE_0,
+            &btc::NONCE_PKS_0,
+            &btc::ATTESTATIONS_0,
+        )
+    }
+
+    pub fn btc_example_1() -> OliviaData {
+        OliviaData::example(
+            btc::EVENT_ID_1,
+            btc::PRICE_1,
+            &btc::NONCE_PKS_1,
+            &btc::ATTESTATIONS_1,
+        )
+    }
+}
 
 #[allow(dead_code)]
 #[derive(Clone)]
 pub struct OliviaData {
     ids: Vec<BitMexPriceEventId>,
-    pk: XOnlyPublicKey,
     nonce_pks: Vec<XOnlyPublicKey>,
     price: u64,
     attestations: Vec<SecretKey>,
 }
 
 impl OliviaData {
-    pub fn example_0() -> Self {
-        Self::example(
-            Self::EVENT_ID_0,
-            Self::PRICE_0,
-            &Self::NONCE_PKS_0,
-            &Self::ATTESTATIONS_0,
-        )
-    }
-
-    pub fn example_1() -> Self {
-        Self::example(
-            Self::EVENT_ID_1,
-            Self::PRICE_1,
-            &Self::NONCE_PKS_1,
-            &Self::ATTESTATIONS_1,
-        )
-    }
-
     /// Generate an example of all the data from `olivia` needed to test the
     /// CFD protocol end-to-end.
     fn example(id: &str, price: u64, nonce_pks: &[&str], attestations: &[&str]) -> Self {
-        let oracle_pk = XOnlyPublicKey::from_str(Self::OLIVIA_PK).unwrap();
-
         let id = id.parse::<BitMexPriceEventId>().unwrap();
-        let ids = olivia::hourly_events(
+        let ids = model::olivia::hourly_events(
             id.timestamp(),
             id.timestamp() + 24.hours(),
             id.index_price(),
@@ -60,18 +62,17 @@ impl OliviaData {
 
         Self {
             ids,
-            pk: oracle_pk,
             nonce_pks,
             attestations,
             price,
         }
     }
 
-    pub fn announcements(&self) -> Vec<olivia::Announcement> {
+    pub fn announcements(&self) -> Vec<Announcement> {
         self.ids
             .clone()
             .into_iter()
-            .map(|id| olivia::Announcement {
+            .map(|id| Announcement {
                 id,
                 expected_outcome_time: id.timestamp(),
                 nonce_pks: self.nonce_pks.clone(),
@@ -79,7 +80,7 @@ impl OliviaData {
             .collect()
     }
 
-    pub fn settlement_announcement(&self) -> olivia::Announcement {
+    pub fn settlement_announcement(&self) -> Announcement {
         self.announcements().last().unwrap().clone()
     }
 
@@ -88,7 +89,7 @@ impl OliviaData {
             .clone()
             .into_iter()
             .map(|id| {
-                oracle::Attestation::new(olivia::Attestation {
+                oracle::Attestation::new(model::olivia::Attestation {
                     id,
                     price: self.price,
                     scalars: self.attestations.clone(),
@@ -114,12 +115,11 @@ impl OliviaData {
             .find(|attestation| attestation.id() == event_id)
             .cloned()
     }
+}
 
-    const OLIVIA_PK: &'static str =
-        "ddd4636845a90185991826be5a494cde9f4a6947b1727217afedc6292fa4caf7";
-
-    const EVENT_ID_0: &'static str = "/x/BitMEX/BXBT/2021-10-05T02:00:00.price?n=20";
-    const NONCE_PKS_0: [&'static str; 20] = [
+mod btc {
+    pub const EVENT_ID_0: &str = "/x/BitMEX/BXBT/2021-10-05T02:00:00.price?n=20";
+    pub const NONCE_PKS_0: [&str; 20] = [
         "d02d163cf9623f567c4e3faf851a9266ac1ede13da4ca4141f3a7717fba9a739",
         "bc310f26aa5addbc382f653d8530aaead7c25e3546abc24639f490e36d4bdb88",
         "2661375f570dcc32300d442e85b6d72dfa3232dccda45e8fb4a2d1e758d1d374",
@@ -141,8 +141,8 @@ impl OliviaData {
         "3867af9048309a05004a164bdea09899f23ff1d83b6491b2b53a1b7b92e0eb2e",
         "688118e6b59e27944c277513db2711a520f4283c7c53a11f58d9f6a46d82c964",
     ];
-    const PRICE_0: u64 = 49262;
-    const ATTESTATIONS_0: [&'static str; 20] = [
+    pub const PRICE_0: u64 = 49262;
+    pub const ATTESTATIONS_0: [&str; 20] = [
         "5bc7663195971daaa1e3e6a81b4bca65882791644bc446fc060cbc118a3ace0f",
         "721d0cb56a0778a1ca7907f81a0787f34385b13f854c845c4c5539f7f6267958",
         "044aeef0d525c8ff48758c80939e95807bc640990cc03f53ab6fc0b262045221",
@@ -165,8 +165,8 @@ impl OliviaData {
         "90c4d8ec9f408ccb62a62daa993c20f2f86799e1fdea520c6d060418e55fd216",
     ];
 
-    const EVENT_ID_1: &'static str = "/x/BitMEX/BXBT/2021-10-05T08:00:00.price?n=20";
-    const NONCE_PKS_1: [&'static str; 20] = [
+    pub const EVENT_ID_1: &str = "/x/BitMEX/BXBT/2021-10-05T08:00:00.price?n=20";
+    pub const NONCE_PKS_1: [&str; 20] = [
         "150df2e64f39706e726eaa1fe081af3edf376d9644723e135a99328fd194caca",
         "b90629cedc7cb8430b4d15c84bbe1fe173e70e626d40c465e64de29d4879e20f",
         "ae14ffb8701d3e224b6632a1bb7b099c8aa90979c3fb788422daa08bca25fa68",
@@ -188,8 +188,8 @@ impl OliviaData {
         "5c4fb87b3812982759ed7264676e713e4e477a41759261515b04797db393ef62",
         "f3f6b9134c0fdd670767fbf478fd0dd3430f195ce9c21cabb84f3c1dd4848a11",
     ];
-    const PRICE_1: u64 = 49493;
-    const ATTESTATIONS_1: [&'static str; 20] = [
+    pub const PRICE_1: u64 = 49493;
+    pub const ATTESTATIONS_1: [&str; 20] = [
         "605f458e9a7bd216ff522e45f6cd14378c03ccfd4d35a69b9b6ce5c4ebfc89fa",
         "edc7215277d2c24a7a4659ff8831352db609fcc467fead5e27fdada172cdfd86",
         "1c2d76fcbe724b1fabd2622b991e90bbb2ea9244489de960747134c9fd695dcb",

--- a/daemon-tests/src/mocks.rs
+++ b/daemon-tests/src/mocks.rs
@@ -1,10 +1,12 @@
 use crate::dummy_latest_quotes;
 use crate::maia::olivia::btc_example_0;
+use crate::maia::olivia::eth_example_0;
 use crate::mocks::monitor::MockMonitor;
 use crate::mocks::oracle::MockOracle;
 use crate::mocks::price_feed::MockPriceFeed;
 use crate::mocks::wallet::MockWallet;
 use model::olivia;
+use model::ContractSymbol;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::sync::MutexGuard;
@@ -60,8 +62,12 @@ impl Mocks {
             .returning(|sign_msg| Ok(sign_msg.psbt));
     }
 
-    pub async fn mock_oracle_announcement(&mut self) {
-        self.mock_oracle_announcement_with(btc_example_0().announcements())
+    pub async fn mock_oracle_announcement(&mut self, symbol: ContractSymbol) {
+        let oracle_data = match symbol {
+            ContractSymbol::BtcUsd => btc_example_0(),
+            ContractSymbol::EthUsd => eth_example_0(),
+        };
+        self.mock_oracle_announcement_with(oracle_data.announcements())
             .await;
     }
 

--- a/daemon-tests/src/mocks.rs
+++ b/daemon-tests/src/mocks.rs
@@ -1,5 +1,5 @@
 use crate::dummy_latest_quotes;
-use crate::maia::OliviaData;
+use crate::maia::olivia::btc_example_0;
 use crate::mocks::monitor::MockMonitor;
 use crate::mocks::oracle::MockOracle;
 use crate::mocks::price_feed::MockPriceFeed;
@@ -61,7 +61,7 @@ impl Mocks {
     }
 
     pub async fn mock_oracle_announcement(&mut self) {
-        self.mock_oracle_announcement_with(OliviaData::example_0().announcements())
+        self.mock_oracle_announcement_with(btc_example_0().announcements())
             .await;
     }
 

--- a/daemon-tests/src/mocks/oracle.rs
+++ b/daemon-tests/src/mocks/oracle.rs
@@ -1,4 +1,4 @@
-use crate::maia::OliviaData;
+use crate::maia::olivia::btc_example_0;
 use async_trait::async_trait;
 use daemon::command;
 use daemon::oracle;
@@ -87,9 +87,8 @@ impl MockOracle {
 /// announcement/attestation is hard-coded in OliviaData struct (along with event id's).
 /// Therefore, an attestation based on current utc time will always be wrong.
 pub fn dummy_wrong_attestation() -> oracle::Attestation {
-    let olivia::Attestation { id, price, scalars } = OliviaData::example_0().attestations()[0]
-        .clone()
-        .into_inner();
+    let olivia::Attestation { id, price, scalars } =
+        btc_example_0().attestations()[0].clone().into_inner();
 
     oracle::Attestation::new(olivia::Attestation {
         id: BitMexPriceEventId::with_20_digits(OffsetDateTime::now_utc(), id.index_price()),

--- a/daemon-tests/src/mocks/wallet.rs
+++ b/daemon-tests/src/mocks/wallet.rs
@@ -93,7 +93,7 @@ fn dummy_wallet_info() -> Result<WalletInfo> {
 
 pub fn build_party_params(msg: wallet::BuildPartyParams) -> Result<PartyParams> {
     let mut rng = thread_rng();
-    let wallet = new_test_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
+    let wallet = new_test_wallet(&mut rng, Amount::from_btc(1.4).unwrap(), 5).unwrap();
 
     let mut builder = wallet.build_tx();
 

--- a/daemon-tests/tests/main/collaborative_settlement.rs
+++ b/daemon-tests/tests/main/collaborative_settlement.rs
@@ -2,22 +2,35 @@ use daemon::projection::CfdState;
 use daemon_tests::confirm;
 use daemon_tests::flow::next_with;
 use daemon_tests::flow::one_cfd_with_state;
+use daemon_tests::maia::olivia::btc_example_0;
+use daemon_tests::maia::olivia::eth_example_0;
 use daemon_tests::mock_quotes;
 use daemon_tests::open_cfd;
 use daemon_tests::start_both;
 use daemon_tests::wait_next_state;
 use daemon_tests::OpenCfdArgs;
+use model::ContractSymbol;
 use model::Position;
 use otel_tests::otel_test;
 
 #[otel_test]
-async fn collaboratively_close_an_open_cfd_maker_going_short() {
-    collaboratively_close_an_open_cfd(Position::Short).await;
+async fn collaboratively_close_an_open_btc_usd_cfd_maker_going_short() {
+    collaboratively_close_an_open_cfd(Position::Short, ContractSymbol::BtcUsd).await;
 }
 
 #[otel_test]
-async fn collaboratively_close_an_open_cfd_maker_going_long() {
-    collaboratively_close_an_open_cfd(Position::Long).await;
+async fn collaboratively_close_an_open_btc_usd_cfd_maker_going_long() {
+    collaboratively_close_an_open_cfd(Position::Long, ContractSymbol::BtcUsd).await;
+}
+
+#[otel_test]
+async fn collaboratively_close_an_open_eth_usd_cfd_maker_going_short() {
+    collaboratively_close_an_open_cfd(Position::Short, ContractSymbol::EthUsd).await;
+}
+
+#[otel_test]
+async fn collaboratively_close_an_open_eth_usd_cfd_maker_going_long() {
+    collaboratively_close_an_open_cfd(Position::Long, ContractSymbol::EthUsd).await;
 }
 
 #[otel_test]
@@ -63,13 +76,22 @@ async fn maker_accepts_collab_settlement_after_commit_finality() {
     wait_next_state!(order_id, maker, taker, CfdState::OpenCommitted);
 }
 
-async fn collaboratively_close_an_open_cfd(position_maker: Position) {
+async fn collaboratively_close_an_open_cfd(
+    position_maker: Position,
+    contract_symbol: ContractSymbol,
+) {
     let (mut maker, mut taker) = start_both().await;
+    let oracle_data = match contract_symbol {
+        ContractSymbol::BtcUsd => btc_example_0(),
+        ContractSymbol::EthUsd => eth_example_0(),
+    };
     let order_id = open_cfd(
         &mut taker,
         &mut maker,
         OpenCfdArgs {
             position_maker,
+            contract_symbol,
+            oracle_data,
             ..Default::default()
         },
     )

--- a/daemon-tests/tests/main/liquidation.rs
+++ b/daemon-tests/tests/main/liquidation.rs
@@ -1,4 +1,5 @@
-use daemon_tests::maia::OliviaData;
+use daemon_tests::maia::olivia::btc_example_0;
+use daemon_tests::maia::olivia::btc_example_1;
 use daemon_tests::open_cfd;
 use daemon_tests::rollover::rollover;
 use daemon_tests::settle_non_collaboratively;
@@ -13,7 +14,7 @@ use rust_decimal::Decimal;
 async fn given_open_cfd_when_oracle_attests_long_liquidation_price_can_liquidate() {
     let (mut maker, mut taker) = start_both().await;
 
-    let oracle_data = OliviaData::example_0();
+    let oracle_data = btc_example_0();
 
     // We set the initial price to a value much higher than that of the price that the mock oracle
     // will attest to. This is so that the price attested to falls within the long liquidation
@@ -52,7 +53,7 @@ async fn given_open_cfd_when_oracle_attests_long_liquidation_price_can_liquidate
 async fn given_rollover_when_oracle_attests_long_liquidation_price_can_liquidate() {
     let (mut maker, mut taker) = start_both().await;
 
-    let oracle_data_contract_setup = OliviaData::example_0();
+    let oracle_data_contract_setup = btc_example_0();
 
     // We set the initial price to a value much higher than that of the price that the mock oracle
     // will attest to. This is so that the price attested to falls within the long liquidation
@@ -79,7 +80,7 @@ async fn given_rollover_when_oracle_attests_long_liquidation_price_can_liquidate
         )
     );
 
-    let oracle_data_rollover = OliviaData::example_1();
+    let oracle_data_rollover = btc_example_1();
     rollover(
         &mut maker,
         &mut taker,

--- a/daemon-tests/tests/main/non_collaborative_settlement.rs
+++ b/daemon-tests/tests/main/non_collaborative_settlement.rs
@@ -2,24 +2,36 @@ use daemon_tests::open_cfd;
 use daemon_tests::settle_non_collaboratively;
 use daemon_tests::start_both;
 use daemon_tests::OpenCfdArgs;
+use model::ContractSymbol;
 use model::Position;
 use otel_tests::otel_test;
 
 #[otel_test]
-async fn force_close_an_open_cfd_maker_going_short() {
-    force_close_open_cfd(Position::Short).await;
+async fn force_close_an_open_btc_usd_cfd_maker_going_short() {
+    force_close_open_cfd(Position::Short, ContractSymbol::BtcUsd).await;
 }
 
 #[otel_test]
-async fn force_close_an_open_cfd_maker_going_long() {
-    force_close_open_cfd(Position::Long).await;
+async fn force_close_an_open_btc_usd_cfd_maker_going_long() {
+    force_close_open_cfd(Position::Long, ContractSymbol::BtcUsd).await;
 }
 
-async fn force_close_open_cfd(position_maker: Position) {
+#[otel_test]
+async fn force_close_an_open_eth_usd_cfd_maker_going_short() {
+    force_close_open_cfd(Position::Short, ContractSymbol::EthUsd).await;
+}
+
+#[otel_test]
+async fn force_close_an_open_eth_usd_cfd_maker_going_long() {
+    force_close_open_cfd(Position::Long, ContractSymbol::EthUsd).await;
+}
+
+async fn force_close_open_cfd(position_maker: Position, contract_symbol: ContractSymbol) {
     let (mut maker, mut taker) = start_both().await;
 
     let open_cfd_args = OpenCfdArgs {
         position_maker,
+        contract_symbol,
         ..Default::default()
     };
 

--- a/daemon-tests/tests/main/offer.rs
+++ b/daemon-tests/tests/main/offer.rs
@@ -3,7 +3,9 @@ use daemon::projection::MakerOffers;
 use daemon_tests::flow::ensure_null_next_offers;
 use daemon_tests::flow::next_maker_offers;
 use daemon_tests::start_both;
+use daemon_tests::Maker;
 use daemon_tests::OfferParamsBuilder;
+use daemon_tests::Taker;
 use model::ContractSymbol;
 use model::Leverage;
 use otel_tests::otel_test;
@@ -18,13 +20,16 @@ async fn taker_receives_eth_usd_offer_from_maker_on_publication() {
     taker_receives_offer_from_maker_on_publication(ContractSymbol::EthUsd).await;
 }
 
-// TODO: Potentially create a test where we send out both and ensure we receive as expected
-
-async fn taker_receives_offer_from_maker_on_publication(contract_symbol: ContractSymbol) {
+#[otel_test]
+async fn taker_can_receive_offers_with_different_symbols_from_maker() {
     let (mut maker, mut taker) = start_both().await;
-
     ensure_null_next_offers(taker.offers_feed()).await.unwrap();
 
+    test_offer(&mut maker, &mut taker, ContractSymbol::BtcUsd).await;
+    test_offer(&mut maker, &mut taker, ContractSymbol::EthUsd).await;
+}
+
+async fn publish_offer(maker: &mut Maker, contract_symbol: ContractSymbol) {
     let leverage = Leverage::TWO;
     maker
         .set_offer_params(
@@ -34,13 +39,23 @@ async fn taker_receives_offer_from_maker_on_publication(contract_symbol: Contrac
                 .build(),
         )
         .await;
+}
 
+/// Verify that an offer with a given contract symbol gets published by the
+/// maker an is received by the taker
+async fn test_offer(maker: &mut Maker, taker: &mut Taker, symbol: ContractSymbol) {
+    publish_offer(maker, symbol).await;
     let (published, received) =
-        next_maker_offers(maker.offers_feed(), taker.offers_feed(), &contract_symbol)
+        next_maker_offers(maker.offers_feed(), taker.offers_feed(), &symbol)
             .await
             .unwrap();
-
     assert_eq_offers(published, received);
+}
+
+async fn taker_receives_offer_from_maker_on_publication(contract_symbol: ContractSymbol) {
+    let (mut maker, mut taker) = start_both().await;
+    ensure_null_next_offers(taker.offers_feed()).await.unwrap();
+    test_offer(&mut maker, &mut taker, contract_symbol).await;
 }
 
 fn assert_eq_offers(published: MakerOffers, received: MakerOffers) {

--- a/daemon-tests/tests/main/rollover.rs
+++ b/daemon-tests/tests/main/rollover.rs
@@ -26,14 +26,12 @@ async fn rollover_an_open_btc_usd_cfd_maker_going_short() {
     let (mut maker, mut taker, order_id, fee_calculator) =
         prepare_rollover(Position::Short, ContractSymbol::BtcUsd, btc_example_0()).await;
 
-    // We charge 24 hours for the rollover because that is the fallback strategy if the timestamp of
-    // the settlement-event is already expired
     rollover(
         &mut maker,
         &mut taker,
         order_id,
         btc_example_0(),
-        fee_calculator.complete_fee_for_rollover_hours(24),
+        fee_calculator.complete_fee_for_expired_settlement_event(),
     )
     .await;
 }
@@ -43,14 +41,12 @@ async fn rollover_an_open_eth_usd_cfd_maker_going_short() {
     let (mut maker, mut taker, order_id, fee_calculator) =
         prepare_rollover(Position::Short, ContractSymbol::EthUsd, eth_example_0()).await;
 
-    // We charge 24 hours for the rollover because that is the fallback strategy if the timestamp of
-    // the settlement-event is already expired
     rollover(
         &mut maker,
         &mut taker,
         order_id,
         eth_example_0(),
-        fee_calculator.complete_fee_for_rollover_hours(24),
+        fee_calculator.complete_fee_for_expired_settlement_event(),
     )
     .await;
 }
@@ -60,14 +56,12 @@ async fn rollover_an_open_cfd_maker_going_long() {
     let (mut maker, mut taker, order_id, fee_calculator) =
         prepare_rollover(Position::Long, ContractSymbol::BtcUsd, btc_example_0()).await;
 
-    // We charge 24 hours for the rollover because that is the fallback strategy if the timestamp of
-    // the settlement-event is already expired
     rollover(
         &mut maker,
         &mut taker,
         order_id,
         btc_example_0(),
-        fee_calculator.complete_fee_for_rollover_hours(24),
+        fee_calculator.complete_fee_for_expired_settlement_event(),
     )
     .await;
 }
@@ -79,14 +73,12 @@ async fn double_rollover_an_open_cfd() {
     let (mut maker, mut taker, order_id, fee_calculator) =
         prepare_rollover(Position::Short, ContractSymbol::BtcUsd, btc_example_0()).await;
 
-    // We charge 24 hours for the rollover because that is the fallback strategy if the timestamp of
-    // the settlement-event is already expired
     rollover(
         &mut maker,
         &mut taker,
         order_id,
         btc_example_0(),
-        fee_calculator.complete_fee_for_rollover_hours(24),
+        fee_calculator.complete_fee_for_expired_settlement_event(),
     )
     .await;
 
@@ -145,7 +137,7 @@ async fn given_rollover_completed_when_taker_fails_rollover_can_retry() {
         &mut taker,
         order_id,
         btc_example_1(),
-        fee_calculator.complete_fee_for_rollover_hours(24),
+        fee_calculator.complete_fee_for_expired_settlement_event(),
     )
     .await;
 
@@ -219,7 +211,7 @@ async fn given_contract_setup_completed_when_taker_fails_first_rollover_can_retr
         &mut taker,
         order_id,
         btc_example_1(),
-        fee_calculator.complete_fee_for_rollover_hours(24),
+        fee_calculator.complete_fee_for_expired_settlement_event(),
     )
     .await;
 
@@ -234,8 +226,7 @@ async fn given_contract_setup_completed_when_taker_fails_first_rollover_can_retr
         )
         .await;
 
-    // When retrying the rollover we expect to be charged the same amount (i.e. 24h, no fee
-    // increase)
+    // When retrying the rollover we expect to be charged the same amount
     rollover_from_commit_tx(
         &mut maker,
         &mut taker,
@@ -245,10 +236,7 @@ async fn given_contract_setup_completed_when_taker_fails_first_rollover_can_retr
             taker_commit_txid_after_contract_setup,
             taker_settlement_event_id_after_contract_setup,
         )),
-        // Only one term of 24h is charged, so the expected fees are for 24h.
-        // This is due to the rollover falling back to charging one full term if the event is
-        // already past expiry.
-        fee_calculator.complete_fee_for_rollover_hours(24),
+        fee_calculator.complete_fee_for_expired_settlement_event(),
     )
     .await;
 
@@ -314,10 +302,7 @@ async fn given_contract_setup_completed_when_taker_fails_two_rollovers_can_retry
             taker_commit_txid_after_contract_setup,
             taker_settlement_event_id_after_contract_setup,
         )),
-        // The expected to be charged for 24h because we only charge one full term
-        // This is due to the rollover falling back to charging one full term if the event is
-        // already past expiry.
-        fee_calculator.complete_fee_for_rollover_hours(24),
+        fee_calculator.complete_fee_for_expired_settlement_event(),
     )
     .await;
 

--- a/daemon-tests/tests/main/rollover.rs
+++ b/daemon-tests/tests/main/rollover.rs
@@ -3,6 +3,8 @@ use daemon::bdk::bitcoin::Txid;
 use daemon::projection::CfdState;
 use daemon_tests::flow::next_with;
 use daemon_tests::flow::one_cfd_with_state;
+use daemon_tests::maia::olivia::btc_example_0;
+use daemon_tests::maia::olivia::btc_example_1;
 use daemon_tests::maia::OliviaData;
 use daemon_tests::open_cfd;
 use daemon_tests::start_both;
@@ -20,7 +22,7 @@ use otel_tests::otel_test;
 #[otel_test]
 async fn rollover_an_open_cfd_maker_going_short() {
     let (mut maker, mut taker, order_id, fee_calculator) =
-        prepare_rollover(Position::Short, OliviaData::example_0()).await;
+        prepare_rollover(Position::Short, btc_example_0()).await;
 
     // We charge 24 hours for the rollover because that is the fallback strategy if the timestamp of
     // the settlement-event is already expired
@@ -28,7 +30,7 @@ async fn rollover_an_open_cfd_maker_going_short() {
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_0(),
+        btc_example_0(),
         fee_calculator.complete_fee_for_rollover_hours(24),
     )
     .await;
@@ -37,7 +39,7 @@ async fn rollover_an_open_cfd_maker_going_short() {
 #[otel_test]
 async fn rollover_an_open_cfd_maker_going_long() {
     let (mut maker, mut taker, order_id, fee_calculator) =
-        prepare_rollover(Position::Long, OliviaData::example_0()).await;
+        prepare_rollover(Position::Long, btc_example_0()).await;
 
     // We charge 24 hours for the rollover because that is the fallback strategy if the timestamp of
     // the settlement-event is already expired
@@ -45,7 +47,7 @@ async fn rollover_an_open_cfd_maker_going_long() {
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_0(),
+        btc_example_0(),
         fee_calculator.complete_fee_for_rollover_hours(24),
     )
     .await;
@@ -56,7 +58,7 @@ async fn double_rollover_an_open_cfd() {
     // double rollover ensures that both parties properly succeeded and can do another rollover
 
     let (mut maker, mut taker, order_id, fee_calculator) =
-        prepare_rollover(Position::Short, OliviaData::example_0()).await;
+        prepare_rollover(Position::Short, btc_example_0()).await;
 
     // We charge 24 hours for the rollover because that is the fallback strategy if the timestamp of
     // the settlement-event is already expired
@@ -64,7 +66,7 @@ async fn double_rollover_an_open_cfd() {
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_0(),
+        btc_example_0(),
         fee_calculator.complete_fee_for_rollover_hours(24),
     )
     .await;
@@ -73,7 +75,7 @@ async fn double_rollover_an_open_cfd() {
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_0(),
+        btc_example_0(),
         fee_calculator.complete_fee_for_rollover_hours(48),
     )
     .await;
@@ -116,14 +118,14 @@ async fn maker_rejects_rollover_of_open_cfd() {
 #[otel_test]
 async fn given_rollover_completed_when_taker_fails_rollover_can_retry() {
     let (mut maker, mut taker, order_id, fee_calculator) =
-        prepare_rollover(Position::Short, OliviaData::example_0()).await;
+        prepare_rollover(Position::Short, btc_example_0()).await;
 
     // 1. Do two rollovers
     rollover(
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_1(),
+        btc_example_1(),
         fee_calculator.complete_fee_for_rollover_hours(24),
     )
     .await;
@@ -137,7 +139,7 @@ async fn given_rollover_completed_when_taker_fails_rollover_can_retry() {
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_1(),
+        btc_example_1(),
         // The second rollover increases the complete fees to 48h
         fee_calculator.complete_fee_for_rollover_hours(48),
     )
@@ -158,7 +160,7 @@ async fn given_rollover_completed_when_taker_fails_rollover_can_retry() {
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_1(),
+        btc_example_1(),
         Some((
             taker_commit_txid_after_first_rollover,
             taker_settlement_event_id_after_first_rollover,
@@ -174,7 +176,7 @@ async fn given_rollover_completed_when_taker_fails_rollover_can_retry() {
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_1(),
+        btc_example_1(),
         // Additional rollover increases the complete fees to 72h
         fee_calculator.complete_fee_for_rollover_hours(72),
     )
@@ -184,7 +186,7 @@ async fn given_rollover_completed_when_taker_fails_rollover_can_retry() {
 #[otel_test]
 async fn given_contract_setup_completed_when_taker_fails_first_rollover_can_retry() {
     let (mut maker, mut taker, order_id, fee_calculator) =
-        prepare_rollover(Position::Short, OliviaData::example_0()).await;
+        prepare_rollover(Position::Short, btc_example_0()).await;
 
     let taker_commit_txid_after_contract_setup = taker.latest_commit_txid();
     let taker_settlement_event_id_after_contract_setup = taker.latest_settlement_event_id();
@@ -197,7 +199,7 @@ async fn given_contract_setup_completed_when_taker_fails_first_rollover_can_retr
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_1(),
+        btc_example_1(),
         fee_calculator.complete_fee_for_rollover_hours(24),
     )
     .await;
@@ -219,7 +221,7 @@ async fn given_contract_setup_completed_when_taker_fails_first_rollover_can_retr
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_1(),
+        btc_example_1(),
         Some((
             taker_commit_txid_after_contract_setup,
             taker_settlement_event_id_after_contract_setup,
@@ -237,7 +239,7 @@ async fn given_contract_setup_completed_when_taker_fails_first_rollover_can_retr
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_1(),
+        btc_example_1(),
         fee_calculator.complete_fee_for_rollover_hours(48),
     )
     .await;
@@ -246,7 +248,7 @@ async fn given_contract_setup_completed_when_taker_fails_first_rollover_can_retr
 #[otel_test]
 async fn given_contract_setup_completed_when_taker_fails_two_rollovers_can_retry() {
     let (mut maker, mut taker, order_id, fee_calculator) =
-        prepare_rollover(Position::Short, OliviaData::example_0()).await;
+        prepare_rollover(Position::Short, btc_example_0()).await;
 
     let taker_commit_txid_after_contract_setup = taker.latest_commit_txid();
     let taker_settlement_event_id_after_contract_setup = taker.latest_settlement_event_id();
@@ -258,7 +260,7 @@ async fn given_contract_setup_completed_when_taker_fails_two_rollovers_can_retry
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_1(),
+        btc_example_1(),
         fee_calculator.complete_fee_for_rollover_hours(24),
     )
     .await;
@@ -267,7 +269,7 @@ async fn given_contract_setup_completed_when_taker_fails_two_rollovers_can_retry
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_1(),
+        btc_example_1(),
         // The second rollover increases the complete fees to 48h
         fee_calculator.complete_fee_for_rollover_hours(48),
     )
@@ -288,7 +290,7 @@ async fn given_contract_setup_completed_when_taker_fails_two_rollovers_can_retry
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_1(),
+        btc_example_1(),
         Some((
             taker_commit_txid_after_contract_setup,
             taker_settlement_event_id_after_contract_setup,
@@ -305,7 +307,7 @@ async fn given_contract_setup_completed_when_taker_fails_two_rollovers_can_retry
         &mut maker,
         &mut taker,
         order_id,
-        OliviaData::example_1(),
+        btc_example_1(),
         // After another rollover we expect to be charged for 48h
         fee_calculator.complete_fee_for_rollover_hours(48),
     )


### PR DESCRIPTION
Extend the internals to be able to configure tests per contract symbol.

Note that this results in quite a lot more actor tests, but as far as I could see the test runtime did not go up significantly.
