### PR TITLE
Improve randomness of ports in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,7 @@ dependencies = [
  "mockall_derive",
  "model",
  "otel-tests",
+ "portpicker",
  "quiet-spans",
  "rand 0.6.5",
  "rust_decimal",
@@ -2941,6 +2942,15 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "portpicker"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
+dependencies = [
+ "rand 0.8.4",
 ]
 
 [[package]]

--- a/daemon-tests/Cargo.toml
+++ b/daemon-tests/Cargo.toml
@@ -14,6 +14,7 @@ mockall = "0.11"
 mockall_derive = "0.11"
 model = { path = "../model" }
 otel-tests = { version = "0.1", default-features = false }
+portpicker = "0.1.1"
 quiet-spans = { path = "../quiet-spans" }
 rand = "0.6"
 rust_decimal = "1.26"

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -562,16 +562,7 @@ pub struct MakerConfig {
     oracle_pk: XOnlyPublicKey,
     seed: RandomSeed,
     n_payouts: usize,
-    dedicated_libp2p_port: Option<u16>,
-}
-
-impl MakerConfig {
-    pub fn with_dedicated_libp2p_port(self, port: u16) -> Self {
-        Self {
-            dedicated_libp2p_port: Some(port),
-            ..self
-        }
-    }
+    libp2p_port: u16,
 }
 
 impl Default for MakerConfig {
@@ -580,7 +571,7 @@ impl Default for MakerConfig {
             oracle_pk: oracle_pk(),
             seed: RandomSeed::default(),
             n_payouts: N_PAYOUTS,
-            dedicated_libp2p_port: None,
+            libp2p_port: portpicker::pick_unused_port().expect("to be able to find a free port"),
         }
     }
 }
@@ -664,13 +655,7 @@ impl Maker {
 
     #[instrument(name = "Start maker", skip_all)]
     pub async fn start(config: &MakerConfig) -> Self {
-        let port = find_random_free_port().await;
-        let libp2p_port = match config.dedicated_libp2p_port {
-            Some(port) => port,
-            None => find_random_free_port().await,
-        };
-
-        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), config.libp2p_port);
 
         let db = sqlite_db::memory().await.unwrap();
 
@@ -696,7 +681,7 @@ impl Maker {
         let mut oracle_mock = None;
 
         let endpoint_listen =
-            daemon::libp2p_utils::create_listen_tcp_multiaddr(&address.ip(), libp2p_port)
+            daemon::libp2p_utils::create_listen_tcp_multiaddr(&address.ip(), address.port())
                 .expect("to parse properly");
 
         let maker = maker::ActorSystem::new(
@@ -784,10 +769,6 @@ impl Maker {
             .await
             .unwrap();
     }
-}
-
-async fn find_random_free_port() -> u16 {
-    portpicker::pick_unused_port().expect("to be able to find a free port")
 }
 
 /// Taker Test Setup

--- a/daemon-tests/src/lib.rs
+++ b/daemon-tests/src/lib.rs
@@ -60,7 +60,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use time::OffsetDateTime;
-use tokio::net::TcpListener;
 use tokio::sync::watch;
 use tokio_extras::Tasks;
 use tracing::instrument;
@@ -788,12 +787,7 @@ impl Maker {
 }
 
 async fn find_random_free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .await
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
+    portpicker::pick_unused_port().expect("to be able to find a free port")
 }
 
 /// Taker Test Setup

--- a/daemon-tests/tests/main/connectivity.rs
+++ b/daemon-tests/tests/main/connectivity.rs
@@ -8,7 +8,8 @@ use otel_tests::otel_test;
 
 #[otel_test]
 async fn taker_notices_lack_of_maker() {
-    let maker_config = MakerConfig::default().with_dedicated_libp2p_port(35124); // set fixed ports so the taker can reconnect
+    let maker_config =
+        MakerConfig::default().with_dedicated_libp2p_port(portpicker::pick_unused_port().unwrap());
     let maker = Maker::start(&maker_config).await;
 
     let taker_config = TakerConfig::default();

--- a/daemon-tests/tests/main/connectivity.rs
+++ b/daemon-tests/tests/main/connectivity.rs
@@ -8,8 +8,7 @@ use otel_tests::otel_test;
 
 #[otel_test]
 async fn taker_notices_lack_of_maker() {
-    let maker_config =
-        MakerConfig::default().with_dedicated_libp2p_port(portpicker::pick_unused_port().unwrap());
+    let maker_config = MakerConfig::default();
     let maker = Maker::start(&maker_config).await;
 
     let taker_config = TakerConfig::default();


### PR DESCRIPTION
We're picking random ports first, and testing whether they are both free no UDP
and TCP instead of just relying on the OS to give us one.