### PR TITLE
chore: Add missing clippy job to bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -20,6 +20,7 @@ status = [
   "clippy (xtra-libp2p-offer)",
   "clippy (quiet-spans)",
   "clippy (xtra-libp2p-rollover)",
+  "clippy (taker-electron)",
   "lint-commits",
   "frontend (maker)",
   "frontend (taker)",


### PR DESCRIPTION
Unfortunately we still need to manually update this whenever there's a new crate
in the workspace.