### PR TITLE
fix: taker-electron window width was too small

### DIFF
--- a/crates/taker-electron/src/main/main.ts
+++ b/crates/taker-electron/src/main/main.ts
@@ -56,7 +56,7 @@ const createWindow = async (endpoint: Endpoint) => {
 
     mainWindow = new BrowserWindow({
         show: false,
-        width: 1024,
+        width: 1124,
         height: 728,
         icon: getAssetPath("icon.png"),
         webPreferences: {


### PR DESCRIPTION
Before

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/224613/194785946-864367f8-050a-476e-acc2-5a130e88756a.png">


After

<img width="1187" alt="image" src="https://user-images.githubusercontent.com/224613/194785924-335d445a-2050-403c-8b4f-88e21b819ab7.png">
