### PR TITLE
Use actual liquidation price for open CFDs

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -1135,31 +1135,3 @@ pub async fn mock_quotes(maker: &mut Maker, taker: &mut Taker, contract_symbol: 
         .await
         .unwrap(); // if quote is available on feed, it propagated through the system
 }
-
-pub fn expected_taker_liquidation_price(
-    symbol: ContractSymbol,
-    taker_position: Position,
-) -> Decimal {
-    match (symbol, taker_position) {
-        // inverse payout curve
-        (ContractSymbol::BtcUsd, Position::Long) => dec!(33_333.333333333333333333333333),
-        (ContractSymbol::BtcUsd, Position::Short) => dec!(100_000),
-        // quanto linear payout curve
-        (ContractSymbol::EthUsd, Position::Long) => dec!(750),
-        (ContractSymbol::EthUsd, Position::Short) => dec!(2_250),
-    }
-}
-
-pub fn expected_maker_liquidation_price(
-    symbol: ContractSymbol,
-    maker_position: Position,
-) -> Decimal {
-    match (symbol, maker_position) {
-        // inverse payout curve
-        (ContractSymbol::BtcUsd, Position::Long) => dec!(25_000),
-        (ContractSymbol::BtcUsd, Position::Short) => dec!(21_000_000), // INFINITE
-        // quanto linear payout curve
-        (ContractSymbol::EthUsd, Position::Long) => dec!(1),
-        (ContractSymbol::EthUsd, Position::Short) => dec!(3_000),
-    }
-}

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -1136,26 +1136,30 @@ pub async fn mock_quotes(maker: &mut Maker, taker: &mut Taker, contract_symbol: 
         .unwrap(); // if quote is available on feed, it propagated through the system
 }
 
