### PR TITLE
chore: Move build.rs frontend prep to relevant crates

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -61,6 +61,3 @@ xtras = { path = "../xtras" }
 [dev-dependencies]
 serde_test = "1"
 time = { version = "0.3.14", features = ["std"] }
-
-[build-dependencies]
-anyhow = "1"

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -47,3 +47,6 @@ xtra-bitmex-price-feed = { path = "../xtra-bitmex-price-feed" }
 xtra-libp2p = { path = "../xtra-libp2p" }
 xtra_productivity = { version = "0.1.0", features = ["instrumentation"] }
 xtras = { path = "../xtras" }
+
+[build-dependencies]
+anyhow = "1"

--- a/maker/build.rs
+++ b/maker/build.rs
@@ -2,6 +2,5 @@ use anyhow::Result;
 
 fn main() -> Result<()> {
     std::fs::create_dir_all("../maker-frontend/dist/maker")?;
-    std::fs::create_dir_all("../taker-frontend/dist/taker")?;
     Ok(())
 }

--- a/taker/Cargo.toml
+++ b/taker/Cargo.toml
@@ -37,3 +37,6 @@ xtras = { path = "../xtras" }
 
 [dev-dependencies]
 serde_test = "1"
+
+[build-dependencies]
+anyhow = "1"

--- a/taker/build.rs
+++ b/taker/build.rs
@@ -1,0 +1,6 @@
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    std::fs::create_dir_all("../taker-frontend/dist/taker")?;
+    Ok(())
+}


### PR DESCRIPTION
Daemon crate should not be concerned about frontend directories; this is the job of the binaries.