### PR TITLE
Run CI tests in release mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Compile tests before running
-        run: cargo test --workspace --no-run
+        run: cargo test --release --workspace --no-run
       - name: Test execution
         run: cargo nextest run --profile ci
 


### PR DESCRIPTION
It takes a bit longer to compile, but the execution should be much faster,
bringing in an overall improvement.