-pub fn expected_taker_liquidation_price(symbol: ContractSymbol, taker_position: Position) -> Price {
-    let expected_liquidation_price = match (symbol, taker_position) {
+pub fn expected_taker_liquidation_price(
+    symbol: ContractSymbol,
+    taker_position: Position,
+) -> Decimal {
+    match (symbol, taker_position) {
         // inverse payout curve
         (ContractSymbol::BtcUsd, Position::Long) => dec!(33_333.333333333333333333333333),
         (ContractSymbol::BtcUsd, Position::Short) => dec!(100_000),
         // quanto linear payout curve
         (ContractSymbol::EthUsd, Position::Long) => dec!(750),
         (ContractSymbol::EthUsd, Position::Short) => dec!(2_250),
-    };
-    Price::new(expected_liquidation_price).unwrap()
+    }
 }
 
-pub fn expected_maker_liquidation_price(symbol: ContractSymbol, maker_position: Position) -> Price {
-    let expected_liquidation_price = match (symbol, maker_position) {
+pub fn expected_maker_liquidation_price(
+    symbol: ContractSymbol,
+    maker_position: Position,
+) -> Decimal {
+    match (symbol, maker_position) {
         // inverse payout curve
         (ContractSymbol::BtcUsd, Position::Long) => dec!(25_000),
         (ContractSymbol::BtcUsd, Position::Short) => dec!(21_000_000), // INFINITE
         // quanto linear payout curve
         (ContractSymbol::EthUsd, Position::Long) => dec!(1),
         (ContractSymbol::EthUsd, Position::Short) => dec!(3_000),
-    };
-    Price::new(expected_liquidation_price).unwrap()
+    }
 }

--- a/daemon-tests/tests/main/collaborative_settlement.rs
+++ b/daemon-tests/tests/main/collaborative_settlement.rs
@@ -181,10 +181,10 @@ fn assert_taker_liquidation_price(taker: &mut Taker) {
 fn expected_taker_liquidation_price(symbol: ContractSymbol, taker_position: Position) -> Decimal {
     match (symbol, taker_position) {
         // inverse payout curve
-        (ContractSymbol::BtcUsd, Position::Long) => dec!(33_333.333333333333333333333333),
-        (ContractSymbol::BtcUsd, Position::Short) => dec!(100_000),
+        (ContractSymbol::BtcUsd, Position::Long) => dec!(32_767),
+        (ContractSymbol::BtcUsd, Position::Short) => dec!(99_620),
         // quanto linear payout curve
-        (ContractSymbol::EthUsd, Position::Long) => dec!(750),
+        (ContractSymbol::EthUsd, Position::Long) => dec!(511),
         (ContractSymbol::EthUsd, Position::Short) => dec!(2_250),
     }
 }
@@ -194,8 +194,8 @@ fn expected_taker_liquidation_price(symbol: ContractSymbol, taker_position: Posi
 fn expected_maker_liquidation_price(symbol: ContractSymbol, maker_position: Position) -> Decimal {
     match (symbol, maker_position) {
         // inverse payout curve
-        (ContractSymbol::BtcUsd, Position::Long) => dec!(25_000),
-        (ContractSymbol::BtcUsd, Position::Short) => dec!(21_000_000), // INFINITE
+        (ContractSymbol::BtcUsd, Position::Long) => dec!(16_383),
+        (ContractSymbol::BtcUsd, Position::Short) => dec!(99_751),
         // quanto linear payout curve
         (ContractSymbol::EthUsd, Position::Long) => dec!(1),
         (ContractSymbol::EthUsd, Position::Short) => dec!(3_000),

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -151,7 +151,7 @@ pub struct Cfd {
     pub contract_symbol: ContractSymbol,
     pub position: Position,
     #[serde(with = "round_to_two_dp")]
-    pub liquidation_price: Price,
+    pub liquidation_price: Decimal,
 
     #[serde(with = "round_to_two_dp")]
     pub quantity: Contracts,
@@ -1324,7 +1324,7 @@ pub struct LeverageDetails {
     pub leverage: Leverage,
     /// Own liquidation price according to position and leverage
     #[serde(with = "round_to_two_dp")]
-    pub liquidation_price: Price,
+    pub liquidation_price: Decimal,
     /// Margin per lot from the perspective of the role
     ///
     /// Since this is a calculated value that we need in the UI this value is based on the

--- a/daemon/src/projection.rs
+++ b/daemon/src/projection.rs
@@ -350,6 +350,8 @@ impl Cfd {
             counterparty_leverage,
         );
 
+        // This value will be updated as we apply `{ContractSetup,Rollover}Completed` events to the
+        // `Cfd`
         let liquidation_price = match position {
             Position::Long => {
                 calculate_long_liquidation_price(initial_price, our_leverage, contract_symbol)
@@ -428,6 +430,12 @@ impl Cfd {
             }
             ContractSetupCompleted { dlc } => {
                 self.expiry_timestamp = dlc.as_ref().map(|dlc| dlc.settlement_event_id.timestamp());
+
+                if let Some(dlc) = &dlc {
+                    self.liquidation_price =
+                        Decimal::from(dlc.liquidation_price(self.role, self.position));
+                }
+
                 self.aggregated.latest_dlc = dlc;
 
                 self.aggregated.state = CfdState::PendingOpen;
@@ -444,6 +452,12 @@ impl Cfd {
                 complete_fee,
             } => {
                 self.expiry_timestamp = dlc.as_ref().map(|dlc| dlc.settlement_event_id.timestamp());
+
+                if let Some(dlc) = &dlc {
+                    self.liquidation_price =
+                        Decimal::from(dlc.liquidation_price(self.role, self.position));
+                }
+
                 self.aggregated.latest_dlc = dlc;
 
                 self.aggregated.fee_account = match complete_fee {
@@ -1886,7 +1900,21 @@ mod tests {
                 .load_closed_cfd::<Cfd>(order_id, bdk::bitcoin::Network::Testnet)
                 .await
                 .unwrap();
-            projection_closed.with_current_quote(None) // unconditional processing in `projection`
+            let mut projection_closed = projection_closed.with_current_quote(None); // unconditional processing in `projection`
+
+            // We expect these liquidation prices to differ, because they are calculated to
+            // different level of precision depending on whether the CFD is open, closed or failed
+            assert_ne!(
+                projection_closed.liquidation_price,
+                projection_open.liquidation_price
+            );
+
+            // We set the liquidation prices to be equal to ensure that when we compare CFDs we
+            // effectively don't take into account the liquidation price, because it will always be
+            // different
+            projection_closed.liquidation_price = projection_open.liquidation_price;
+
+            projection_closed
         };
 
         // this comparison actually omits the `aggregated` field on

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -1858,10 +1858,10 @@ pub fn calculate_long_liquidation_price(
     initial_price: Price,
     leverage: Leverage,
     contract_symbol: ContractSymbol,
-) -> Price {
+) -> Decimal {
     match contract_symbol {
         ContractSymbol::BtcUsd => {
-            inverse::calculate_long_liquidation_price(leverage, initial_price)
+            inverse::calculate_long_liquidation_price(leverage, initial_price).into_decimal()
         }
         ContractSymbol::EthUsd => {
             let initial_price = initial_price.to_u64();
@@ -1869,14 +1869,7 @@ pub fn calculate_long_liquidation_price(
             let liquidation_price =
                 quanto::bankruptcy_price_long(initial_price, leverage.as_decimal());
 
-            // The `model::Price` type does not allow non-positive values, but the quanto long
-            // liquidation price can easily be 0. We avoid this problem by defaulting to 1
-            if liquidation_price == 0 {
-                Price::new(Decimal::ONE).expect("one to be valid price")
-            } else {
-                Price::new(Decimal::from(liquidation_price))
-                    .expect("liquidation price to fit into Price")
-            }
+            Decimal::from(liquidation_price)
         }
     }
 }
@@ -1886,10 +1879,10 @@ pub fn calculate_short_liquidation_price(
     initial_price: Price,
     leverage: Leverage,
     contract_symbol: ContractSymbol,
-) -> Price {
+) -> Decimal {
     match contract_symbol {
         ContractSymbol::BtcUsd => {
-            inverse::calculate_short_liquidation_price(leverage, initial_price)
+            inverse::calculate_short_liquidation_price(leverage, initial_price).into_decimal()
         }
         ContractSymbol::EthUsd => {
             let initial_price = initial_price.to_u64();
@@ -1897,8 +1890,7 @@ pub fn calculate_short_liquidation_price(
             let liquidation_price =
                 quanto::bankruptcy_price_short(initial_price, leverage.as_decimal());
 
-            Price::new(Decimal::from(liquidation_price))
-                .expect("liquidation price to fit into Price")
+            Decimal::from(liquidation_price)
         }
     }
 }


### PR DESCRIPTION
I propose to do something like this to deal with https://github.com/itchysats/itchysats/issues/2809. Eventually we may just want to store this information directly, particularly for closed and failed CFDs.

---

We can deduce the liquidation prices for open CFDs by looking at the stored CETs, as soon as we have them (after we apply `{ContractSetup, Rollover}Completed` events.

This is only possible for open CFDs, because they are the only ones that have access to this information (unlike offers, closed CFDs and failed CFDs). Having correct liquidation prices also matters a lot more for open CFDs, as the user can actually use this information to make decisions.