### PR TITLE
feat(electron): pick random port

### DIFF
--- a/taker-electron/src/lib.rs
+++ b/taker-electron/src/lib.rs
@@ -24,6 +24,7 @@ pub fn start(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
     let network = cx.argument::<JsString>(0)?.value(&mut cx);
     let data_dir = cx.argument::<JsString>(1)?.value(&mut cx);
+    let port = cx.argument::<JsNumber>(2)?.value(&mut cx) as u16;
 
     // Spawn an `async` task on the tokio runtime. Only Rust types that are
     // `Send` may be moved into this block. `Context` may not be passed and all
@@ -32,7 +33,7 @@ pub fn start(mut cx: FunctionContext) -> JsResult<JsPromise> {
     // This task will _not_ block the JavaScript main thread.
     rt.spawn(async move {
         // Inside this block, it is possible to `await` Rust `Future`
-        let opts = Opts::new(network, data_dir).expect("valid options");
+        let opts = Opts::new(network, data_dir, port).expect("valid options");
         let result = taker::run(opts).await;
 
         // Settle the promise from the result of a closure. JavaScript exceptions

--- a/taker/src/lib.rs
+++ b/taker/src/lib.rs
@@ -182,7 +182,7 @@ impl Opts {
     }
 
     // use this method to construct the options from parameters.
-    pub fn new(network: String, data_dir: String) -> Result<Self> {
+    pub fn new(network: String, data_dir: String, port: u16) -> Result<Self> {
         let network = PublicNetwork::from_str(&network)?;
 
         let maker = Self::maker_url(&network);
@@ -193,7 +193,7 @@ impl Opts {
             maker: Some(maker),
             maker_id: Some(maker_id),
             maker_peer_id: Some(maker_peer_id),
-            http_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8000),
+            http_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port),
             data_dir: Some(PathBuf::from(data_dir)),
             json: false,
             json_span_list: false,


### PR DESCRIPTION
resolves #2992

Using [get-port](https://github.com/sindresorhus/get-port) would have been nicer, but the library is built ESM only and can not be used from our CommonJS project. Hence I followed the title of the ticket and simply picked a random port between 10000 and 65535.