### PR TITLE
Extend electron configuration to allow logging into a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,6 +4303,7 @@ dependencies = [
  "serde",
  "time",
  "tracing",
+ "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "webbrowser",
@@ -5133,6 +5134,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -112,4 +112,8 @@ pub struct Opts {
 
     #[clap(subcommand)]
     pub network: Network,
+
+    /// If enabled, the log will be printed to {service_name}.log in the data dir
+    #[clap(long)]
+    pub log_to_file: bool,
 }

--- a/shared-bin/Cargo.toml
+++ b/shared-bin/Cargo.toml
@@ -22,6 +22,7 @@ rocket = { version = "0.5.0-rc.2", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 time = "0.3.14"
 tracing = { version = "0.1" }
+tracing-appender = "0.2.2"
 tracing-opentelemetry = "0.17.4"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter", "local-time", "tracing-log", "json"] }
 webbrowser = "0.8.0"


### PR DESCRIPTION
Introduces an opt for writing logs to a file. If flag is set, logs will be written to the data dir. The file name will be concatenated from the service name + itchysats.log

### Examples

```
cargo run --bin taker -- --data-dir /itchysats/ --log-to-file testnet
```
You can find the logs here.
/itchysats/testnet/taker.log

```
cargo run --bin maker -- --data-dir /itchysats/ --log-to-file mainnet
```
You can find the logs here.
- /itchysats/mainnet/maker.log

resolves #2982
