### PR TITLE
Use a local subscriber in xtra-libp2p-{offer,ping} tests

### DIFF
--- a/xtra-libp2p-offer/src/lib.rs
+++ b/xtra-libp2p-offer/src/lib.rs
@@ -23,6 +23,7 @@ mod tests {
     use rust_decimal_macros::dec;
     use std::time::Duration;
     use time::macros::datetime;
+    use tracing_subscriber::util::SubscriberInitExt;
     use xtra::spawn::TokioGlobalSpawnExt;
     use xtra::Actor as _;
     use xtra::Address;
@@ -40,10 +41,10 @@ mod tests {
 
     #[tokio::test]
     async fn given_new_offers_then_received_offers_match_originals() {
-        tracing_subscriber::fmt()
+        let _g = tracing_subscriber::fmt()
             .with_env_filter("xtra_libp2p_offer=trace")
             .with_test_writer()
-            .init();
+            .set_default();
 
         let (maker_peer_id, maker_offer_addr, maker_endpoint_addr) =
             create_endpoint_with_offer_maker();
@@ -95,10 +96,10 @@ mod tests {
 
     #[tokio::test]
     async fn given_taker_connects_then_taker_receives_all_current_offers() {
-        tracing_subscriber::fmt()
+        let _g = tracing_subscriber::fmt()
             .with_env_filter("xtra_libp2p_offer=trace")
             .with_test_writer()
-            .init();
+            .set_default();
 
         let (maker_peer_id, maker_offer_addr, maker_endpoint_addr) =
             create_endpoint_with_offer_maker();

--- a/xtra-libp2p-ping/src/lib.rs
+++ b/xtra-libp2p-ping/src/lib.rs
@@ -13,6 +13,7 @@ mod tests {
     use futures::Future;
     use futures::FutureExt;
     use std::time::Duration;
+    use tracing_subscriber::util::SubscriberInitExt;
     use xtra::spawn::TokioGlobalSpawnExt;
     use xtra::Actor as _;
     use xtra::Address;
@@ -29,10 +30,10 @@ mod tests {
 
     #[tokio::test]
     async fn latency_to_peer_is_recorded() {
-        tracing_subscriber::fmt()
+        let _g = tracing_subscriber::fmt()
             .with_env_filter("xtra_libp2p_ping=trace")
             .with_test_writer()
-            .init();
+            .set_default();
 
         let (alice_peer_id, alice_ping_actor, alice_endpoint) = create_endpoint_with_ping();
         let (bob_peer_id, bob_ping_actor, bob_endpoint) = create_endpoint_with_ping();


### PR DESCRIPTION
This prevents panics in the case of multiple tests all trying to set the global subscriber. Fixes #2815.