### PR TITLE
fix(cookie-auth): the field is called `first_login` and not `expired`

### DIFF
--- a/maker-frontend/src/authentication/session.tsx
+++ b/maker-frontend/src/authentication/session.tsx
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from "axios";
 
 export interface User {
-    expired: boolean;
+    first_login: boolean;
     id: number;
 }
 

--- a/maker-frontend/src/authentication/useAuth.tsx
+++ b/maker-frontend/src/authentication/useAuth.tsx
@@ -67,7 +67,7 @@ export function AuthProvider({
 
         sessionsApi.login({ password })
             .then((user) => {
-                if (user.expired) {
+                if (user.first_login) {
                     setFirstLogin(true);
                     navigate("/change-password");
                 } else {

--- a/taker-frontend/src/authentication/session.tsx
+++ b/taker-frontend/src/authentication/session.tsx
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from "axios";
 
 export interface User {
-    expired: boolean;
+    first_login: boolean;
     id: number;
 }
 

--- a/taker-frontend/src/authentication/useAuth.tsx
+++ b/taker-frontend/src/authentication/useAuth.tsx
@@ -67,7 +67,7 @@ export function AuthProvider({
 
         sessionsApi.login({ password })
             .then((user) => {
-                if (user.expired) {
+                if (user.first_login) {
                     setFirstLogin(true);
                     navigate("/change-password");
                 } else {


### PR DESCRIPTION
fixes #2979