### PR TITLE
Replace `chashmap` with `dashmap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,15 +126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-lock"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,27 +550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chashmap"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff41a3c2c1e39921b9003de14bf0439c7b63a9039637c291e1a64925d8ddfa45"
-dependencies = [
- "owning_ref",
- "parking_lot 0.4.8",
-]
-
-[[package]]
-name = "chashmap-async"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e040eb99fdc6ab52714dab2337c0a9e516cfdeac3dbee4bc64075418e661229"
-dependencies = [
- "async-lock",
- "owning_ref_async",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,8 +895,8 @@ dependencies = [
  "bdk-ext",
  "btsieve",
  "bytes",
- "chashmap-async",
  "conquer-once",
+ "dashmap",
  "derivative",
  "futures",
  "hkdf",
@@ -1033,6 +1003,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -1547,9 +1530,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
@@ -1560,7 +1543,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d452c155cb93fecdfb02a73dd57b5d8e442c2063bd7aac72f1bc5e4263a43086"
 dependencies = [
- "hashbrown 0.12.1",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1924,7 +1907,7 @@ dependencies = [
  "rw-stream-sink",
  "serde",
  "sha2 0.10.5",
- "smallvec 1.7.0",
+ "smallvec",
  "thiserror",
  "unsigned-varint",
  "void",
@@ -1995,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg 1.1.0",
  "scopeguard",
@@ -2132,12 +2115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,7 +2169,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2343,7 +2320,7 @@ dependencies = [
  "futures",
  "log",
  "pin-project",
- "smallvec 1.7.0",
+ "smallvec",
  "unsigned-varint",
 ]
 
@@ -2483,7 +2460,7 @@ dependencies = [
  "neon-macros",
  "neon-runtime",
  "semver 0.9.0",
- "smallvec 1.7.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -2511,7 +2488,7 @@ checksum = "4676720fa8bb32c64c3d9f49c47a47289239ec46b4bdb66d0913cc512cb0daca"
 dependencies = [
  "cfg-if",
  "libloading 0.6.7",
- "smallvec 1.7.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -2780,34 +2757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owning_ref"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
-name = "owning_ref_async"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31875764d9988da8b0c45cd2c558736f0a5e36c841b08a42bd92c622104427d9"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
-dependencies = [
- "owning_ref",
- "parking_lot_core 0.2.14",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,19 +2774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.2",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
-dependencies = [
- "libc",
- "rand 0.4.6",
- "smallvec 0.6.14",
- "winapi 0.3.9",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -2850,21 +2787,21 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.7.0",
+ "smallvec",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.7.0",
- "windows-sys 0.34.0",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3321,19 +3258,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -3736,7 +3660,7 @@ name = "rocket-cookie-auth"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chashmap",
+ "dashmap",
  "http-api-problem",
  "rand 0.8.5",
  "rocket",
@@ -3783,7 +3707,7 @@ dependencies = [
  "pin-project-lite",
  "ref-cast",
  "serde",
- "smallvec 1.7.0",
+ "smallvec",
  "stable-pattern",
  "state",
  "time",
@@ -4335,15 +4259,6 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
@@ -4420,7 +4335,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "bdk",
- "chashmap-async",
+ "dashmap",
  "futures",
  "hex",
  "libp2p-core",
@@ -4487,7 +4402,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "sha2 0.10.5",
- "smallvec 1.7.0",
+ "smallvec",
  "sqlformat",
  "sqlx-rt",
  "stringprep",
@@ -4539,12 +4454,6 @@ checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state"
@@ -5170,7 +5079,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.7.0",
+ "smallvec",
  "thread_local",
  "time",
  "tracing",
@@ -5607,35 +5516,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
-dependencies = [
- "windows_aarch64_msvc 0.34.0",
- "windows_i686_gnu 0.34.0",
- "windows_i686_msvc 0.34.0",
- "windows_x86_64_gnu 0.34.0",
- "windows_x86_64_msvc 0.34.0",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5645,21 +5535,9 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5669,21 +5547,9 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -13,8 +13,8 @@ bdk = { version = "0.21.0", default-features = false, features = ["key-value-db"
 bdk-ext = { path = "../bdk-ext" }
 btsieve = { path = "../btsieve" }
 bytes = "1"
-chashmap-async = "0.1"
 conquer-once = "0.3"
+dashmap = "5"
 derivative = "2"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hkdf = "0.12"

--- a/rocket-cookie-auth/Cargo.toml
+++ b/rocket-cookie-auth/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-chashmap = "2.2.2"
+dashmap = "5"
 http-api-problem = { version = "0.55.0", features = ["rocket"] }
 rand = "0.8.5"
 rocket = { version = "0.5.0-rc.2", features = ["secrets"] }

--- a/rocket-cookie-auth/src/session.rs
+++ b/rocket-cookie-auth/src/session.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use anyhow::Context;
 use anyhow::Result;
-use chashmap::CHashMap;
+use dashmap::DashMap;
 use rocket::http::CookieJar;
 use rocket::http::Status;
 use rocket::request::FromRequest;
@@ -51,7 +51,7 @@ pub trait SessionManager: Send + Sync {
     fn get(&self, id: u32) -> Result<Option<String>>;
 }
 
-impl SessionManager for CHashMap<u32, AuthKey> {
+impl SessionManager for DashMap<u32, AuthKey> {
     fn insert_for(&self, id: u32, key: String, time: Duration) {
         let key = AuthKey {
             expires: time.whole_seconds(),

--- a/rocket-cookie-auth/src/users.rs
+++ b/rocket-cookie-auth/src/users.rs
@@ -8,6 +8,7 @@ use crate::user::User;
 use crate::Database;
 use anyhow::Context;
 use anyhow::Result;
+use dashmap::DashMap;
 
 pub struct Users {
     db: Box<dyn Database>,
@@ -18,7 +19,7 @@ impl Users {
     pub fn new(db: Box<dyn Database>) -> Users {
         Self {
             db,
-            sessions: Box::new(chashmap::CHashMap::new()),
+            sessions: Box::new(DashMap::new()),
         }
     }
 

--- a/sqlite-db/Cargo.toml
+++ b/sqlite-db/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1"
 async-stream = "0.3"
 bdk = "0.21.0"
-chashmap-async = "0.1"
+dashmap = "5"
 futures = { version = "0.3", default-features = false }
 hex = "0.4"
 libp2p-core = { version = "0.33", default-features = false }


### PR DESCRIPTION
The `chashmap` dependency has lead to dependabot alerting<sup>[1]</sup> about a vulnerability in a transitive dependency. Looking at `chashmap`'s repository it looks to me like it's not very well maintained.

On the other hand, `dashmap` looks great and should be a good replacement for `chashmap` and `chashmap-async`. Even though `dashmap` does not yet support async locks<sup>[2]</sup>, the maintainer states that synchronous locks "are also fine to use in async as per tokio docs"<sup>[3]</sup>.

[1]: https://github.com/itchysats/itchysats/security/dependabot/35.
[2]: https://github.com/xacrimon/dashmap/issues/150.
[3]: https://github.com/xacrimon/dashmap/issues/150#issuecomment-1030858774.

---

Fixes https://github.com/itchysats/itchysats/security/dependabot/35.