### PR TITLE
Add the capability to block peers through a configurable blocklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `/itchysats/rollover/3.0.0`. This fixes a bug where inverse payout curves where capped at double the value of the initial price.
 - Support for `/itchysats/collab-settlement/2.0.0`. This fixes a bug where inverse payout curves where capped at double the value of the initial price.
 - Support for `/itchysats/order/2.0.0`. This fixes a bug where inverse payout curves where capped at double the value of the initial price.
+- Configurable peer id block list. Peer IDs can be added to `blocked_peers.toml`, stored in the data directory. The
+  format is expected to be a simple TOML array of peer ID strings.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,6 +2135,7 @@ dependencies = [
  "tokio",
  "tokio-extras",
  "tokio-util 0.7.4",
+ "toml",
  "tracing",
  "uuid 1.1.2",
  "vergen-version",

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -53,6 +53,7 @@ use model::TxFeeRate;
 use model::SETTLEMENT_INTERVAL;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
+use std::collections::HashSet;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
@@ -557,12 +558,13 @@ pub async fn start_both() -> (Maker, Taker) {
     (maker, taker)
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct MakerConfig {
     oracle_pk: XOnlyPublicKey,
     seed: RandomSeed,
     n_payouts: usize,
     libp2p_port: u16,
+    blocked_peers: HashSet<xtra_libp2p::libp2p::PeerId>,
 }
 
 impl Default for MakerConfig {
@@ -572,6 +574,7 @@ impl Default for MakerConfig {
             seed: RandomSeed::default(),
             n_payouts: N_PAYOUTS,
             libp2p_port: portpicker::pick_unused_port().expect("to be able to find a free port"),
+            blocked_peers: HashSet::new(),
         }
     }
 }
@@ -705,6 +708,7 @@ impl Maker {
             projection_actor,
             identities.clone(),
             endpoint_listen.clone(),
+            config.blocked_peers.clone(), // TODO(restioson): test
         )
         .unwrap();
 

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -708,7 +708,7 @@ impl Maker {
             projection_actor,
             identities.clone(),
             endpoint_listen.clone(),
-            config.blocked_peers.clone(), // TODO(restioson): test
+            config.blocked_peers.clone(),
         )
         .unwrap();
 

--- a/daemon/src/identify.rs
+++ b/daemon/src/identify.rs
@@ -44,6 +44,7 @@ mod tests {
     use crate::Environment;
     use libp2p_core::PublicKey;
     use std::collections::HashSet;
+    use std::sync::Arc;
     use std::time::Duration;
     use tokio::sync::watch;
     use xtra::spawn::TokioGlobalSpawnExt;
@@ -151,6 +152,7 @@ mod tests {
                 vec![],
                 vec![],
             ),
+            Arc::new(HashSet::default()),
         );
 
         #[allow(clippy::disallowed_methods)]

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -31,6 +31,7 @@ use ping_pong::ping;
 use ping_pong::pong;
 use seed::Identities;
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 use time::ext::NumericalDuration;
 use tokio::sync::watch;
@@ -318,6 +319,7 @@ where
                 vec![],
                 vec![],
             ),
+            Arc::new(HashSet::default()), // Taker does not block peers
         );
 
         tasks.add(endpoint_context.run(endpoint));

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -38,6 +38,7 @@ time = { version = "0.3.14", features = ["serde", "macros", "parsing", "formatti
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "tracing"] }
 tokio-extras = { path = "../tokio-extras", features = ["xtra"] }
 tokio-util = { version = "0.7", features = ["codec"] }
+toml = "0.5.9"
 tracing = { version = "0.1" }
 uuid = "1.1"
 vergen-version = { path = "../vergen-version" }

--- a/maker/src/actor_system.rs
+++ b/maker/src/actor_system.rs
@@ -38,6 +38,7 @@ use model::TxFeeRate;
 use ping_pong::ping;
 use ping_pong::pong;
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio_extras::Tasks;
 use xtra::Actor;
@@ -46,6 +47,7 @@ use xtra::Context;
 use xtra::Handler;
 use xtra_libp2p::endpoint;
 use xtra_libp2p::libp2p::Multiaddr;
+use xtra_libp2p::libp2p::PeerId;
 use xtra_libp2p::listener;
 use xtra_libp2p::Endpoint;
 use xtras::supervisor::always_restart_after;
@@ -103,6 +105,7 @@ where
         projection_actor: Address<projection::Actor>,
         identity: Identities,
         listen_multiaddr: Multiaddr,
