### PR TITLE
fix: copy and paste error

### DIFF
--- a/daemon-tests/src/flow.rs
+++ b/daemon-tests/src/flow.rs
@@ -27,7 +27,7 @@ pub async fn next_maker_offers(
             ..
         } if contract_symbol == &ContractSymbol::BtcUsd => Some(offers),
         MakerOffers {
-            btcusd_long: Some(_),
+            btcusd_short: Some(_),
             ..
         } if contract_symbol == &ContractSymbol::BtcUsd => Some(offers),
         MakerOffers {
@@ -35,7 +35,7 @@ pub async fn next_maker_offers(
             ..
         } if contract_symbol == &ContractSymbol::EthUsd => Some(offers),
         MakerOffers {
-            ethusd_long: Some(_),
+            ethusd_short: Some(_),
             ..
         } if contract_symbol == &ContractSymbol::EthUsd => Some(offers),
         _ => None,


### PR DESCRIPTION
While going through the tests I found these replicated match clauses. This looks like a copy and paste error to me. I think one clause should be short respectively.