### PR TITLE
chore: Rename umbrel seed to app seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Breaking change: with bdk>0.20 key derivations will take into account the network, i.e. for mainnet it uses `m/84'/0'/0'` and for testnet/regtest it uses `m/84'/1'/0'`. This was caused by https://github.com/bitcoindevkit/bdk/pull/585. If you want to withdraw your testnet funds make sure to use the withdraw functionality prior upgrading to a different wallet or return them to the faucet. Existing mainnet wallets are not affected.
+- Breaking change: Rename `--umbrel-seed` to `--app-seed`. Integration with Umbrel and other environments might be affected. This is unlikely to affect regular users, as this parameter is not used outside such environments.
 
 ## [0.6.1] - 2022-09-01
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Additionally, when a CFD is closed, your payout is sent to an address owned by t
 This wallet is completely under your control.
 You can withdraw from the wallet at any time.
 
-On Umbrel this wallet is derived from the Umbrel Seed, so the only thing you have to back up is the Umbrel seed.
+On Umbrel this wallet is derived from its app seed, so the only thing you have to back up is the Umbrel seed.
 
 When running the binary / docker container a random seed will be used to derive the wallet.
 Make sure to back up the `taker_seed` file that can be found in the data directory of the application.

--- a/daemon/src/seed.rs
+++ b/daemon/src/seed.rs
@@ -153,15 +153,15 @@ impl Default for RandomSeed {
 }
 
 #[derive(Copy, Clone)]
-pub struct UmbrelSeed([u8; 32]);
+pub struct AppSeed([u8; 32]);
 
-impl Seed for UmbrelSeed {
+impl Seed for AppSeed {
     fn seed(&self) -> Vec<u8> {
         self.0.to_vec()
     }
 }
 
-impl From<[u8; 32]> for UmbrelSeed {
+impl From<[u8; 32]> for AppSeed {
     fn from(bytes: [u8; 32]) -> Self {
         Self(bytes)
     }


### PR DESCRIPTION
The mechanism of passing external app seed is not specific to Umbrel, it is used
in other distributions as well. It is even called APP_SEED on Umbrel itself.

Note: this will require rolling out on umbrel with the next ItchySats version bump.