### PR TITLE
Bump maia to latest HEAD and bdk to 0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Breaking change: with bdk>0.20 key derivations will take into account the network, i.e. for mainnet it uses `m/84'/0'/0'` and for testnet/regtest it uses `m/84'/1'/0'`. This was caused by https://github.com/bitcoindevkit/bdk/pull/585. If you want to withdraw your testnet funds make sure to use the withdraw functionality prior upgrading to a different wallet or return them to the faucet. Existing mainnet wallets are not affected.
+
 ## [0.6.1] - 2022-09-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c4c49915b82a2576bc7dee83d2f274387904b79305e6ae8b622daa0b282c1"
+checksum = "3a7dad109193db0d196e9149bb56ba991aacfc1e1a2cf400053358b75f6c2fb5"
 dependencies = [
  "async-trait",
  "bdk-macros",
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "maia"
 version = "0.2.0"
-source = "git+https://github.com/comit-network/maia?rev=fc6b78b98407b10b55f8cfd152062ad77f98cd9f#fc6b78b98407b10b55f8cfd152062ad77f98cd9f"
+source = "git+https://github.com/comit-network/maia?rev=9899c9eda1f7685493aecdd7f8ba9124787056bd#9899c9eda1f7685493aecdd7f8ba9124787056bd"
 dependencies = [
  "anyhow",
  "bdk",
@@ -2061,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "maia-core"
 version = "0.1.1"
-source = "git+https://github.com/comit-network/maia?tag=0.1.1#e1354e9c0397326a99bb5068e3afbc8cf2e07a9d"
+source = "git+https://github.com/comit-network/maia?rev=9899c9eda1f7685493aecdd7f8ba9124787056bd#9899c9eda1f7685493aecdd7f8ba9124787056bd"
 dependencies = [
  "anyhow",
  "bdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ resolver = "2"
 
 [patch.crates-io]
 xtra = { git = "https://github.com/Restioson/xtra", rev = "285b3e986013888cb68b9219464ef325d2468c2c" } # Unreleased
-maia = { git = "https://github.com/comit-network/maia", rev = "fc6b78b98407b10b55f8cfd152062ad77f98cd9f" } # Unreleased
-maia-core = { git = "https://github.com/comit-network/maia", tag = "0.1.1", package = "maia-core" } # Pinned to support maia 0.1 and 0.2
+maia = { git = "https://github.com/comit-network/maia", rev = "9899c9eda1f7685493aecdd7f8ba9124787056bd" }
+maia-core = { git = "https://github.com/comit-network/maia", rev = "9899c9eda1f7685493aecdd7f8ba9124787056bd", package = "maia-core" }
 xtra_productivity = { git = "https://github.com/comit-network/xtra-productivity", rev = "0bfd589b42a63149221dec7e95aca932875374dd" } # Unreleased
 electrum-client = { git = "https://github.com/comit-network/rust-electrum-client/", branch = "do-not-ignore-empty-lines" }
 otel-tests = { git = "https://github.com/itchysats/otel-tests/", rev = "4a57d84ad5780c30d09222c56440482d9e722363" } # unreleased

--- a/bdk-ext/Cargo.toml
+++ b/bdk-ext/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.19.0", default-features = false, features = ["key-value-db"] }
+bdk = { version = "0.21.0", default-features = false, features = ["key-value-db"] }
 rand = "0.6"
 secp256k1 = { version = "0.22", features = ["rand", "global-context-less-secure"] }

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 async-stream = "0.3"
 async-trait = "0.1.57"
 asynchronous-codec = { version = "0.6.0", features = ["json"] }
-bdk = { version = "0.19.0", default-features = false, features = ["key-value-db"] }
+bdk = { version = "0.21.0", default-features = false, features = ["key-value-db"] }
 bdk-ext = { path = "../bdk-ext" }
 btsieve = { path = "../btsieve" }
 bytes = "1"

--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -167,8 +167,9 @@ where
                 .context("Failed to sync wallet")
         })?;
 
-        let balance =
-            tracing::debug_span!("Get wallet balance").in_scope(|| self.wallet.get_balance())?;
+        let balance = tracing::debug_span!("Get wallet balance")
+            .in_scope(|| self.wallet.get_balance())?
+            .get_spendable();
 
         let utxo_values = tracing::debug_span!("Collect UTXO values").in_scope(|| {
             Ok::<_, bdk::Error>(Data::new(

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.57"
-bdk = { version = "0.19.0", default-features = false, features = ["electrum"] }
+bdk = { version = "0.21.0", default-features = false, features = ["electrum"] }
 clap = { version = "3", features = ["derive"] }
 conquer-once = "0.3"
 daemon = { path = "../daemon" }

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -78,12 +78,8 @@ async fn main() -> Result<()> {
     let mut wallet_dir = data_dir.clone();
 
     wallet_dir.push(MAKER_WALLET_ID);
-    let (wallet, wallet_feed_receiver) = wallet::Actor::spawn(
-        opts.network.electrum(),
-        ext_priv_key,
-        wallet_dir,
-        MAKER_WALLET_ID.to_string(),
-    )?;
+    let (wallet, wallet_feed_receiver) =
+        wallet::Actor::spawn(opts.network.electrum(), ext_priv_key, wallet_dir)?;
 
     if let Some(Withdraw::Withdraw {
         amount,

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-bdk = { version = "0.19.0", default-features = false }
+bdk = { version = "0.21.0", default-features = false }
 bdk-ext = { path = "../bdk-ext" }
 conquer-once = "0.3"
 derivative = "2"

--- a/sqlite-db/Cargo.toml
+++ b/sqlite-db/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 async-stream = "0.3"
-bdk = "0.19.0"
+bdk = "0.21.0"
 chashmap-async = "0.1"
 futures = { version = "0.3", default-features = false }
 hex = "0.4"

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -257,12 +257,8 @@ async fn main() -> Result<()> {
 
     let mut wallet_dir = data_dir.clone();
     wallet_dir.push(TAKER_WALLET_ID);
-    let (wallet, wallet_feed_receiver) = wallet::Actor::spawn(
-        network.electrum(),
-        ext_priv_key,
-        wallet_dir,
-        TAKER_WALLET_ID.to_string(),
-    )?;
+    let (wallet, wallet_feed_receiver) =
+        wallet::Actor::spawn(network.electrum(), ext_priv_key, wallet_dir)?;
 
     if let Some(Withdraw::Withdraw {
         amount,

--- a/xtra-libp2p-rollover/Cargo.toml
+++ b/xtra-libp2p-rollover/Cargo.toml
@@ -8,7 +8,7 @@ description = "Implementation of the `/itchysats/rollover` protocol using xtra-l
 anyhow = "1"
 async-trait = "0.1.57"
 asynchronous-codec = { version = "0.6.0", features = ["json"] }
-bdk = { version = "0.19.0", default-features = false }
+bdk = { version = "0.21.0", default-features = false }
 bdk-ext = { path = "../bdk-ext" }
 futures = { version = "0.3", default-features = false }
 libp2p-core = { version = "0.33", default-features = false }


### PR DESCRIPTION
Includes latest BDK and drops backwards compatibility.

BDK changed balance API in 0.21 and now you need to explicitly specify which
balance one you want (I opted for all spendable utxos).
It also includes a breaking change for the wallet derivation paths:
From now on keys for testnet/regtest are derived from the path `m/84'/1'/0` while mainnet they are derived from `m/84'/0'/0`. Before that testnet/regtest keys were derived from `m/84'/0'/0` as well.


The second commit includes a fix for #2917

With bdk>=0.20 the wallets are derived from a different derivation paths for testnet/regtest. This may lead to checksum errors if you had a db pre initialized. In order to not ask the user to delete their db we derive the wallet name from the key.

Resolves #2917

Note: this is a breaking change for our testnet setup. Once merged we should withdraw all funds from the old versions or simply fund them again using faucets. 

Note2: I opted for the breaking change because I think the testnet setup is not critical. No funds are in danger on mainnet as the derivation path on mainnet has not changed. 