### PR TITLE
feat: Extend Environment enum to new platforms

### DIFF
--- a/daemon/src/identify/protocol.rs
+++ b/daemon/src/identify/protocol.rs
@@ -110,6 +110,9 @@ where
 pub enum Environment {
     Umbrel,
     RaspiBlitz,
+    Citadel,
+    Start9,
+    MyNode,
     Docker,
     Binary,
     Test,
@@ -122,6 +125,9 @@ impl From<crate::Environment> for Environment {
         match environment {
             crate::Environment::Umbrel => Environment::Umbrel,
             crate::Environment::RaspiBlitz => Environment::RaspiBlitz,
+            crate::Environment::Citadel => Environment::Citadel,
+            crate::Environment::Start9 => Environment::Start9,
+            crate::Environment::MyNode => Environment::MyNode,
             crate::Environment::Docker => Environment::Docker,
             crate::Environment::Binary => Environment::Binary,
             crate::Environment::Test => Environment::Test,
@@ -136,6 +142,9 @@ impl From<Environment> for crate::Environment {
         match environment {
             Environment::Umbrel => crate::Environment::Umbrel,
             Environment::RaspiBlitz => crate::Environment::RaspiBlitz,
+            Environment::Citadel => crate::Environment::Citadel,
+            Environment::Start9 => crate::Environment::Start9,
+            Environment::MyNode => crate::Environment::MyNode,
             Environment::Docker => crate::Environment::Docker,
             Environment::Binary => crate::Environment::Binary,
             Environment::Test => crate::Environment::Test,

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -448,6 +448,9 @@ where
 pub enum Environment {
     Umbrel,
     RaspiBlitz,
+    Citadel,
+    Start9,
+    MyNode,
     Docker,
     Binary,
     Test,
@@ -460,6 +463,9 @@ impl Environment {
         match envvar_val {
             "umbrel" => Environment::Umbrel,
             "raspiblitz" => Environment::RaspiBlitz,
+            "citadel" => Environment::Citadel,
+            "start9" => Environment::Start9,
+            "mynode" => Environment::MyNode,
             "docker" => Environment::Docker,
             _ => Environment::Unknown,
         }
@@ -476,14 +482,15 @@ fn into_price_feed_symbol(symbol: model::ContractSymbol) -> xtra_bitmex_price_fe
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Environment::Docker;
-    use crate::Environment::RaspiBlitz;
-    use crate::Environment::Umbrel;
+    use crate::Environment::*;
 
     #[test]
     fn snapshot_test_environment_from_str_or_unknown() {
         assert_eq!(Environment::from_str_or_unknown("umbrel"), Umbrel);
         assert_eq!(Environment::from_str_or_unknown("raspiblitz"), RaspiBlitz);
+        assert_eq!(Environment::from_str_or_unknown("citadel"), Citadel);
+        assert_eq!(Environment::from_str_or_unknown("start9"), Start9);
+        assert_eq!(Environment::from_str_or_unknown("mynode"), MyNode);
         assert_eq!(Environment::from_str_or_unknown("docker"), Docker);
     }
 }


### PR DESCRIPTION
Extend Environment enums for the platforms we're about to integrate on.