+        blocked_peers: HashSet<PeerId>,
     ) -> Result<Self>
     where
         M: Handler<monitor::MonitorAfterContractSetup, Return = ()>
@@ -319,6 +322,7 @@ where
                 vec![],
                 vec![listener_actor.into()],
             ),
+            Arc::new(blocked_peers),
         );
 
         tasks.add(endpoint_context.run(endpoint));

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -18,12 +18,16 @@ use model::olivia;
 use model::Role;
 use model::SETTLEMENT_INTERVAL;
 use rocket_cookie_auth::users::Users;
+use serde::Deserialize;
 use shared_bin::catchers::default_catchers;
 use shared_bin::cli::Withdraw;
 use shared_bin::fairings;
 use shared_bin::logger;
+use std::collections::HashSet;
 use std::net::SocketAddr;
+use std::path::Path;
 use tokio_extras::Tasks;
+use xtra_libp2p::libp2p::PeerId;
 use xtras::supervisor::always_restart;
 use xtras::supervisor::Supervisor;
 
@@ -117,6 +121,19 @@ async fn main() -> Result<()> {
     let db =
         sqlite_db::connect(data_dir.join("maker.sqlite"), opts.ignore_migration_errors).await?;
 
+    let blocked_peers_path = data_dir.join("blocked_peers.toml");
+    let blocked_peers = load_blocked_peers(&blocked_peers_path)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::error!(
+                ?blocked_peers_path,
+                %err,
+                "Error loading blocked peers list; ignoring and allowing all connections",
+            );
+            HashSet::default()
+        });
+
+    // Create actors
     let endpoint_listen =
         daemon::libp2p_utils::create_listen_tcp_multiaddr(&p2p_socket.ip(), p2p_socket.port())
             .expect("to parse properly");
@@ -161,6 +178,7 @@ async fn main() -> Result<()> {
         projection_actor.clone(),
         identities,
         endpoint_listen,
+        blocked_peers,
     )?;
 
     if let Some(password) = opts.password {
@@ -240,4 +258,19 @@ impl rocket_cookie_auth::Database for RocketAuthDbConnection {
         self.inner.clone().update_password(password).await?;
         Ok(())
     }
+}
+
+/// Convenience type to load the blocked peer list from toml
+#[derive(Deserialize)]
+struct BlockedPeers {
+    blocked: HashSet<PeerId>,
+}
+
+async fn load_blocked_peers(blocked_peers_path: &Path) -> Result<HashSet<PeerId>> {
+    anyhow::ensure!(
+        blocked_peers_path.try_exists()?,
+        "No blocked peers file found in {blocked_peers_path:?}",
+    );
+    let raw = tokio::fs::read_to_string(blocked_peers_path).await?;
+    Ok(toml::from_str::<BlockedPeers>(&raw)?.blocked)
 }

--- a/xtra-libp2p-offer/src/lib.rs
+++ b/xtra-libp2p-offer/src/lib.rs
@@ -21,6 +21,8 @@ mod tests {
     use model::TxFeeRate;
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
+    use std::collections::HashSet;
+    use std::sync::Arc;
     use std::time::Duration;
     use time::macros::datetime;
     use tracing_subscriber::util::SubscriberInitExt;
@@ -169,6 +171,7 @@ mod tests {
                 vec![],
                 vec![],
             ),
+            Arc::new(HashSet::default()),
         );
 
         #[allow(clippy::disallowed_methods)]
@@ -190,6 +193,7 @@ mod tests {
             Duration::from_secs(10),
             [(PROTOCOL, offer_taker_addr.into())],
             Subscribers::default(),
+            Arc::new(HashSet::default()),
         )
         .create(None)
         .spawn_global();

--- a/xtra-libp2p-ping/src/lib.rs
+++ b/xtra-libp2p-ping/src/lib.rs
@@ -12,6 +12,8 @@ mod tests {
     use super::*;
     use futures::Future;
     use futures::FutureExt;
+    use std::collections::HashSet;
+    use std::sync::Arc;
     use std::time::Duration;
     use tracing_subscriber::util::SubscriberInitExt;
     use xtra::spawn::TokioGlobalSpawnExt;
@@ -101,6 +103,7 @@ mod tests {
                 vec![],
                 vec![],
             ),
+            Arc::new(HashSet::default()),
         );
 
         #[allow(clippy::disallowed_methods)]

