### PR TITLE
Revert "Electron builder is unable to add to add to an existing release"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,17 +19,14 @@ jobs:
             package_arg: --mac --arm64
             arch: arm64
             target: aarch64-apple-darwin
-            name: ItchySats-0.7.0-arm64.dmg
           - os: macos-latest
             package_arg: --mac
             target: x86_64-apple-darwin
             arch: x64
-            name: ItchySats-0.7.0.dmg
           - os: windows-latest
             package_arg: --win --x64
             target: x86_64-pc-windows-msvc
             arch: x64
-            name: ItchySats-Setup-0.7.0.exe
     defaults:
       run:
         working-directory: "taker-electron"
@@ -117,13 +114,4 @@ jobs:
           # This is used for uploading release assets to github
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          yarn electron-builder -- --publish never ${{matrix.package_arg}}
-
-      - name: Upload archive
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.ITCHY_GITHUB_TOKEN }}
-        with:
-          upload_url: https://uploads.github.com/repos/itchysats/itchysats/releases/78657732/assets{?name,label}
-          asset_path: ./release/build/${{matrix.name}}
-          asset_name: ${{matrix.name}}
+          yarn electron-builder -- --publish always ${{matrix.package_arg}}


### PR DESCRIPTION
Reverts itchysats/itchysats#3075

@bonomat pointed out that setting `EP_GH_IGNORE_TIME` on the job should solve the issue of the artifact upload getting skipped. Reverting.