### PR TITLE
Separate monitor logic from transaction data 

### DIFF
--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -250,6 +250,10 @@ impl Cfd {
                 broadcast_lock: None,
                 ..self
             },
+            ManualCommit { tx } => Self {
+                broadcast_commit: Some(tx),
+                ..self
+            },
             CommitConfirmed => Self {
                 monitor_commit_finality: false,
                 broadcast_commit: None,
@@ -291,7 +295,6 @@ impl Cfd {
             | RolloverStarted { .. }
             | RolloverAccepted
             | RolloverFailed
-            | ManualCommit { .. }
             | OracleAttestedPriorCetTimelock { .. }
             | CollaborativeSettlementStarted { .. }
             | CollaborativeSettlementRejected

--- a/daemon/src/monitor.rs
+++ b/daemon/src/monitor.rs
@@ -230,19 +230,6 @@ impl Cfd {
                     ..self
                 }
             }
-            ContractSetupStarted | ContractSetupFailed | OfferRejected | RolloverRejected => Self {
-                monitor_lock_finality: None,
-                monitor_commit_finality: None,
-                monitor_cet_timelock: false,
-                monitor_refund_timelock: false,
-                monitor_refund_finality: None,
-                monitor_revoked_commit_transactions: Vec::new(),
-                monitor_collaborative_settlement_finality: None,
-                lock_tx: None,
-                cet: None,
-                commit_tx: None,
-                ..self
-            },
             LockConfirmed | LockConfirmedAfterFinality => Self {
                 monitor_lock_finality: None,
                 lock_tx: None,
@@ -297,7 +284,11 @@ impl Cfd {
             | CollaborativeSettlementStarted { .. }
             | CollaborativeSettlementRejected
             | CollaborativeSettlementFailed
-            | CollaborativeSettlementProposalAccepted => self,
+            | CollaborativeSettlementProposalAccepted
+            | ContractSetupStarted
+            | ContractSetupFailed
+            | OfferRejected
+            | RolloverRejected => self,
             RevokeConfirmed => {
                 // TODO: Implement revoked logic
                 self


### PR DESCRIPTION
Fixes https://github.com/itchysats/itchysats/issues/3028.

When we worked on https://github.com/itchysats/itchysats/commit/b4225d5d35e27caef749d5c8ebf4e0f28c55d649 we inadvertently introduced a bug[1]. The gist of it is that, after a restart following a commit transaction being confirmed, we were not monitoring for the CET and refund timelocks anymore. This means that such a CFD would be stuck.

To fix it we have separated the transaction data that becomes available as events are processed from the logic of whether a
transaction (or a timelock) should be monitored or not. The data should always be remembered, and only the flags that control the monitoring logic should change as new events are processed.

[1]: https://github.com/itchysats/itchysats/issues/3028.