### PR TITLE
Fix build release binary workflow

### DIFF
--- a/.github/actions/build-release-binary/action.yml
+++ b/.github/actions/build-release-binary/action.yml
@@ -22,6 +22,11 @@ runs:
       with:
         key: ${{ inputs.target }}
 
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Install compiler for aarch64 arch (armv8)
       shell: bash
       if: inputs.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
`protoc` is not bundled anymore; we fixed other CI jobs but missed this one.

This prevents us from creating Docker images of latest master.

the job was failing for a while now: https://github.com/itchysats/itchysats/actions/workflows/docker-push-master.yml