### PR TITLE
Use unconfirmed balance for non-mainnet networks

### DIFF
--- a/daemon/src/wallet.rs
+++ b/daemon/src/wallet.rs
@@ -175,9 +175,13 @@ where
                 .context("Failed to sync wallet")
         })?;
 
-        let balance = tracing::debug_span!("Get wallet balance")
-            .in_scope(|| self.wallet.get_balance())?
-            .get_spendable();
+        let balance =
+            tracing::debug_span!("Get wallet balance").in_scope(|| self.wallet.get_balance())?;
+
+        let balance = match self.wallet.network() {
+            Network::Bitcoin => balance.get_spendable(),
+            _ => balance.get_total(),
+        };
 
         let utxo_values = tracing::debug_span!("Collect UTXO values").in_scope(|| {
             Ok::<_, bdk::Error>(Data::new(


### PR DESCRIPTION
This is helpful for anyone who wants to test or try out the application on testnet (or other non-mainnet networks).