### PR TITLE
fix: Prefer `ItchySats` to `Itchy Sats`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Itchy Sats
+# ItchySats
 
 [![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/39253)
 

--- a/taker-frontend/index.html
+++ b/taker-frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/src/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Itchy Sats</title>
+    <title>ItchySats</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
We want to be consistent with the spelling of the app name