### PR TITLE
chore: dependabot is spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,15 +24,3 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-
-  - package-ecosystem: "npm"
-    directory: "/maker-frontend"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "npm"
-    directory: "/crates/taker-electron"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
We don't have to stay up-2-date for all dependencies at all time. Dependabot will give us security alerts no matter what open-pull-requests-limit says, hence, I changed it to 1 update per week.