### PR TITLE
Supply a config file with otel-tests tracing directives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,7 +2737,9 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "otel-tests-macro",
+ "serde",
  "tokio",
+ "toml",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -4827,9 +4829,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]

--- a/daemon-tests/otel-tests.toml
+++ b/daemon-tests/otel-tests.toml
@@ -1,0 +1,11 @@
+directives = [
+  "wire=trace",
+  "taker=debug",
+  "maker=debug",
+  "daemon=debug",
+  "model=info",
+  "xtra_libp2p=debug",
+  "xtra_libp2p_offer=debug",
+  "xtra_libp2p_ping=debug",
+  "rocket=warn",
+]

--- a/otel-tests/Cargo.toml
+++ b/otel-tests/Cargo.toml
@@ -9,7 +9,9 @@ futures = "0.3"
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"], optional = true }
 opentelemetry-otlp = { version = "0.10.0", features = ["grpc-sys", "trace"], optional = true }
 otel-tests-macro = { path = "../otel-tests-macro" }
+serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros"] }
+toml = { version = "0.5.9", default-features = false }
 tracing = "0.1"
 tracing-opentelemetry = "0.17.4"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter", "local-time", "tracing-log", "json"] }


### PR DESCRIPTION
Removes the need for the crate to know about other crates that are set further
down the dependency chain and allows for extracting this generic crate out of
the itchysats workspace.

New `otel-tests.toml` file needs to be located in the directory of the crate
using `otel-tests` macro for tests.

In case the file is not present or it is malformed, an otel-test will fail to compile.

This paves the way to #2822