### PR TITLE
Compute liquidation price in ui

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -1340,9 +1340,6 @@ pub struct CfdOffer {
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 pub struct LeverageDetails {
     pub leverage: Leverage,
-    /// Own liquidation price according to position and leverage
-    #[serde(with = "round_to_two_dp")]
-    pub liquidation_price: Price,
     /// Margin per lot from the perspective of the role
     ///
     /// Since this is a calculated value that we need in the UI this value is based on the
@@ -1371,20 +1368,6 @@ impl CfdOffer {
             .leverage_choices
             .iter()
             .map(|leverage| {
-                let liquidation_price = match own_position {
-                    Position::Long => calculate_long_liquidation_price(
-                        offer.price,
-                        offer.max_quantity,
-                        *leverage,
-                        offer.contract_symbol,
-                    ),
-                    Position::Short => calculate_short_liquidation_price(
-                        offer.price,
-                        offer.max_quantity,
-                        *leverage,
-                        offer.contract_symbol,
-                    ),
-                };
                 // Margin per lot price is dependent on one's own leverage
                 let margin_per_lot = calculate_margin(
                     offer.contract_symbol,
@@ -1415,7 +1398,6 @@ impl CfdOffer {
 
                 Ok(LeverageDetails {
                     leverage: *leverage,
-                    liquidation_price,
                     margin_per_lot,
                     initial_funding_fee_per_lot,
                 })

--- a/taker-frontend/src/components/LiquidationPrice.test.tsx
+++ b/taker-frontend/src/components/LiquidationPrice.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/extend-expect";
-import { liquidationPriceQuantoContracts } from "./LiquidationPrice";
+import { liquidationPriceInverseContracts, liquidationPriceQuantoContracts } from "./LiquidationPrice";
 
 it("given quanto contract with leverage 1 compute long liquidation price", () => {
     let liquidationPrice = liquidationPriceQuantoContracts(1, 10, 1000, true);
@@ -19,4 +19,24 @@ it("given quanto contract with leverage 2 compute long liquidation price", () =>
 it("given quanto contract with leverage 2 compute short liquidation price", () => {
     let liquidationPrice = liquidationPriceQuantoContracts(2, 10, 1000, false);
     expect(liquidationPrice).toBe(1500);
+});
+
+it("given inverse contract with leverage 1 compute short liquidation price", () => {
+    let liquidationPrice = liquidationPriceInverseContracts(1, 1000, true);
+    expect(liquidationPrice).toBe(500);
+});
+
+it("given inverse contract with leverage 1 compute long liquidation price", () => {
+    let liquidationPrice = liquidationPriceInverseContracts(1, 1000, false);
+    expect(liquidationPrice).toBe(21_000_000);
+});
+
+it("given inverse contract with leverage 2 compute long liquidation price", () => {
+    let liquidationPrice = liquidationPriceInverseContracts(2, 60000, true);
+    expect(liquidationPrice).toBe(40_000);
+});
+
+it("given inverse contract with leverage 2 compute short liquidation price", () => {
+    let liquidationPrice = liquidationPriceInverseContracts(2, 60000, false);
+    expect(liquidationPrice).toBe(120_000);
 });

--- a/taker-frontend/src/components/LiquidationPrice.test.tsx
+++ b/taker-frontend/src/components/LiquidationPrice.test.tsx
@@ -1,0 +1,22 @@
+import "@testing-library/jest-dom/extend-expect";
+import { liquidationPriceQuantoContracts } from "./LiquidationPrice";
+
+it("given quanto contract with leverage 1 compute long liquidation price", () => {
+    let liquidationPrice = liquidationPriceQuantoContracts(1, 10, 1000, true);
+    expect(liquidationPrice).toBe(1);
+});
+
+it("given quanto contract with leverage 1 compute short liquidation price", () => {
+    let liquidationPrice = liquidationPriceQuantoContracts(1, 10, 1000, false);
+    expect(liquidationPrice).toBe(2000);
+});
+
+it("given quanto contract with leverage 2 compute long liquidation price", () => {
+    let liquidationPrice = liquidationPriceQuantoContracts(2, 10, 1000, true);
+    expect(liquidationPrice).toBe(500);
+});
+
+it("given quanto contract with leverage 2 compute short liquidation price", () => {
+    let liquidationPrice = liquidationPriceQuantoContracts(2, 10, 1000, false);
+    expect(liquidationPrice).toBe(1500);
+});

--- a/taker-frontend/src/components/LiquidationPrice.ts
+++ b/taker-frontend/src/components/LiquidationPrice.ts
@@ -14,3 +14,16 @@ export function liquidationPriceQuantoContracts(leverage: number, quantity: numb
         return price + quantoLiquidationPrice(leverage, quantity, price);
     }
 }
+
+// returns the liquidation price for inverse contracts e.g. BTCUSD rounded to 0
+export function liquidationPriceInverseContracts(leverage: number, price: number, isLong: boolean) {
+    if (isLong) {
+        return Math.round(price * leverage / (leverage + 1));
+    } else {
+        if (leverage === 1) {
+            // With a leverage of 1 there is theoretically no liquidation
+            return 21_000_000;
+        }
+        return Math.round(price * leverage / (leverage - 1));
+    }
+}

--- a/taker-frontend/src/components/LiquidationPrice.ts
+++ b/taker-frontend/src/components/LiquidationPrice.ts
@@ -1,0 +1,16 @@
+function quantoLiquidationPrice(leverage: number, quantity: number, price: number) {
+    return (price * (1 / leverage));
+}
+
+// returns the liquidation price for quanto contracts e.g. ETHUSD
+export function liquidationPriceQuantoContracts(leverage: number, quantity: number, price: number, isLong: boolean) {
+    if (isLong) {
+        const liquidationPrice = price - quantoLiquidationPrice(leverage, quantity, price);
+        if (liquidationPrice <= 0) {
+            return 1;
+        }
+        return liquidationPrice;
+    } else {
+        return price + quantoLiquidationPrice(leverage, quantity, price);
+    }
+}

--- a/taker-frontend/src/components/Trade.tsx
+++ b/taker-frontend/src/components/Trade.tsx
@@ -46,7 +46,7 @@ import BitcoinAmount from "./BitcoinAmount";
 import ConfirmOrderModal from "./ConfirmOrderModal";
 import DollarAmount from "./DollarAmount";
 import { FundingRateTooltip } from "./FundingRateTooltip";
-import { liquidationPriceQuantoContracts } from "./LiquidationPrice";
+import { liquidationPriceInverseContracts, liquidationPriceQuantoContracts } from "./LiquidationPrice";
 
 const MotionBox = motion<BoxProps>(Box);
 
@@ -121,7 +121,7 @@ export default function Trade({
             break;
         case "BTCUSD":
         default:
-            liquidationPrice = currentLeverageDetails?.liquidation_price || 0;
+            liquidationPrice = liquidationPriceInverseContracts(leverage, priceAsNumber!, isLong);
     }
 
     if (connectedToMaker.online) {

--- a/taker-frontend/src/components/Trade.tsx
+++ b/taker-frontend/src/components/Trade.tsx
@@ -46,6 +46,7 @@ import BitcoinAmount from "./BitcoinAmount";
 import ConfirmOrderModal from "./ConfirmOrderModal";
 import DollarAmount from "./DollarAmount";
 import { FundingRateTooltip } from "./FundingRateTooltip";
+import { liquidationPriceQuantoContracts } from "./LiquidationPrice";
 
 const MotionBox = motion<BoxProps>(Box);
 
@@ -112,6 +113,16 @@ export default function Trade({
         && quantityIsEvenlyDivisibleByIncrement;
 
     let alertBox;
+
+    let liquidationPrice = 0;
+    switch (contractSymbol) {
+        case "ETHUSD":
+            liquidationPrice = liquidationPriceQuantoContracts(leverage, quantity, priceAsNumber!, isLong);
+            break;
+        case "BTCUSD":
+        default:
+            liquidationPrice = currentLeverageDetails?.liquidation_price || 0;
+    }
 
     if (connectedToMaker.online) {
         if (balanceTooLow) {
@@ -293,7 +304,7 @@ export default function Trade({
                                 quantity={quantity}
                                 margin={margin}
                                 leverage={leverage}
-                                liquidationPriceAsNumber={currentLeverageDetails?.liquidation_price || 0}
+                                liquidationPriceAsNumber={liquidationPrice}
                                 feeForFirstSettlementInterval={feeForFirstSettlementInterval}
                                 fundingRateHourly={fundingRateHourly || 0}
                                 fundingRateAnnualized={fundingRateAnnualized || 0}

--- a/taker-frontend/src/types.ts
+++ b/taker-frontend/src/types.ts
@@ -35,7 +35,6 @@ export interface MakerOffer {
 
 export interface LeverageDetails {
     leverage: number;
-    liquidation_price: number;
     margin_per_lot: number;
     initial_funding_fee_per_lot: number;
 }


### PR DESCRIPTION
Without back and forth it is impossible to compute the liquidation price for quanto contracts in the backend. Hence, we compute it in the frontend.

resolves #2754

Signed-off-by: Philipp Hoenisch <philipp@coblox.tech>