### PR TITLE
Enforce electron-builder to publish artifacts

### DIFF
--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -197,5 +197,7 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           # This is used for uploading release assets to github
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Enforce that electron-builder does not skip publication if the release was created more than two hours ago
+          EP_GH_IGNORE_TIME: true
         run: |
           yarn electron-builder -- --publish always ${{matrix.package_arg}}


### PR DESCRIPTION
By default, `electron-builder` prevents creating (or updating) a release that was created more than two hours ago. This enables us to publish artifacts when a release is more than two hours old.