### PR TITLE
feat(daemon-tests): Log CFD state inside wait_state macro

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -204,6 +204,8 @@ macro_rules! wait_next_state {
         );
         assert_eq!(taker_cfd.order_id, $id, "unexpected order id in the taker");
         assert_eq!(maker_cfd.order_id, $id, "unexpected order id in the maker");
+        tracing::info!(?maker_cfd.state, "Current maker CFD state");
+        tracing::info!(?taker_cfd.state, "Current taker CFD state");
     };
     ($id:expr, $maker:expr, $taker:expr, $state:expr) => {
         wait_next_state!($id, $maker, $taker, $state, $state)


### PR DESCRIPTION
Allows for easier debuggability during test failures and provides more context
to test execution.

Without this, when the test failes due to unsatisfied predicate, we don't know what state the Cfd actually was.