### PR TITLE
Forbid sending empty offers via `/itchysats/offer/1.0.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,6 +2101,7 @@ dependencies = [
  "maia 0.2.0",
  "maia-core",
  "model",
+ "nonempty",
  "prometheus",
  "quiet-spans",
  "rocket",
@@ -2524,6 +2525,12 @@ dependencies = [
  "minimal-lexical",
  "version_check",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f1f8e5676e1a1f2ee8b21f38238e1243c827531c9435624c7bfb305102cee4"
 
 [[package]]
 name = "normalize-line-endings"
@@ -5700,6 +5707,7 @@ dependencies = [
  "conquer-once",
  "futures",
  "model",
+ "nonempty",
  "prometheus",
  "quiet-spans",
  "rust_decimal",

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -18,6 +18,7 @@ libp2p-tcp = { version = "0.33", default-features = false, features = ["tokio"] 
 maia = "0.2.0"
 maia-core = "0.1.1"
 model = { path = "../model" }
+nonempty = { version = "0.8.0", default-features = false }
 prometheus = { version = "0.13", default-features = false }
 quiet-spans = { path = "../quiet-spans" }
 rocket = { version = "0.5.0-rc.2", features = ["json", "uuid"] }

--- a/xtra-libp2p-offer/Cargo.toml
+++ b/xtra-libp2p-offer/Cargo.toml
@@ -11,6 +11,7 @@ asynchronous-codec = { version = "0.6.0", features = ["json"] }
 conquer-once = "0.3.2"
 futures = { version = "0.3", default-features = false }
 model = { path = "../model" }
+nonempty = { version = "0.8.0", default-features = false }
 prometheus = { version = "0.13", default-features = false }
 quiet-spans = { path = "../quiet-spans" }
 serde = { version = "1", features = ["derive"] }

--- a/xtra-libp2p-offer/src/deprecated/maker.rs
+++ b/xtra-libp2p-offer/src/deprecated/maker.rs
@@ -2,6 +2,7 @@ use crate::deprecated;
 use crate::deprecated::protocol;
 use crate::deprecated::protocol::MakerOffers;
 use async_trait::async_trait;
+use nonempty::NonEmpty;
 use std::collections::HashSet;
 use std::time::Duration;
 use tokio_extras::spawn_fallible;
@@ -102,10 +103,10 @@ impl Actor {
 
 /// Instruct the `offer::maker::Actor` to broadcast to all
 /// connected peers an update to the current offers.
-pub struct NewOffers(Vec<model::Offer>);
+pub struct NewOffers(NonEmpty<model::Offer>);
 
 impl NewOffers {
-    pub fn new(offers: Vec<model::Offer>) -> Self {
+    pub fn new(offers: NonEmpty<model::Offer>) -> Self {
         Self(offers)
     }
 }

--- a/xtra-libp2p-offer/src/deprecated/protocol.rs
+++ b/xtra-libp2p-offer/src/deprecated/protocol.rs
@@ -15,6 +15,7 @@ use model::Position;
 use model::Price;
 use model::Timestamp;
 use model::TxFeeRate;
+use nonempty::NonEmpty;
 use serde::Deserialize;
 use serde::Serialize;
 use time::Duration;
@@ -85,10 +86,10 @@ impl From<model::Offer> for Offer {
 }
 
 impl MakerOffers {
-    pub(crate) fn new(offers: Vec<model::Offer>) -> Option<Self> {
+    pub(crate) fn new(offers: NonEmpty<model::Offer>) -> Option<Self> {
         // We can safely assume that the new offers all have the same `tx_fee_rate`, because this
         // field is redundant across offers
-        let tx_fee_rate = offers.first()?.tx_fee_rate;
+        let tx_fee_rate = offers.first().tx_fee_rate;
 
         // This version of the protocol caters to takers that only support BTCUSD CFDs
         let mut offers = offers


### PR DESCRIPTION
Fix https://github.com/itchysats/itchysats/issues/2817 (definitely).

By leveraging the `nonempty::NonEmpty` type we can use the type system to ensure that we will never send empty offers to takers via `/itchysats/offer/1.0.0`.

The problem with sending a `MakerOffers` with `None` values for `long` and/or `short` is that takers will interpret this as an instruction to delete their local offer state. That is something that we no longer want to trigger from the maker's perspective.

In particular, this patch fixes a bug where any `taker:<=0.5.5` was deleting its local offer state every time the maker was trying to send ETHUSD offers via the `/itchysats/offer/2.0.0` protocol. This was precisely because we were filtering out all ETHUSD offers derived from the `OfferParams`, resulting in an empty list of offers.