### PR TITLE
Attempt to make smoke tests more robust

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,9 @@ linker = "aarch64-linux-gnu-gcc"
 dev-maker = "run --bin maker -- --instrumentation --password dev testnet"
 dev-taker = "run --bin taker -- --instrumentation --maker localhost:10000 --maker-id 10d4ba2ac3f7a22da4009d813ff1bc3f404dfe2cc93a32bedf1512aa9951c95e --maker-peer-id 12D3KooWDjzHna3pNi1Bt1DoRfrpsBREykJKXDRDxXvhJNAdDZEk --password dev testnet" # Maker ID matches seed found in `testnet/maker_seed`
 
+dev-maker-headless = "run --bin maker -- --instrumentation --password dev --headless testnet"
+dev-taker-headless = "run --bin taker -- --instrumentation --maker localhost:10000 --maker-id 10d4ba2ac3f7a22da4009d813ff1bc3f404dfe2cc93a32bedf1512aa9951c95e --maker-peer-id 12D3KooWDjzHna3pNi1Bt1DoRfrpsBREykJKXDRDxXvhJNAdDZEk --password dev --headless testnet" # Maker ID matches seed found in `testnet/maker_seed`
+
 # Inspired by https://github.com/EmbarkStudios/rust-ecosystem/pull/68.
 # tokio_unstable enabled for tokio_console and tokio_metrics only
 [build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,16 +148,25 @@ jobs:
       - name: Smoke testing maker for ${{ matrix.os }} binary
         shell: bash
         run: |
-          cargo dev-maker &
-          sleep 10 # Wait for binaries to start
-          curl --fail http://localhost:8001/api/alive
+          cargo dev-maker-headless &
+          n=0
+          until [ "$n" -ge 3 ]
+          do
+            n=$((n+1))
+            sleep 10
+            curl --fail http://localhost:8001/api/alive && break;
+          done
       - name: Smoke testing taker for ${{ matrix.os }} binary
         shell: bash
         run: |
-          cargo dev-taker &
-          sleep 10 # Wait for binaries to start
-          curl --fail http://localhost:8000/api/alive
-
+          cargo dev-taker-headless &
+          n=0
+          until [ "$n" -ge 3 ]
+          do
+            n=$((n+1))
+            sleep 10
+            curl --fail http://localhost:8000/api/alive && break;
+          done
   daemons_arm_build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Our smoke tests on CI are unreliable, assuming because of the low system resources. With this patch I've added a simple retry mechanism: if a request fails, it will retry up to 3 times 

I've also added a new cargo alias to start dev-maker/dev-taker in headless mode. I'm not sure if it is required but I noticed that it says: `opening in default browser` which does not make sense on ci. 

