### PR TITLE
feat(taker): import seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Electron App has now a tray icon for macOS 🚀
+- Split identity and wallet seed into two separate files.
+- Wallet seeds created by ItchySats can now be imported and exported for the taker.
 
 ## [0.7.0] - 2022-09-30
 

--- a/crates/daemon-tests/src/mocks/wallet.rs
+++ b/crates/daemon-tests/src/mocks/wallet.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use bdk_ext::new_test_wallet;
+use daemon::bdk;
 use daemon::bdk::bitcoin::util::psbt::PartiallySignedTransaction;
 use daemon::bdk::bitcoin::Amount;
 use daemon::bdk::bitcoin::Txid;
@@ -52,6 +53,9 @@ impl WalletActor {
     async fn handle(&mut self, msg: wallet::Sync) {
         self.mock.lock().await.sync(msg)
     }
+    async fn handle(&mut self, msg: wallet::ImportSeed) -> Result<bdk::wallet::AddressInfo> {
+        self.mock.lock().await.import_seed(msg)
+    }
 }
 
 #[automock]
@@ -69,6 +73,10 @@ pub trait Wallet {
     }
 
     fn sync(&mut self, _msg: wallet::Sync) {
+        unreachable!("mockall will reimplement this method")
+    }
+
+    fn import_seed(&mut self, _msg: wallet::ImportSeed) -> Result<bdk::wallet::AddressInfo> {
         unreachable!("mockall will reimplement this method")
     }
 }

--- a/crates/daemon-tests/tests/main/import_seed.rs
+++ b/crates/daemon-tests/tests/main/import_seed.rs
@@ -1,0 +1,42 @@
+use daemon::bdk::bitcoin;
+use daemon::seed;
+use daemon::seed::RandomSeed;
+use daemon::seed::Seed;
+use daemon_tests::open_cfd;
+use daemon_tests::start_both;
+use daemon_tests::OpenCfdArgs;
+use otel_tests::otel_test;
+use rand::distributions::Alphanumeric;
+use rand::thread_rng;
+use rand::Rng;
+use std::env;
+use std::path::Path;
+
+#[otel_test]
+async fn fail_to_import_seed_with_open_cfds() {
+    let (mut maker, mut taker) = start_both().await;
+
+    let cfd_args = OpenCfdArgs::default();
+    open_cfd(&mut taker, &mut maker, cfd_args.clone()).await;
+
+    let random_dir: String = thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(7)
+        .map(char::from)
+        .collect();
+    let data_dir = env::temp_dir().join(Path::new(&random_dir));
+    tokio::fs::create_dir_all(&data_dir)
+        .await
+        .expect("failed to create random temp folder");
+
+    taker
+        .system
+        .import_seed(
+            RandomSeed::default().seed(),
+            data_dir,
+            bitcoin::Network::Testnet,
+            seed::TAKER_WALLET_SEED_FILE,
+        )
+        .await
+        .expect_err("import seed should be rejected as open CFDs exist");
+}

--- a/crates/daemon-tests/tests/main/main.rs
+++ b/crates/daemon-tests/tests/main/main.rs
@@ -1,5 +1,6 @@
 mod collaborative_settlement;
 mod connectivity;
+mod import_seed;
 mod liquidation;
 mod non_collaborative_settlement;
 mod offer;

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -456,6 +456,7 @@ pub struct WalletInfo {
     pub address: Address,
     pub last_updated_at: Timestamp,
     pub transactions: Vec<TransactionDetails>,
+    pub managed_wallet: bool,
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -484,6 +485,12 @@ impl Timestamp {
     pub fn seconds_u64(&self) -> Result<u64> {
         let out = self.0.try_into().context("Unable to convert i64 to u64")?;
         Ok(out)
+    }
+}
+
+impl fmt::Display for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/crates/shared-bin/src/to_sse_event.rs
+++ b/crates/shared-bin/src/to_sse_event.rs
@@ -29,6 +29,7 @@ pub struct WalletInfo {
     address: String,
     last_updated_at: Timestamp,
     transactions: Vec<TransactionDetails>,
+    managed_wallet: bool,
 }
 
 #[derive(Serialize, Debug, Clone, PartialEq, Eq, Default)]
@@ -75,6 +76,7 @@ impl ToSseEvent for Option<model::WalletInfo> {
                 address: wallet_info.address.to_string(),
                 last_updated_at: wallet_info.last_updated_at,
                 transactions: transaction_details,
+                managed_wallet: wallet_info.managed_wallet,
             }
         });
 

--- a/taker-frontend/src/App.tsx
+++ b/taker-frontend/src/App.tsx
@@ -287,7 +287,7 @@ export const App = () => {
             >
                 <Route
                     path="/wallet"
-                    element={<Wallet walletInfo={walletInfo} />}
+                    element={<Wallet walletInfo={walletInfo} cfds={cfds.length > 0} />}
                 />
                 <Route
                     element={

--- a/taker-frontend/src/LoginPage.tsx
+++ b/taker-frontend/src/LoginPage.tsx
@@ -28,7 +28,6 @@ export default function Login() {
     const handleClick = () => setShow(!show);
     const [password, setPassword] = useState("");
 
-    console.log(localStorage.getItem("oldUser"));
     function handleSubmit(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
         login(password);

--- a/taker-frontend/src/components/Trade.tsx
+++ b/taker-frontend/src/components/Trade.tsx
@@ -156,7 +156,7 @@ export default function Trade({
 
     return (
         <VStack>
-            ?<Center>
+            <Center>
                 <Grid
                     templateRows="repeat(1, 1fr)"
                     templateColumns="repeat(1, 1fr)"

--- a/taker-frontend/src/types.ts
+++ b/taker-frontend/src/types.ts
@@ -11,6 +11,7 @@ export interface WalletInfo {
     address: string;
     last_updated_at: number;
     transactions: Transaction[];
+    managed_wallet: boolean;
 }
 
 export interface Transaction {


### PR DESCRIPTION
- allows to import a seed from a file.
- only supports a 256 bytes seed file - umbrel seeds are actively rejected.
- splits the identity from the wallet seed for taker and maker.
- extended the wallet info event for a managed_wallet flag, indicating if the seed was externally provided or generated by ItchySats.
- creates an backup file of the old seed file before overwriting it with the imported one.

![import-seed](https://user-images.githubusercontent.com/382048/195764624-a3cc825c-6d15-42d5-8260-d35de92a88a5.gif)

resolves #2989 

see also https://github.com/itchysats/itchysats/discussions/3048


