### PR TITLE
Allow unauthenticated access to  `/api/metrics` endpoint

### DIFF
--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -320,9 +320,11 @@ pub async fn get_cfds<'r>(
     }
 }
 
+// TODO: Use non-cookie auth for /metrics endpoint as Prometheus does not
+// support cookie-auth (for now, leave unauthenticated)
 #[rocket::get("/metrics")]
 #[instrument(name = "GET /metrics", skip_all, err)]
-pub async fn get_metrics<'r>(_user: User) -> Result<String, HttpApiProblem> {
+pub async fn get_metrics<'r>() -> Result<String, HttpApiProblem> {
     let metrics = prometheus::TextEncoder::new()
         .encode_to_string(&prometheus::gather())
         .map_err(|e| {

--- a/taker/src/routes.rs
+++ b/taker/src/routes.rs
@@ -297,9 +297,11 @@ pub async fn post_withdraw_request(
     Ok(projection::to_mempool_url(txid, *network.inner()))
 }
 
+// TODO: Use non-cookie auth for /metrics endpoint as Prometheus does not
+// support cookie-auth (for now, leave unauthenticated)
 #[rocket::get("/metrics")]
 #[instrument(name = "GET /metrics", skip_all, err)]
-pub async fn get_metrics<'r>(_user: User) -> Result<String, HttpApiProblem> {
+pub async fn get_metrics<'r>() -> Result<String, HttpApiProblem> {
     let metrics = prometheus::TextEncoder::new()
         .encode_to_string(&prometheus::gather())
         .map_err(|e| {


### PR DESCRIPTION
Prometheus does not allow cookie-based auth. Leave it unauthenticated until we
support different type of auth for prometheus.