### PR TITLE
feat(electron): keep separate config for dev and prod

### DIFF
--- a/taker-electron/.gitignore
+++ b/taker-electron/.gitignore
@@ -6,3 +6,5 @@ npm-debug.log*
 
 out/
 dist/
+mainnet/
+testnet/

--- a/taker-electron/src/main.ts
+++ b/taker-electron/src/main.ts
@@ -23,14 +23,16 @@ export default class Main {
         logger.debug("Waiting for ItchySats to become available.");
         Main.createWindow();
 
-        const userData = app.getPath("userData");
-        logger.info(`Storing wallet to ${userData}`);
-
         process.env.ITCHYSATS_ENV = "electron";
 
-        // start itchysats taker
+        const dataDir = app.isPackaged ? app.getPath("userData") : app.getAppPath();
+        const network = app.isPackaged ? "mainnet" : "testnet";
         logger.info("Starting ItchySats ...");
-        itchysats("mainnet", userData).then(() => {
+        logger.info(`Network: ${network}`);
+        logger.info(`Data Dir: ${dataDir}`);
+
+        // start itchysats taker
+        itchysats(network, dataDir).then(() => {
             logger.info("Stopped ItchySats.");
         }).catch((error: Error) => logger.error(error));
 


### PR DESCRIPTION
Starting the electron from the dev environment should not use the same user path as the packaged version - in case you want to use the electron app yourself. Also it makes more sense to run itchysats against the testnet during development.