### PR TITLE
chore: Remove remnants of the legacy network connection in CLI args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY $BINARY_PATH /usr/bin/binary
 
 VOLUME /data
 
-# HTTP Port, legacy P2P Port and libp2p P2P Port
-EXPOSE 8000 9999 10000
+# HTTP Port and libp2p P2P Port
+EXPOSE 8000 10000
 
 ENTRYPOINT ["/usr/bin/binary", "--data-dir=/data", "--http-address=0.0.0.0:8000"]

--- a/daemon/src/libp2p_utils.rs
+++ b/daemon/src/libp2p_utils.rs
@@ -41,14 +41,6 @@ pub fn create_listen_tcp_multiaddr(ip: &IpAddr, port: u16) -> Result<Multiaddr> 
         .with_context(|| "failed to construct multiaddr")
 }
 
-/// By convention we increment the port by 1 for libp2p-based connections.
-///
-/// The obvious drawback is that when doing blue/green deployment, we need to
-/// increment/decrement ports by 2.
-pub fn libp2p_socket_from_legacy_networking(legacy_addr: &SocketAddr) -> SocketAddr {
-    SocketAddr::new(legacy_addr.ip(), legacy_addr.port() + 1)
-}
-
 /// Determine whether to use libp2p or fallback to a legacy protocol
 pub fn can_use_libp2p(cfd: &model::Cfd) -> bool {
     // Our abitily to kick-off a libp2p version of protocol is constrained by

--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -16,8 +16,8 @@ pub mod routes;
 
 #[derive(Parser)]
 pub struct Opts {
-    /// The port to listen on for p2p connections.
-    #[clap(long, default_value = "9999")]
+    /// The port to listen on for libp2p connections.
+    #[clap(long, default_value = "10000")]
     pub p2p_port: u16,
 
     /// The IP address to listen on for the HTTP API.

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -123,14 +123,9 @@ async fn main() -> Result<()> {
     let db =
         sqlite_db::connect(data_dir.join("maker.sqlite"), opts.ignore_migration_errors).await?;
 
-    // Create actors
-
-    let libp2p_socket = daemon::libp2p_utils::libp2p_socket_from_legacy_networking(&p2p_socket);
-    let endpoint_listen = daemon::libp2p_utils::create_listen_tcp_multiaddr(
-        &libp2p_socket.ip(),
-        libp2p_socket.port(),
-    )
-    .expect("to parse properly");
+    let endpoint_listen =
+        daemon::libp2p_utils::create_listen_tcp_multiaddr(&p2p_socket.ip(), p2p_socket.port())
+            .expect("to parse properly");
 
     let (supervisor, price_feed) = Supervisor::with_policy(
         {

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -7,7 +7,6 @@ use clap::Parser;
 use daemon::bdk::bitcoin;
 use daemon::bdk::FeeRate;
 use daemon::libp2p_utils::create_connect_tcp_multiaddr;
-use daemon::libp2p_utils::libp2p_socket_from_legacy_networking;
 use daemon::monitor;
 use daemon::oracle;
 use daemon::projection;
@@ -44,11 +43,11 @@ mod routes;
 
 pub const ANNOUNCEMENT_LOOKAHEAD: time::Duration = time::Duration::hours(24);
 
-const MAINNET_MAKER: &str = "mainnet.itchysats.network:10000";
+const MAINNET_MAKER: &str = "mainnet.itchysats.network:10001";
 const MAINNET_MAKER_ID: &str = "7e35e34801e766a6a29ecb9e22810ea4e3476c2b37bf75882edf94a68b1d9607";
 const MAINNET_MAKER_PEER_ID: &str = "12D3KooWP3BN6bq9jPy8cP7Grj1QyUBfr7U6BeQFgMwfTTu12wuY";
 
-const TESTNET_MAKER: &str = "testnet.itchysats.network:9999";
+const TESTNET_MAKER: &str = "testnet.itchysats.network:10000";
 const TESTNET_MAKER_ID: &str = "69a42aa90da8b065b9532b62bff940a3ba07dbbb11d4482c7db83a7e049a9f1e";
 const TESTNET_MAKER_PEER_ID: &str = "12D3KooWEsK2X8Tp24XtyWh7DM65VfwXtNH2cmfs2JsWmkmwKbV1";
 
@@ -297,13 +296,11 @@ async fn main() -> Result<()> {
     let possible_addresses = resolve_maker_addresses(maker_url.as_str()).await?;
 
     // Assume that the first resolved ipv4 address is good enough for libp2p.
-    let first_maker_address = possible_addresses
+    let maker_libp2p_address = possible_addresses
         .iter()
         .find(|x| x.is_ipv4())
         .context("Could not resolve maker URL")?;
-
-    let maker_libp2p_address = libp2p_socket_from_legacy_networking(first_maker_address);
-    let maker_multiaddr = create_connect_tcp_multiaddr(&maker_libp2p_address, maker_peer_id)?;
+    let maker_multiaddr = create_connect_tcp_multiaddr(maker_libp2p_address, maker_peer_id)?;
 
     let hex_pk = hex::encode(identities.identity_pk.to_bytes());
     let peer_id = identities.libp2p.public().to_peer_id().to_string();


### PR DESCRIPTION
We used to derive libp2p port everywhere to be "legacy+1". Since legacy
connection is fully retired, we can directly specify libp2p ports now.