### PR TITLE
fix(oracle): Use a timeout for all GET requests from Olivia

### DIFF
--- a/crates/daemon/src/oracle.rs
+++ b/crates/daemon/src/oracle.rs
@@ -154,7 +154,10 @@ impl Actor {
             pending_attestations: HashSet::new(),
             executor,
             db,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(REQWEST_TIMEOUT)
+                .build()
+                .expect("to build from static arguments"),
         }
     }
 
@@ -237,7 +240,6 @@ impl Actor {
 
                     let response = client
                         .get(url.clone())
-                        .timeout(REQWEST_TIMEOUT)
                         .send()
                         .await
                         .with_context(|| format!("Failed to GET {url}"))?;


### PR DESCRIPTION
Globally configured request timeout avoids needing to worry about timeouts
whenever we use `client.get()`.
In this example, timeout was applied when fetching pending attestations, but was
missing for announcements.