### PR TITLE
Stop emitting errors if we cannot auto-rollover an empty CFD

### DIFF
--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -278,6 +278,8 @@ pub enum CannotRollover {
     InCollaborativeSettlement,
     #[error("Cannot roll over when CFD is already closed")]
     Closed,
+    #[error("Cannot rollover CFD without events")]
+    NoEvents,
 }
 
 /// Reasons why we cannot collab close a CFD
@@ -730,6 +732,10 @@ impl Cfd {
 
         if self.is_in_force_close() {
             return Err(CannotRollover::Committed);
+        }
+
+        if self.version == 0 {
+            return Err(CannotRollover::NoEvents);
         }
 
         // Rollover and collaborative settlement are mutually exclusive, if we are currently


### PR DESCRIPTION
By empty CFD we mean a CFD without any events associated with it. This can happen if the CFD is inserted into the database, but placing the order actually fails.

These CFDs are currently not cleaned up from the database, so their presence causes error log spamming when failing to auto-rollover on the taker side. Since these error logs are false positives (there's nothing dangerous about not being able to rollover an empty CFD), we opt to suppress them.

The strategy followed is to emit a different kind of error as a reason for not being able to roll over a CFD: a `CannotRollover::NoEvents` error. Since the `auto_rollover::Actor` only logs errors about `CannotRollover::NoDlc`, we no longer see error logs associated with not being to auto-rollover empty CFDs.