### PR TITLE
Fix the memory growth

### DIFF
--- a/crates/btsieve/src/lib.rs
+++ b/crates/btsieve/src/lib.rs
@@ -55,7 +55,7 @@ where
     pub fn update(
         &mut self,
         latest_block_height: BlockHeight,
-        status_list_batch: Vec<Vec<TxStatus>>,
+        status_list: Vec<TxStatus>,
     ) -> Vec<E> {
         let txid_to_script = self
             .awaiting_status
@@ -64,20 +64,16 @@ where
             .collect::<HashMap<_, _>>();
 
         let mut status_map = HashMap::new();
-        for status_list in status_list_batch {
-            for status in status_list {
-                let txid = status.tx_hash;
-                let script = match txid_to_script.get(&txid) {
-                    None => {
-                        tracing::trace!(
-                            "Could not find script in own state for txid {txid}, ignoring"
-                        );
-                        continue;
-                    }
-                    Some(script) => script,
-                };
-                status_map.insert((txid, script.clone()), status);
-            }
+        for status in status_list {
+            let txid = status.tx_hash;
+            let script = match txid_to_script.get(&txid) {
+                None => {
+                    tracing::trace!("Could not find script in own state for txid {txid}, ignoring");
+                    continue;
+                }
+                Some(script) => script,
+            };
+            status_map.insert((txid, script.clone()), status);
         }
 
         if latest_block_height > self.latest_block_height {

--- a/crates/btsieve/src/lib.rs
+++ b/crates/btsieve/src/lib.rs
@@ -292,20 +292,20 @@ mod tests {
 
         let ready_events = state.update(
             BlockHeight(10),
-            vec![vec![TxStatus {
+            vec![TxStatus {
                 height: 5,
                 tx_hash: txid1(),
-            }]],
+            }],
         );
 
         assert_eq!(ready_events, vec![foo_finality]);
 
         let ready_events = state.update(
             BlockHeight(20),
-            vec![vec![TxStatus {
+            vec![TxStatus {
                 height: 5,
                 tx_hash: txid1(),
-            }]],
+            }],
         );
 
         assert_eq!(ready_events, vec![baz_expired]);
@@ -335,10 +335,10 @@ mod tests {
 
         let ready_events = state.update(
             BlockHeight(0),
-            vec![vec![TxStatus {
+            vec![TxStatus {
                 height: 5,
                 tx_hash: txid1(),
-            }]],
+            }],
         );
 
         assert_eq!(ready_events, vec![bar_finality]);
@@ -361,10 +361,10 @@ mod tests {
 
         let ready_events = state.update(
             BlockHeight(0),
-            vec![vec![TxStatus {
+            vec![TxStatus {
                 height: 5,
                 tx_hash: txid1(),
-            }]],
+            }],
         );
 
         assert_eq!(ready_events, vec![foo_finality]);

--- a/crates/daemon/src/monitor.rs
+++ b/crates/daemon/src/monitor.rs
@@ -40,6 +40,13 @@ const CET_FINALITY_CONFIRMATIONS: u32 = 3;
 const REFUND_FINALITY_CONFIRMATIONS: u32 = 3;
 const BATCH_SIZE: usize = 25;
 
+/// Electrum client timeout in seconds
+///
+/// This timeout is used when establishing the connection and for all requests of the electrum
+/// client. We explicitly set the timeout because otherwise the underlying TCP connection timeout is
+/// used which is hard to be predicted.
+const ELECTRUM_CLIENT_TIMEOUT_SECS: u8 = 120;
+
 pub struct MonitorAfterContractSetup {
     order_id: OrderId,
     transactions: TransactionsAfterContractSetup,
@@ -333,8 +340,13 @@ impl Actor {
         electrum_rpc_url: String,
         executor: command::Executor,
     ) -> Result<Self> {
-        let client = bdk::electrum_client::Client::new(&electrum_rpc_url)
-            .context("Failed to initialize Electrum RPC client")?;
+        let client = bdk::electrum_client::Client::from_config(
+            &electrum_rpc_url,
+            electrum_client::ConfigBuilder::new()
+                .timeout(Some(ELECTRUM_CLIENT_TIMEOUT_SECS))?
+                .build(),
+        )
+        .context("Failed to initialize Electrum RPC client")?;
 
         // Initially fetch the latest block for storing the height.
         // We do not act on this subscription after this call.

--- a/crates/sqlite-db/src/lib.rs
+++ b/crates/sqlite-db/src/lib.rs
@@ -706,6 +706,8 @@ async fn load_cfd_events(
             if let Some((dlc, funding_fee, complete_fee)) =
                 rollover::load(&mut *conn, *cfd_row_id, *event_row_id).await?
             {
+                let dlc_id = dlc.commit.0.txid();
+                tracing::warn!("Attaching DLC {dlc_id} from event {event_row_id} to CFD {id}");
                 event.event = RolloverCompleted {
                     dlc: Some(dlc),
                     funding_fee,


### PR DESCRIPTION
This is an attempt to fix the memory growth caused by `rust-electrum-client`'s `batch_script_get_history` implementation. We chunk up the scripts to be checked into batches and call `script_get_history` for the batches in parallel in separate worker threads.

The results are communicated back using a channel, and are processed as they come; we don't have to rely on any order here.

---

The implementation should be complete and compiles, but there are still a few rough edges ;)
@klochowicz please run this with profiling so we can see if it has the expected behavior.

TODO:

- [x] Fix tests: The tests have to be adapted to cover the new behavior. 
- [x] Evaluate if the buffer size for the channel should be in relation to the batch size