--- a/xtra-libp2p/examples/hello_world_dialer.rs
+++ b/xtra-libp2p/examples/hello_world_dialer.rs
@@ -8,6 +8,8 @@ use libp2p_core::identity::Keypair;
 use libp2p_core::Multiaddr;
 use libp2p_core::PeerId;
 use libp2p_tcp::TokioTcpConfig;
+use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 use xtra::prelude::*;
 use xtra::spawn::TokioGlobalSpawnExt;
@@ -41,6 +43,7 @@ async fn main() -> Result<()> {
         Duration::from_secs(20),
         [],
         Subscribers::default(),
+        Arc::new(HashSet::default()),
     )
     .create(None)
     .spawn_global();

--- a/xtra-libp2p/examples/hello_world_listener.rs
+++ b/xtra-libp2p/examples/hello_world_listener.rs
@@ -7,6 +7,8 @@ use futures::StreamExt;
 use libp2p_core::identity::Keypair;
 use libp2p_core::Multiaddr;
 use libp2p_tcp::TokioTcpConfig;
+use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::Level;
 use xtra::prelude::*;
@@ -56,6 +58,7 @@ async fn main() -> Result<()> {
         Duration::from_secs(30),
         [("/hello-world/1.0.0", hello_world_addr.clone().into())],
         Subscribers::default(),
+        Arc::new(HashSet::default()),
     )
     .create(None)
     .spawn_global();

--- a/xtra-libp2p/tests/load.rs
+++ b/xtra-libp2p/tests/load.rs
@@ -9,6 +9,8 @@ use futures::StreamExt;
 use libp2p_core::identity::Keypair;
 use libp2p_core::transport::MemoryTransport;
 use libp2p_core::Multiaddr;
+use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -157,6 +159,7 @@ async fn test_runner<
                     vec![subscriber_stats.clone().into()],
                     vec![subscriber_stats.clone().into()],
                 ),
+                Arc::new(HashSet::default()),
             );
 
             #[allow(clippy::disallowed_methods)]

--- a/xtra-libp2p/tests/util.rs
+++ b/xtra-libp2p/tests/util.rs
@@ -27,6 +27,13 @@ pub struct Node {
 pub fn make_node<const N: usize>(
     substream_handlers: [(&'static str, MessageChannel<NewInboundSubstream, ()>); N],
 ) -> Node {
+    make_node_with_blocklist(substream_handlers, Arc::new(HashSet::new()))
+}
+
+pub fn make_node_with_blocklist<const N: usize>(
+    substream_handlers: [(&'static str, MessageChannel<NewInboundSubstream, ()>); N],
+    blocked_peers: Arc<HashSet<PeerId>>,
+) -> Node {
     let id = Keypair::generate_ed25519();
     let peer_id = id.public().to_peer_id();
 
@@ -45,7 +52,7 @@ pub fn make_node<const N: usize>(
             vec![subscriber_stats.clone().into()],
             vec![subscriber_stats.clone().into()],
         ),
-        Arc::new(HashSet::default()),
+        blocked_peers,
     )
     .create(None)
     .spawn_global();

--- a/xtra-libp2p/tests/util.rs
+++ b/xtra-libp2p/tests/util.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use libp2p_core::Multiaddr;
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 use xtra::message_channel::MessageChannel;
 use xtra::spawn::TokioGlobalSpawnExt;
@@ -44,6 +45,7 @@ pub fn make_node<const N: usize>(
             vec![subscriber_stats.clone().into()],
             vec![subscriber_stats.clone().into()],
         ),
+        Arc::new(HashSet::default()),
     )
     .create(None)
     .spawn_global();


### PR DESCRIPTION
Fixes #2527. I have not currently included documentation on this feature as I was not 100% on where to put it. I am happy to write some docs for this once someone can tell me where to write it :sweat_smile: It currently is just a simple plaintext list with each peer id on a new line, stored in `[data_dir]/blocked_peers`.

This does not address IP blacklisting. Peers which do not specify their peer ID in their multiaddr will only be blocked after the libp2p connection is upgraded, which could result in `DEBUG libp2p_core::upgrade::apply: Successfully applied negotiated protocol` messages being logged. I am not sure if this is relevant as it could just be disabled on mainnet.

Currently, blocked peers are logged with their peer id each time they are blocked. This is logged to the blocked_peers target at INFO, so this can be easily disabled. 

## TODO
- [x] TOML format
- [x] Test
- [x] Should Arc, &'static, or clone be used?
- [x] Document (where?)
- [x] Should the taker get an error?