### PR TITLE
Do not overwrite inverse payout curve liquidation bound

### DIFF
--- a/model/src/payout_curve.rs
+++ b/model/src/payout_curve.rs
@@ -109,7 +109,7 @@ impl Payouts {
         n_payouts: usize,
         fee: CompleteFee,
     ) -> Result<Self> {
-        let mut payouts = payout_curve::inverse::calculate(
+        let payouts = payout_curve::inverse::calculate(
             price,
             quantity,
             leverage_long,
@@ -117,15 +117,6 @@ impl Payouts {
             n_payouts,
             fee,
         )?;
-
-        // Overwrite the short liquidation upper bound with the maximum price that Olivia can attest
-        // to
-        {
-            let n_payouts = payouts.len() - 1;
-            let short_liquidation = payouts.get_mut(n_payouts).expect("several payouts");
-            short_liquidation.range =
-                *short_liquidation.range.start()..=maia_core::interval::MAX_PRICE_DEC;
-        }
 
         let settlement: Vec<_> = match (position, role) {
             (Position::Long, Role::Taker) | (Position::Short, Role::Maker) => payouts


### PR DESCRIPTION
Unfixes https://github.com/itchysats/itchysats/issues/2571 😛 

---

This reverts 2298059164d39ea744b708e6f54dcee46ab96037. Whilst this fixed https://github.com/itchysats/itchysats/issues/2571, it also meant that takers without this fix would not be able to perform contract setup and rollover with a maker with this fix.

We will very likely introduce an equivalent fix in the future, but it cannot be safely introduced without changing `/itchysats/order/1.0.0` or introducing a new version altogether.