### PR TITLE
Hide percentage PnL behind tooltip

### DIFF
--- a/taker-frontend/src/components/BitcoinAmount.tsx
+++ b/taker-frontend/src/components/BitcoinAmount.tsx
@@ -1,17 +1,20 @@
-import { Skeleton, Text } from "@chakra-ui/react";
+import { forwardRef, Skeleton, Text, TextProps } from "@chakra-ui/react";
 import * as React from "react";
 
-interface Props {
+interface Props extends TextProps {
     btc: number;
 }
 
 /// Displays a BTC value with a fixed precision of 8, also prepending the Bitcoin symbol in front of it.
-export default function BitcoinAmount({ btc }: Props) {
-    const formatted = btc.toFixed(8);
-
+const BitcoinAmount = forwardRef<Props, "div">((props, ref) => {
+    const formatted = props.btc.toFixed(8);
     return (
-        <Skeleton isLoaded={Number.isFinite(btc)}>
-            <Text>₿{formatted}</Text>
+        <Skeleton isLoaded={Number.isFinite(props.btc)}>
+            <Text ref={ref} {...props}>
+                ₿{formatted}
+            </Text>
         </Skeleton>
     );
-}
+});
+
+export default BitcoinAmount;

--- a/taker-frontend/src/components/History.tsx
+++ b/taker-frontend/src/components/History.tsx
@@ -170,12 +170,14 @@ const CfdDetails = ({ cfd, connectedToMaker, displayCloseButton, showExtraInfo }
                                     <Text as={"b"}>{profitLabel}</Text>
                                 </Td>
                                 <Td textAlign="right">
-                                    <Tooltip label={`${cfd.profit_btc}`} placement={"right"}>
-                                        <Skeleton isLoaded={cfd.profit_btc != null}>
-                                            {(cfd.profit_percent && cfd.profit_percent > 0) ? "+" : ""}
-                                            {cfd.profit_percent}%
-                                        </Skeleton>
-                                    </Tooltip>
+                                    <Skeleton isLoaded={cfd.profit_btc != null}>
+                                        <Tooltip label={`${cfd.profit_btc}`} placement={"right"}>
+                                            <Text>
+                                                {(cfd.profit_percent && cfd.profit_percent > 0) ? "+" : ""}
+                                                {cfd.profit_percent} %
+                                            </Text>
+                                        </Tooltip>
+                                    </Skeleton>
                                 </Td>
                             </Tr>
                             <Tr textColor={useColorModeValue(profitColors.light, profitColors.dark)}>

--- a/taker-frontend/src/components/History.tsx
+++ b/taker-frontend/src/components/History.tsx
@@ -185,9 +185,7 @@ const CfdDetails = ({ cfd, connectedToMaker, displayCloseButton, showExtraInfo }
                                     <Text as={"b"}>Payout</Text>
                                 </Td>
                                 <Td textAlign="right">
-                                    <Skeleton isLoaded={cfd.payout != null}>
-                                        <BitcoinAmount btc={cfd.payout ? cfd.payout : 0} />
-                                    </Skeleton>
+                                    <BitcoinAmount btc={cfd.payout ? cfd.payout : 0} />
                                 </Td>
                             </Tr>
                             <Tr>

--- a/taker-frontend/src/components/History.tsx
+++ b/taker-frontend/src/components/History.tsx
@@ -171,11 +171,18 @@ const CfdDetails = ({ cfd, connectedToMaker, displayCloseButton, showExtraInfo }
                                 </Td>
                                 <Td textAlign="right">
                                     <Skeleton isLoaded={cfd.profit_btc != null}>
-                                        <Tooltip label={`${cfd.profit_btc}`} placement={"right"}>
-                                            <Text>
-                                                {(cfd.profit_percent && cfd.profit_percent > 0) ? "+" : ""}
-                                                {cfd.profit_percent} %
-                                            </Text>
+                                        <Tooltip
+                                            label={
+                                                <Text>
+                                                    {(cfd.profit_percent && cfd.profit_percent > 0)
+                                                        ? "+"
+                                                        : ""}
+                                                    {cfd.profit_percent} %
+                                                </Text>
+                                            }
+                                            placement={"right"}
+                                        >
+                                            <BitcoinAmount btc={cfd.profit_btc ? cfd.profit_btc : 0} />
                                         </Tooltip>
                                     </Skeleton>
                                 </Td>


### PR DESCRIPTION
Might result in better experience. 

Looks like this: 

<img width="546" alt="image" src="https://user-images.githubusercontent.com/224613/188041717-76d3fbaf-ade7-4bf6-82f6-ba5936c8b2b1.png">

What do you think?