### PR TITLE
fix (maker/taker-ui): short/long offers were flipped

### DIFF
--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -1099,22 +1099,22 @@ impl State {
                     contract_symbol: ContractSymbol::BtcUsd,
                     position_maker: Position::Long,
                     ..
-                } => self.offers.btcusd_long = Some(new_offer),
+                } => self.offers.btcusd_short = Some(new_offer),
                 CfdOffer {
                     contract_symbol: ContractSymbol::BtcUsd,
                     position_maker: Position::Short,
                     ..
-                } => self.offers.btcusd_short = Some(new_offer),
+                } => self.offers.btcusd_long = Some(new_offer),
                 CfdOffer {
                     contract_symbol: ContractSymbol::EthUsd,
                     position_maker: Position::Long,
                     ..
-                } => self.offers.ethusd_long = Some(new_offer),
+                } => self.offers.ethusd_short = Some(new_offer),
                 CfdOffer {
                     contract_symbol: ContractSymbol::EthUsd,
                     position_maker: Position::Short,
                     ..
-                } => self.offers.ethusd_short = Some(new_offer),
+                } => self.offers.ethusd_long = Some(new_offer),
             }
         }
     }


### PR DESCRIPTION
When the maker is long and provides a long price, then it's an offer to go short from the taker's perspective with the long price provided by the maker being the short price for the taker🤯.

Men, we really need to change this... everytime I'm looking at this it breaks my brain 😅

resolves #2774

Signed-off-by: Philipp Hoenisch <philipp@coblox.tech>