### PR TITLE
feat: Add headless mode for the binaries

### DIFF
--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -50,6 +50,10 @@ pub struct Opts {
     #[clap(long)]
     pub verbose_spans: bool,
 
+    /// If enabled, browser UI is not automatically launched at startup.
+    #[clap(long)]
+    pub headless: bool,
+
     /// OTEL collector endpoint address
     ///
     /// If not specified it defaults to the local collector endpoint.

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -191,7 +191,7 @@ async fn main() -> Result<()> {
         .register("/", default_catchers())
         .attach(fairings::log_launch())
         .attach(fairings::log_requests())
-        .attach(fairings::ui_browser_launch())
+        .attach(fairings::ui_browser_launch(!opts.headless))
         .launch()
         .await?;
 

--- a/shared-bin/src/fairings.rs
+++ b/shared-bin/src/fairings.rs
@@ -30,7 +30,10 @@ pub fn log_requests() -> impl Fairing {
 }
 
 /// Attach this fairing to enable loading the UI in the system default browser
-pub fn ui_browser_launch() -> impl Fairing {
+///
+/// Passing `true` opens browser at launch, passing `false` logs the link to
+/// open it manually.
+pub fn ui_browser_launch(open_browser: bool) -> impl Fairing {
     AdHoc::on_liftoff("ui browser launch", move |rocket| {
         Box::pin(async move {
             let (username, password) = match (
@@ -51,6 +54,13 @@ pub fn ui_browser_launch() -> impl Fairing {
                 rocket.config().address,
                 rocket.config().port
             );
+
+            if !open_browser {
+                tracing::info!(
+                    "Running in headless mode. The UI can be accessed at {http_endpoint}"
+                );
+                return;
+            }
 
             match webbrowser::open(http_endpoint.as_str()) {
                 Ok(()) => {

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -107,6 +107,10 @@ struct Opts {
     #[clap(long, default_value = LOCAL_COLLECTOR_ENDPOINT )]
     collector_endpoint: String,
 
+    /// If enabled, browser UI is not automatically launched at startup.
+    #[clap(long)]
+    pub headless: bool,
+
     /// Service name for OTEL.
     ///
     /// If not specified it defaults to the binary name.
@@ -389,7 +393,7 @@ async fn main() -> Result<()> {
         .register("/", default_catchers())
         .attach(fairings::log_launch())
         .attach(fairings::log_requests())
-        .attach(fairings::ui_browser_launch())
+        .attach(fairings::ui_browser_launch(!opts.headless))
         .launch()
         .await?;
 


### PR DESCRIPTION
By default, the UI is opened at startup in system webbrowser. For users who do
not wish this to happen, a new parameter called `--headless` got introduced.