### PR TITLE
test: for malicious taker trying to settle unrelated order

### DIFF
--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -803,7 +803,7 @@ pub struct Taker {
     pub mocks: mocks::Mocks,
     pub feeds: FeedReceivers,
     pub maker_peer_id: PeerId,
-    db: sqlite_db::Connection,
+    pub db: sqlite_db::Connection,
     _tasks: Tasks,
 }
 

--- a/model/src/cfd.rs
+++ b/model/src/cfd.rs
@@ -514,7 +514,7 @@ pub struct Cfd {
     // dynamic (based on events)
     fee_account: FeeAccount,
 
-    dlc: Option<Dlc>,
+    pub dlc: Option<Dlc>,
 
     /// Holds the decrypted CET transaction if we have previously emitted it as part of an event.
     ///
@@ -2932,6 +2932,22 @@ mod tests {
 
         let result = cfd.can_auto_rollover_taker(datetime!(2021-11-18 11:00:00).assume_utc());
 
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn given_incorrect_counterparty_id_then_verify_fail() {
+        let cfd = Cfd::dummy_maker_short();
+        let peer_id = PeerId::random();
+        let result = cfd.verify_counterparty_peer_id(&peer_id);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn given_correct_counterparty_id_then_verify_succeed() {
+        let cfd = Cfd::dummy_maker_short();
+        let peer_id = cfd.counterparty_peer_id.unwrap();
+        let result = cfd.verify_counterparty_peer_id(&peer_id);
         assert!(result.is_ok());
     }
 


### PR DESCRIPTION
resolves #2891

I spent some time trying to find the best was to implement that test and I ended up with replicating the state from the takers database to mallorys database. That allowed me to use the existing methods to propose the settlement without changing too much. Another approach I was considering was directly to send the `Settle` event via the libp2p connection - however I didn't find a lean way of doing that.

One drawback of the current implementation is that I had to make the Dlc property on the Cfd public as otherwise I wouldn't have been able to replicate the state from the taker to mallory. side note, its quite odd that the dlc is stored in the events and upon loading mapped to the cfd.

Lastly, it was quite challenging to make well defined assertions about the expected state. One challenge I've noticed is that the changed method on the cfd_feed might get overwritten by newer events - that makes the test potentially flaky. Since all events are stored to the database a better approach could be loading them from the database to ensure nothing has been missed.

Potentially, we could come around some visibility issues (e.g. having to make dlc public on the cfd) by making the connection accessible to the tests. Allowing the test to query a certain state specifically from the database for assertions.