### PR TITLE
Only send BTCUSD offers via `/itchysats/offer/1.0.0`

### DIFF
--- a/maker/src/cfd.rs
+++ b/maker/src/cfd.rs
@@ -273,12 +273,21 @@ impl Actor {
             tracing::warn!("{e:#}");
         }
 
-        if let Err(e) = self
-            .libp2p_offer_deprecated
-            .send_async_safe(xtra_libp2p_offer::deprecated::maker::NewOffers::new(offers))
-            .await
         {
-            tracing::warn!("{e:#}");
+            let btcusd_offers = offers
+                .into_iter()
+                .filter(|offer| offer.contract_symbol == ContractSymbol::BtcUsd)
+                .collect();
+
+            if let Err(e) = self
+                .libp2p_offer_deprecated
+                .send_async_safe(xtra_libp2p_offer::deprecated::maker::NewOffers::new(
+                    btcusd_offers,
+                ))
+                .await
+            {
+                tracing::warn!("{e:#}");
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Fixes https://github.com/itchysats/itchysats/issues/2817 (maybe).

The taker listening for `/itchysats/offer/1.0.0` can only handle BTCUSD offers, so anything else leads us to "undefined" behaviour.