### PR TITLE
feat(wallet-history): show transaction history

### DIFF
--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -198,11 +198,14 @@ where
         STD_DEV_UTXO_VALUE_GAUGE.set(utxo_values.std_dev().unwrap_or_default());
 
         let address = self.wallet.get_address(AddressIndex::LastUnused)?.address;
+        let transactions = self.wallet.list_transactions(false)?;
 
         let wallet_info = WalletInfo {
+            network: self.wallet.network(),
             balance: Amount::from_sat(balance),
             address,
             last_updated_at: Timestamp::now(),
+            transactions,
         };
 
         tracing::trace!(target : "wallet", sync_time_sec = %now.elapsed().as_secs(), "Wallet sync done");

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -5,8 +5,10 @@ use anyhow::Result;
 use bdk::bitcoin::Address;
 use bdk::bitcoin::Amount;
 use bdk::bitcoin::Denomination;
+use bdk::bitcoin::Network;
 use bdk::bitcoin::SignedAmount;
 use bdk::bitcoin::Txid;
+use bdk::TransactionDetails;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use serde::de::Error as _;
@@ -451,9 +453,11 @@ impl str::FromStr for Identity {
 
 #[derive(Debug, Clone)]
 pub struct WalletInfo {
+    pub network: Network,
     pub balance: Amount,
     pub address: Address,
     pub last_updated_at: Timestamp,
+    pub transactions: Vec<TransactionDetails>,
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]

--- a/taker-frontend/src/types.ts
+++ b/taker-frontend/src/types.ts
@@ -10,6 +10,20 @@ export interface WalletInfo {
     balance: number;
     address: string;
     last_updated_at: number;
+    transactions: Transaction[];
+}
+
+export interface Transaction {
+    txid: string;
+    received: number;
+    sent: number;
+    confirmation_time?: BlockTime;
+    link?: String;
+}
+
+interface BlockTime {
+    height: number;
+    timestamp: number;
 }
 
 export function unixTimestampToDate(unixTimestamp: number): Date {


### PR DESCRIPTION
I've chosen to go for a custom type which allows us to add a convenience field for linking to mempool. In the long run we could add a link to a CFD there if the transaction was funding/closing a CFD.

Looks like this: 

![image](https://user-images.githubusercontent.com/224613/191384564-9e176196-71c5-49f3-88fe-fb73c67b5bcf.png)
