### PR TITLE
feat(daemon-tests): Assert more values exposed from projection

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -248,7 +248,7 @@ pub struct OpenCfdArgs {
     pub oracle_data: OliviaData,
 }
 
-fn initial_price_for(symbol: ContractSymbol) -> Price {
+pub fn initial_price_for(symbol: ContractSymbol) -> Price {
     Price::new(match symbol {
         ContractSymbol::BtcUsd => dummy_btc_price(),
         ContractSymbol::EthUsd => dummy_eth_price(),
@@ -1099,11 +1099,11 @@ fn dummy_funding_fee() -> FundingFee {
     .unwrap()
 }
 
-fn dummy_btc_price() -> Decimal {
+pub fn dummy_btc_price() -> Decimal {
     dec!(50_000)
 }
 
-fn dummy_eth_price() -> Decimal {
+pub fn dummy_eth_price() -> Decimal {
     dec!(1_500)
 }
 
@@ -1122,13 +1122,12 @@ pub async fn mock_oracle_announcements(
         .await;
 }
 
-pub async fn mock_quotes(maker: &mut Maker, taker: &mut Taker) {
+pub async fn mock_quotes(maker: &mut Maker, taker: &mut Taker, contract_symbol: ContractSymbol) {
     taker.mocks.mock_latest_quotes().await;
     maker.mocks.mock_latest_quotes().await;
     let mut quote_receiver = taker.quote_feed().clone();
 
-    let non_empty_quote =
-        |quotes: projection::LatestQuotes| quotes.get(&ContractSymbol::BtcUsd).copied();
+    let non_empty_quote = |quotes: projection::LatestQuotes| quotes.get(&contract_symbol).copied();
 
     next_with(&mut quote_receiver, non_empty_quote)
         .await

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -1133,3 +1133,27 @@ pub async fn mock_quotes(maker: &mut Maker, taker: &mut Taker, contract_symbol: 
         .await
         .unwrap(); // if quote is available on feed, it propagated through the system
 }
+
+pub fn expected_taker_liquidation_price(symbol: ContractSymbol, taker_position: Position) -> Price {
+    let expected_liquidation_price = match (symbol, taker_position) {
+        // inverse payout curve
+        (ContractSymbol::BtcUsd, Position::Long) => dec!(33_333.333333333333333333333333),
+        (ContractSymbol::BtcUsd, Position::Short) => dec!(100_000),
+        // quanto linear payout curve
+        (ContractSymbol::EthUsd, Position::Long) => dec!(750),
+        (ContractSymbol::EthUsd, Position::Short) => dec!(2_250),
+    };
+    Price::new(expected_liquidation_price).unwrap()
+}
+
+pub fn expected_maker_liquidation_price(symbol: ContractSymbol, maker_position: Position) -> Price {
+    let expected_liquidation_price = match (symbol, maker_position) {
+        // inverse payout curve
+        (ContractSymbol::BtcUsd, Position::Long) => dec!(25_000),
+        (ContractSymbol::BtcUsd, Position::Short) => dec!(21_000_000), // INFINITE
+        // quanto linear payout curve
+        (ContractSymbol::EthUsd, Position::Long) => dec!(1),
+        (ContractSymbol::EthUsd, Position::Short) => dec!(3_000),
+    };
+    Price::new(expected_liquidation_price).unwrap()
+}

--- a/daemon-tests/tests/main/collaborative_settlement.rs
+++ b/daemon-tests/tests/main/collaborative_settlement.rs
@@ -105,7 +105,7 @@ async fn collaboratively_close_an_open_cfd(
         },
     )
     .await;
-    mock_quotes(&mut maker, &mut taker).await;
+    mock_quotes(&mut maker, &mut taker, contract_symbol).await;
 
     taker.system.propose_settlement(order_id).await.unwrap();
 

--- a/daemon-tests/tests/main/collaborative_settlement.rs
+++ b/daemon-tests/tests/main/collaborative_settlement.rs
@@ -1,17 +1,24 @@
 use daemon::projection::CfdState;
 use daemon_tests::confirm;
+use daemon_tests::dummy_btc_price;
+use daemon_tests::dummy_eth_price;
 use daemon_tests::flow::next_with;
 use daemon_tests::flow::one_cfd_with_state;
+use daemon_tests::initial_price_for;
 use daemon_tests::maia::olivia::btc_example_0;
 use daemon_tests::maia::olivia::eth_example_0;
 use daemon_tests::mock_quotes;
 use daemon_tests::open_cfd;
 use daemon_tests::start_both;
 use daemon_tests::wait_next_state;
+use daemon_tests::Maker;
 use daemon_tests::OpenCfdArgs;
+use daemon_tests::Taker;
 use model::ContractSymbol;
 use model::Position;
+use model::Price;
 use otel_tests::otel_test;
+use rust_decimal_macros::dec;
 
 #[otel_test]
 async fn collaboratively_close_an_open_btc_usd_cfd_maker_going_short() {
@@ -36,8 +43,9 @@ async fn collaboratively_close_an_open_eth_usd_cfd_maker_going_long() {
 #[otel_test]
 async fn maker_rejects_collab_settlement_after_commit_finality() {
     let (mut maker, mut taker) = start_both().await;
-    let order_id = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
-    mock_quotes(&mut maker, &mut taker).await;
+    let cfd_args = OpenCfdArgs::default();
+    let order_id = open_cfd(&mut taker, &mut maker, cfd_args.clone()).await;
+    mock_quotes(&mut maker, &mut taker, cfd_args.contract_symbol).await;
     taker.system.propose_settlement(order_id).await.unwrap();
 
     wait_next_state!(
@@ -57,8 +65,9 @@ async fn maker_rejects_collab_settlement_after_commit_finality() {
 #[otel_test]
 async fn maker_accepts_collab_settlement_after_commit_finality() {
     let (mut maker, mut taker) = start_both().await;
-    let order_id = open_cfd(&mut taker, &mut maker, OpenCfdArgs::default()).await;
-    mock_quotes(&mut maker, &mut taker).await;
+    let cfd_args = OpenCfdArgs::default();
+    let order_id = open_cfd(&mut taker, &mut maker, cfd_args.clone()).await;
+    mock_quotes(&mut maker, &mut taker, cfd_args.contract_symbol).await;
 
     taker.system.propose_settlement(order_id).await.unwrap();
 
@@ -113,4 +122,68 @@ async fn collaboratively_close_an_open_cfd(
 
     confirm!(close transaction, order_id, maker, taker);
     wait_next_state!(order_id, maker, taker, CfdState::Closed);
+    verify_closed_cfds(&mut maker, &mut taker);
+}
+
+/// Sanity check the values we publish in projection
+fn verify_closed_cfds(maker: &mut Maker, taker: &mut Taker) {
+    assert_eq!(
+        maker.first_cfd().closing_price.unwrap(),
+        taker.first_cfd().closing_price.unwrap()
+    );
+    assert_eq!(
+        maker.first_cfd().contract_symbol,
+        taker.first_cfd().contract_symbol
+    );
+
+    assert_ne!(maker.first_cfd().position, taker.first_cfd().position);
+
+    assert_eq!(
+        maker.first_cfd().closing_price.unwrap(),
+        initial_price_for(maker.first_cfd().contract_symbol),
+        "We use same dummy price for offers and quotes everywhere"
+    );
+
+    assert_maker_liquidation_price(maker);
+    assert_taker_liquidation_price(taker);
+}
+
+fn assert_maker_liquidation_price(maker: &mut Maker) {
+    assert_eq!(dummy_btc_price(), dec!(50_000), "precondition");
+    assert_eq!(dummy_eth_price(), dec!(1_500), "precondition");
+
+    let maker_position = maker.first_cfd().position;
+    let symbol = maker.first_cfd().contract_symbol;
+    let expected_liquidation_price = match (symbol, maker_position) {
+        // inverse payout curve
+        (ContractSymbol::BtcUsd, Position::Long) => dec!(25_000),
+        (ContractSymbol::BtcUsd, Position::Short) => dec!(21_000_000), // INFINITE
+        // quanto linear payout curve
+        (ContractSymbol::EthUsd, Position::Long) => dec!(1),
+        (ContractSymbol::EthUsd, Position::Short) => dec!(3_000),
+    };
+    assert_eq!(
+        maker.first_cfd().liquidation_price,
+        Price::new(expected_liquidation_price).unwrap()
+    );
+}
+
+fn assert_taker_liquidation_price(taker: &mut Taker) {
+    assert_eq!(dummy_btc_price(), dec!(50_000), "precondition");
+    assert_eq!(dummy_eth_price(), dec!(1_500), "precondition");
+
+    let taker_position = taker.first_cfd().position;
+    let symbol = taker.first_cfd().contract_symbol;
+    let expected_liquidation_price = match (symbol, taker_position) {
+        // inverse payout curve
+        (ContractSymbol::BtcUsd, Position::Long) => dec!(33333.333333333333333333333333),
+        (ContractSymbol::BtcUsd, Position::Short) => dec!(100_000),
+        // quanto linear payout curve
+        (ContractSymbol::EthUsd, Position::Long) => dec!(750),
+        (ContractSymbol::EthUsd, Position::Short) => dec!(2_250),
+    };
+    assert_eq!(
+        taker.first_cfd().liquidation_price,
+        Price::new(expected_liquidation_price).unwrap()
+    );
 }

--- a/daemon-tests/tests/main/collaborative_settlement.rs
+++ b/daemon-tests/tests/main/collaborative_settlement.rs
@@ -101,6 +101,7 @@ async fn collaboratively_close_an_open_cfd(
             position_maker,
             contract_symbol,
             oracle_data,
+            initial_price: initial_price_for(contract_symbol),
             ..Default::default()
         },
     )

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -94,7 +94,7 @@ impl str::FromStr for Contracts {
 pub struct Price(Decimal);
 
 impl Price {
-    const INFINITE: Price = Price(rust_decimal_macros::dec!(21_000_000));
+    pub const INFINITE: Price = Price(rust_decimal_macros::dec!(21_000_000));
 
     pub fn new(value: Decimal) -> Result<Self> {
         ensure!(value > Decimal::ZERO, "Non-positive price not supported");


### PR DESCRIPTION
Assert on:
- closing price,
- liquidation price
- position (maker and taker should have opposite positions)

Assert for closed CFDs for all possibilities of collab settlement tests (they
test both directions and both contract symbols).