### PR TITLE
chore: Add convenience script that builds latest versions of the frontends

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Note: Before first run, you need to install all dependencies
 
 - Protocol buffers compiler e.g. `brew install protobuf` // see https://docs.rs/prost-build/latest/prost_build/#sourcing-protoc for more details.
 - CMake e.g. `brew install cmake`
-- Maker and taker frontend `cd maker-frontend; yarn install; cd../taker-frontend; yarn install`
 
 The script combines the logs from all binaries inside a single terminal so it
 might not be ideal for all cases, but it is convenient for quick regression testing.
@@ -121,20 +120,8 @@ Embedded frontend is served on ports `8000` and `8001` by default.
 
 This means that it is highly recommended to build the frontend _before_ the daemons.
 
-##### Taker
-
 ```bash
-cd taker-frontend
-yarn install
-yarn build
-```
-
-##### Maker
-
-```bash
-cd maker-frontend
-yarn install
-yarn build
+./build_frontends.sh
 ```
 
 #### Developing frontend code

--- a/build_frontends.sh
+++ b/build_frontends.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Install latest dependencies and build both maker and taker frontends"
+
+cd maker-frontend
+yarn install
+yarn build
+cd ..
+cd taker-frontend
+yarn install
+yarn build
+cd ..
+echo "Maker and taker frontends built successfully"


### PR DESCRIPTION
Refer in the docs to the convenience script