### PR TITLE
fix (model): funding rate > 1

### DIFF
--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -492,11 +492,6 @@ pub struct FundingRate(Decimal);
 
 impl FundingRate {
     pub fn new(rate: Decimal) -> Result<Self> {
-        ensure!(
-            rate.abs() <= Decimal::ONE,
-            "Funding rate can't be higher than 100%"
-        );
-
         Ok(Self(rate))
     }
 


### PR DESCRIPTION
There is no reason why a funding rate can't be greater than >100%

resolves #2806