### PR TITLE
chore: Go back to macos-latest on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
       - name: Setup rust toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@v2.0.0
+      - name: Get CMake
+        uses: lukka/get-cmake@latest
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Compile tests before running
@@ -112,6 +114,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
         run: rustup show
+      - name: Get CMake
+        uses: lukka/get-cmake@latest
       - uses: Swatinem/rust-cache@v2.0.0
       - run: cargo build --bin maker --bin taker
       - name: Smoke testing maker for ${{ matrix.os }} binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -106,7 +106,7 @@ jobs:
   smoke_test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/bors.toml
+++ b/bors.toml
@@ -26,7 +26,7 @@ status = [
   "frontend (taker)",
   "test (ubuntu-latest)",
   "smoke_test (ubuntu-latest)",
-  "smoke_test (macos-12)",
+  "smoke_test (macos-latest)",
   "daemons_arm_build",
   "sqlx-db-check",
 ]


### PR DESCRIPTION
We switched to  macos-12, as it was a bit more reliable at the time in
successfully running tests. This is not the case anymore (it got so
unreliable we had to turn it off in bors). Moreover, we started hitting concurrency
limits for the agent pool on macos-12 jobs; hopefully macos-latest has more
pools as it's the officially endorsed one.