### PR TITLE
Serialize oracle events according to index price

### DIFF
--- a/sqlite-db/src/models.rs
+++ b/sqlite-db/src/models.rs
@@ -719,7 +719,8 @@ impl fmt::Display for BitMexPriceEventId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "/x/BitMEX/BXBT/{}.price?n={}",
+            "/x/BitMEX/{}/{}.price?n={}",
+            self.index,
             self.timestamp
                 .format(&EVENT_TIME_FORMAT)
                 .expect("should always format and we can't return an error here"),


### PR DESCRIPTION
Could be related to #2769.

In a484929f7c0d1b57697fac3ebbe3febb48d9b09c, I correctly adapted the `FromStr` implementation of `sqlite_db::models::BitMexPriceEventId`, but not the `Display` implementation!

This could lead to bugs where `BETH` events saved to the database would be loaded as `BXBT` events.