### PR TITLE
Revert bdk upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "maia"
 version = "0.2.0"
-source = "git+https://github.com/comit-network/maia?rev=9899c9eda1f7685493aecdd7f8ba9124787056bd#9899c9eda1f7685493aecdd7f8ba9124787056bd"
+source = "git+https://github.com/comit-network/maia?rev=fc6b78b98407b10b55f8cfd152062ad77f98cd9f#fc6b78b98407b10b55f8cfd152062ad77f98cd9f"
 dependencies = [
  "anyhow",
  "bdk",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "maia-core"
 version = "0.1.1"
-source = "git+https://github.com/comit-network/maia?rev=9899c9eda1f7685493aecdd7f8ba9124787056bd#9899c9eda1f7685493aecdd7f8ba9124787056bd"
+source = "git+https://github.com/comit-network/maia?tag=0.1.1#e1354e9c0397326a99bb5068e3afbc8cf2e07a9d"
 dependencies = [
  "anyhow",
  "bdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "0.21.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7dad109193db0d196e9149bb56ba991aacfc1e1a2cf400053358b75f6c2fb5"
+checksum = "ec2c4c49915b82a2576bc7dee83d2f274387904b79305e6ae8b622daa0b282c1"
 dependencies = [
  "async-trait",
  "bdk-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ resolver = "2"
 
 [patch.crates-io]
 xtra = { git = "https://github.com/Restioson/xtra", rev = "285b3e986013888cb68b9219464ef325d2468c2c" } # Unreleased
-maia = { git = "https://github.com/comit-network/maia", rev = "9899c9eda1f7685493aecdd7f8ba9124787056bd" }
-maia-core = { git = "https://github.com/comit-network/maia", rev = "9899c9eda1f7685493aecdd7f8ba9124787056bd", package = "maia-core" }
+maia = { git = "https://github.com/comit-network/maia", rev = "fc6b78b98407b10b55f8cfd152062ad77f98cd9f" } # Unreleased
+maia-core = { git = "https://github.com/comit-network/maia", tag = "0.1.1", package = "maia-core" } # Pinned to support maia 0.1 and 0.2
 xtra_productivity = { git = "https://github.com/comit-network/xtra-productivity", rev = "0bfd589b42a63149221dec7e95aca932875374dd" } # Unreleased
 electrum-client = { git = "https://github.com/comit-network/rust-electrum-client/", branch = "do-not-ignore-empty-lines" }
 otel-tests = { git = "https://github.com/itchysats/otel-tests/", rev = "4a57d84ad5780c30d09222c56440482d9e722363" } # unreleased

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY $BINARY_PATH /usr/bin/binary
 
 VOLUME /data
 
-# HTTP Port and libp2p P2P Port
-EXPOSE 8000 10000
+# HTTP Port, legacy P2P Port and libp2p P2P Port
+EXPOSE 8000 9999 10000
 
 ENTRYPOINT ["/usr/bin/binary", "--data-dir=/data", "--http-address=0.0.0.0:8000"]

--- a/bdk-ext/Cargo.toml
+++ b/bdk-ext/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.21.0", default-features = false, features = ["key-value-db"] }
+bdk = { version = "0.19.0", default-features = false, features = ["key-value-db"] }
 rand = "0.6"
 secp256k1 = { version = "0.22", features = ["rand", "global-context-less-secure"] }

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 async-stream = "0.3"
 async-trait = "0.1.57"
 asynchronous-codec = { version = "0.6.0", features = ["json"] }
-bdk = { version = "0.21.0", default-features = false, features = ["key-value-db"] }
+bdk = { version = "0.19.0", default-features = false, features = ["key-value-db"] }
 bdk-ext = { path = "../bdk-ext" }
 btsieve = { path = "../btsieve" }
 bytes = "1"

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -167,9 +167,8 @@ where
                 .context("Failed to sync wallet")
         })?;
 
-        let balance = tracing::debug_span!("Get wallet balance")
-            .in_scope(|| self.wallet.get_balance())?
-            .get_spendable();
+        let balance =
+            tracing::debug_span!("Get wallet balance").in_scope(|| self.wallet.get_balance())?;
 
         let utxo_values = tracing::debug_span!("Collect UTXO values").in_scope(|| {
             Ok::<_, bdk::Error>(Data::new(

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.57"
-bdk = { version = "0.21.0", default-features = false, features = ["electrum"] }
+bdk = { version = "0.19.0", default-features = false, features = ["electrum"] }
 clap = { version = "3", features = ["derive"] }
 conquer-once = "0.3"
 daemon = { path = "../daemon" }

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-bdk = { version = "0.21.0", default-features = false }
+bdk = { version = "0.19.0", default-features = false }
 bdk-ext = { path = "../bdk-ext" }
 conquer-once = "0.3"
 derivative = "2"

--- a/sqlite-db/Cargo.toml
+++ b/sqlite-db/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 async-stream = "0.3"
-bdk = "0.21.0"
+bdk = "0.19.0"
 chashmap-async = "0.1"
 futures = { version = "0.3", default-features = false }
 hex = "0.4"

--- a/xtra-libp2p-rollover/Cargo.toml
+++ b/xtra-libp2p-rollover/Cargo.toml
@@ -8,7 +8,7 @@ description = "Implementation of the `/itchysats/rollover` protocol using xtra-l
 anyhow = "1"
 async-trait = "0.1.57"
 asynchronous-codec = { version = "0.6.0", features = ["json"] }
-bdk = { version = "0.21.0", default-features = false }
+bdk = { version = "0.19.0", default-features = false }
 bdk-ext = { path = "../bdk-ext" }
 futures = { version = "0.3", default-features = false }
 libp2p-core = { version = "0.33", default-features = false }


### PR DESCRIPTION
Recent BDK upgrade broke testnet setup. The wallet does not initialise with our seed.
I'm currently investigating whether this is an error in us initialising the wallet with some subtle bug, or whether this is a bug in BDK.

Reverting to make things work again.