### PR TITLE
fix: add secret key to rocket config figment

### DIFF
--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -108,7 +108,8 @@ async fn main() -> Result<()> {
     let figment = rocket::Config::figment()
         .merge(("address", opts.http_address.ip()))
         .merge(("port", opts.http_address.port()))
-        .merge(("cli_colors", false));
+        .merge(("cli_colors", false))
+        .merge(("secret_key", RandomSeed::default().seed()));
 
     let p2p_port = opts.p2p_port;
     let p2p_socket = format!("0.0.0.0:{p2p_port}").parse::<SocketAddr>().unwrap();

--- a/taker/src/main.rs
+++ b/taker/src/main.rs
@@ -308,7 +308,8 @@ async fn main() -> Result<()> {
     let figment = rocket::Config::figment()
         .merge(("address", opts.http_address.ip()))
         .merge(("port", opts.http_address.port()))
-        .merge(("cli_colors", false));
+        .merge(("cli_colors", false))
+        .merge(("secret_key", RandomSeed::default().seed()));
 
     let db = sqlite_db::connect(data_dir.join("taker.sqlite"), true).await?;
 


### PR DESCRIPTION
resolves #2972

For some reason this works when starting the taker with cargo run, but does not work in docker. I guess if we release the binary the debug profile is disabled and a secret key has to be provided.


    /// The default profile: "debug" on `debug`, "release" on `release`.
    #[cfg(debug_assertions)]
    pub const DEFAULT_PROFILE: Profile = Self::DEBUG_PROFILE;

https://github.com/SergioBenitez/Rocket/blob/6778089c129ee15dfd524413f067c9c572226159/core/lib/src/config/config.rs#L429-L431


see also 
* https://api.rocket.rs/master/rocket/config/struct.SecretKey.html