### PR TITLE
chore: Bump sqlx to 0.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Install sqlx-cli
         # Lock sqlx-cli version to the same version as sqlx in the workspace
         run: |
-          cargo install sqlx-cli@0.6.1
+          cargo install sqlx-cli@0.6.2
 
       - name: Run sqlx prepare
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4280,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.1.8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b7922be017ee70900be125523f38bdd644f4f06a1b16e8fa5a8ee8c34bffd4"
+checksum = "f87e292b4291f154971a43c3774364e2cbcaec599d3f5bf6fa9d122885dbc38a"
 dependencies = [
  "itertools",
  "nom 7.0.0",
@@ -4318,9 +4318,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788841def501aabde58d3666fcea11351ec3962e6ea75dbcd05c84a71d68bcd1"
+checksum = "9249290c05928352f71c077cc44a464d880c63f26f7534728cca008e135c0428"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4328,9 +4328,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c21d3b5e7cadfe9ba7cdc1295f72cc556c750b4419c27c219c0693198901f8e"
+checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
 dependencies = [
  "ahash",
  "atoi",
@@ -4376,9 +4376,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adfd2df3557bddd3b91377fc7893e8fa899e9b4061737cbade4e1bb85f1b45c"
+checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
 dependencies = [
  "dotenvy",
  "either",
@@ -4398,9 +4398,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be52fc7c96c136cedea840ed54f7d446ff31ad670c9dea95ebcb998530971a3"
+checksum = "24c5b2d25fa654cc5f841750b8e1cdedbe21189bf9a9382ee90bfa9dd3562396"
 dependencies = [
  "once_cell",
  "tokio",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -38,7 +38,7 @@ serde_with = { version = "1", features = ["macros"] }
 sha2 = "0.10"
 snow = "0.9"
 sqlite-db = { path = "../sqlite-db" }
-sqlx = { version = "0.6.1", features = ["offline", "sqlite", "uuid", "runtime-tokio-rustls"] }
+sqlx = { version = "0.6.2", features = ["offline", "sqlite", "uuid", "runtime-tokio-rustls"] }
 statrs = "0.16"
 strum = "0.24"
 thiserror = "1"

--- a/sqlite-db/Cargo.toml
+++ b/sqlite-db/Cargo.toml
@@ -20,7 +20,7 @@ rust_decimal = "1.26"
 rust_decimal_macros = "1.26"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { version = "0.6.1", features = ["offline", "sqlite", "uuid", "runtime-tokio-rustls"] }
+sqlx = { version = "0.6.2", features = ["offline", "sqlite", "uuid", "runtime-tokio-rustls"] }
 thiserror = "1"
 time = { version = "0.3.14", features = [] }
 tokio = { version = "1" }


### PR DESCRIPTION
Bump sqlx-cli version to match new sqlx version and regenerate sqlx json file