### PR TITLE
feature(environment): support string

### DIFF
--- a/crates/daemon-tests/src/lib.rs
+++ b/crates/daemon-tests/src/lib.rs
@@ -906,7 +906,7 @@ impl Taker {
             projection_actor,
             maker_identity,
             maker_multiaddr.clone(),
-            Environment::Test,
+            Environment::new("test"),
         )
         .unwrap();
 

--- a/crates/daemon/src/identify.rs
+++ b/crates/daemon/src/identify.rs
@@ -65,14 +65,14 @@ mod tests {
     async fn both_parties_request_identify_info_on_connection_established() {
         let (maker_peer_id, maker_endpoint, maker_receiver) = create_endpoint_with_identify(
             "0.4.22".to_string(),
-            Environment::Unknown,
+            Environment::unknown(),
             Keypair::generate_ed25519().public(),
             HashSet::new(),
             HashSet::from(["some_maker_protocol".to_string()]),
         );
         let (_, taker_endpoint, taker_receiver) = create_endpoint_with_identify(
             "0.4.22".to_string(),
-            Environment::Umbrel,
+            Environment::new("umbrel"),
             Keypair::generate_ed25519().public(),
             HashSet::new(),
             HashSet::from(["some_taker_protocol".to_string()]),
@@ -101,14 +101,14 @@ mod tests {
         let expected_maker_peer_info = PeerInfo {
             wire_version: "0.3.0".to_string(),
             daemon_version: "0.4.22".to_string(),
-            environment: Environment::Unknown,
+            environment: Environment::unknown(),
             protocols: HashSet::from(["some_maker_protocol".to_string()]),
         };
 
         let expected_taker_peer_info = PeerInfo {
             wire_version: "0.3.0".to_string(),
             daemon_version: "0.4.22".to_string(),
-            environment: Environment::Umbrel,
+            environment: Environment::new("umbrel"),
             protocols: HashSet::from(["some_taker_protocol".to_string()]),
         };
 

--- a/crates/daemon/src/identify/dialer.rs
+++ b/crates/daemon/src/identify/dialer.rs
@@ -75,7 +75,7 @@ impl Actor {
 
         let wire_version = peer_info.wire_version.clone();
         let daemon_version = peer_info.daemon_version.clone();
-        let environment = peer_info.environment;
+        let environment = peer_info.environment.clone();
 
         tracing::info!(
             %peer_id,

--- a/crates/daemon/src/identify/listener.rs
+++ b/crates/daemon/src/identify/listener.rs
@@ -44,7 +44,7 @@ impl Actor {
         //  connection
         let identify_msg = protocol::IdentifyMsg::new(
             self.daemon_version.clone(),
-            self.environment.into(),
+            self.environment.clone().into(),
             self.identity.clone(),
             self.listen_addrs.clone(),
             Multiaddr::empty(),

--- a/crates/maker/src/actor_system.rs
+++ b/crates/maker/src/actor_system.rs
@@ -284,7 +284,7 @@ where
             move || {
                 identify::listener::Actor::new(
                     daemon::version(),
-                    Environment::Unknown,
+                    Environment::unknown(),
                     identity.public(),
                     HashSet::from([listen_multiaddr.clone()]),
                     MAKER_LISTEN_PROTOCOLS.into(),

--- a/crates/taker/src/lib.rs
+++ b/crates/taker/src/lib.rs
@@ -423,8 +423,8 @@ pub async fn run(opts: Opts) -> Result<()> {
     };
 
     let environment = match env::var("ITCHYSATS_ENV") {
-        Ok(environment) => Environment::from_str_or_unknown(environment.as_str()),
-        Err(_) => Environment::Binary,
+        Ok(environment) => Environment::new(environment.as_str()),
+        Err(_) => Environment::new("binary"),
     };
 
     let (supervisor, price_feed_actor) =


### PR DESCRIPTION
We can run on all kinds of environment, hence Environment should just be a wrapper around string. However, for backwards compatibility with <=0.6.x we need to support certain formats: `Docker`, `Umbrel`, `RaspiBlitz`, `Unknown`. For all other we format the string to lowercase.

Resolves #3008
Resolves #2969

Let me know what you think.