### PR TITLE
fix (taker-ui): get months obviously starts with 0

### DIFF
--- a/taker-frontend/src/components/History.tsx
+++ b/taker-frontend/src/components/History.tsx
@@ -359,7 +359,7 @@ const TxIcon = ({ tx }: TxIconProps) => {
 function timeConverter(timestamp: number) {
     const a = new Date(timestamp * 1000);
     const year = a.getFullYear();
-    const month = a.getMonth();
+    const month = a.getMonth() + 1;
     const date = a.getDate();
     const hour = a.getHours();
     const min = a.getMinutes() === 0 ? "00" : a.getMinutes();


### PR DESCRIPTION
but getDate starts with 1 🤦‍♂️

noticed because a position created yesterday had an expiry last month:

<img width="519" alt="image" src="https://user-images.githubusercontent.com/224613/187348321-498ec725-ada4-4404-a868-0bfd416ca271.png">

fixed: 

<img width="483" alt="image" src="https://user-images.githubusercontent.com/224613/187348390-57bd23fa-a47d-43df-904b-aa638940e4d2.png">
