### PR TITLE
Remember rollover state if maker fails to send revocation sk 

### DIFF
--- a/crates/daemon-tests/src/lib.rs
+++ b/crates/daemon-tests/src/lib.rs
@@ -14,6 +14,7 @@ use daemon::bdk::bitcoin::Network;
 use daemon::bdk::bitcoin::SignedAmount;
 use daemon::bdk::bitcoin::Txid;
 use daemon::libp2p_utils::create_connect_multiaddr;
+use daemon::maia_core::secp256k1_zkp::SecretKey;
 use daemon::maia_core::secp256k1_zkp::XOnlyPublicKey;
 use daemon::online_status::ConnectionStatus;
 use daemon::oracle::Attestation;
@@ -773,6 +774,19 @@ impl Maker {
             .await
             .unwrap();
     }
+
+    pub fn latest_revoked_revocation_sk_ours(&mut self) -> SecretKey {
+        self.first_cfd()
+            .aggregated()
+            .latest_dlc()
+            .as_ref()
+            .unwrap()
+            .revoked_commit
+            .first()
+            .unwrap()
+            .revocation_sk_ours
+            .unwrap()
+    }
 }
 
 /// Taker Test Setup
@@ -823,6 +837,18 @@ impl Taker {
             .as_ref()
             .unwrap()
             .settlement_event_id
+    }
+
+    pub fn latest_revoked_revocation_sk_theirs(&mut self) -> Option<SecretKey> {
+        self.first_cfd()
+            .aggregated()
+            .latest_dlc()
+            .as_ref()
+            .unwrap()
+            .revoked_commit
+            .first()
+            .unwrap()
+            .revocation_sk_theirs
     }
 
     pub fn latest_dlc(&mut self) -> Dlc {

--- a/crates/daemon-tests/src/rollover.rs
+++ b/crates/daemon-tests/src/rollover.rs
@@ -92,6 +92,12 @@ async fn do_rollover(
         taker.latest_settlement_event_id(),
         "Taker's latest event-id does not match given event-id after rollover"
     );
+
+    assert_eq!(
+        taker.latest_revoked_revocation_sk_theirs(),
+        Some(maker.latest_revoked_revocation_sk_ours()),
+        "Taker receives maker's revocation sk during rollover"
+    )
 }
 
 pub fn assert_rollover_fees(

--- a/crates/model/src/cfd.rs
+++ b/crates/model/src/cfd.rs
@@ -705,7 +705,9 @@ impl Cfd {
             return Err(CannotRollover::TooRecent);
         }
 
-        Ok((dlc.commit.0.txid(), dlc.settlement_event_id))
+        let revoked_commit_data = dlc.revoked_commit_data_for_rollover_taker();
+
+        Ok(revoked_commit_data)
     }
 
     fn can_rollover(&self) -> Result<(), CannotRollover> {
@@ -2372,7 +2374,7 @@ pub struct RevokedCommit {
     /// The maker uses this key for verification if a taker triggers a rollover from a previous
     /// commit-txid.
     pub revocation_sk_ours: Option<SecretKey>,
-    pub revocation_sk_theirs: SecretKey,
+    pub revocation_sk_theirs: Option<SecretKey>,
     pub publication_pk_theirs: PublicKey,
     // To monitor revoked commit transaction
     pub txid: Txid,

--- a/crates/model/src/rollover.rs
+++ b/crates/model/src/rollover.rs
@@ -117,9 +117,6 @@ impl Dlc {
     }
 
     /// Construct the `BaseDlcParams` based on the latest DLC.
-    ///
-    /// This is called if neither party has fallen behind in terms of
-    /// rollovers.
     pub fn base_dlc_params_from_latest(&self, complete_fee: CompleteFee) -> BaseDlcParams {
         BaseDlcParams {
             base_commit_params: BaseCommitParams {
@@ -139,8 +136,6 @@ impl Dlc {
     /// Construct the `BaseDlcParams` based on a revoked DLC. The
     /// commit TXID is used to identify the rollover from which both
     /// parties intend to start the new rollover.
-    ///
-    /// This is called if a party is behind in terms of rollovers.
     fn base_dlc_params_from_revoked_commit(
         &self,
         revoked_commit_txid: Txid,

--- a/crates/sqlite-db/migrations/20221017101900_allow_null_revocation_sk_theirs.sql
+++ b/crates/sqlite-db/migrations/20221017101900_allow_null_revocation_sk_theirs.sql
@@ -1,0 +1,45 @@
+CREATE TABLE revoked_commit_transactions_temp (
+    id integer PRIMARY KEY autoincrement,
+    cfd_id integer NOT NULL,
+    encsig_ours TEXT NOT NULL,
+    publication_pk_theirs TEXT NOT NULL,
+    revocation_sk_theirs TEXT NULL,
+    script_pubkey TEXT NOT NULL,
+    txid TEXT NOT NULL,
+    revocation_sk_ours text NULL,
+    complete_fee INTEGER NULL,
+    complete_fee_flow text NULL,
+    settlement_event_id text NULL,
+    FOREIGN KEY (cfd_id) REFERENCES cfds (id) ON DELETE CASCADE
+);
+INSERT INTO
+    revoked_commit_transactions_temp (
+        id,
+        cfd_id,
+        encsig_ours,
+        publication_pk_theirs,
+        revocation_sk_theirs,
+        script_pubkey,
+        txid,
+        revocation_sk_ours,
+        complete_fee,
+        complete_fee_flow,
+        settlement_event_id
+    )
+SELECT
+    id,
+    cfd_id,
+    encsig_ours,
+    publication_pk_theirs,
+    revocation_sk_theirs,
+    script_pubkey,
+    txid,
+    revocation_sk_ours,
+    complete_fee,
+    complete_fee_flow,
+    settlement_event_id
+FROM
+    revoked_commit_transactions;
+DROP TABLE revoked_commit_transactions;
+ALTER TABLE
+    revoked_commit_transactions_temp RENAME TO revoked_commit_transactions;

--- a/crates/sqlite-db/sqlx-data.json
+++ b/crates/sqlite-db/sqlx-data.json
@@ -216,7 +216,7 @@
       "nullable": [
         false,
         false,
-        false,
+        true,
         true,
         false,
         true,

--- a/crates/sqlite-db/src/rollover/load.rs
+++ b/crates/sqlite-db/src/rollover/load.rs
@@ -145,7 +145,9 @@ async fn load_revoked_commit_transactions(
             revocation_sk_ours: row
                 .revocation_sk_ours
                 .map(|revocation_sk_ours| revocation_sk_ours.into()),
-            revocation_sk_theirs: row.revocation_sk_theirs.into(),
+            revocation_sk_theirs: row
+                .revocation_sk_theirs
+                .map(|revocation_sk_theirs| revocation_sk_theirs.into()),
             publication_pk_theirs: row.publication_pk_theirs.into(),
             script_pubkey: Script::from_hex(row.script_pubkey.as_str())?,
             txid: row.txid.into(),

--- a/crates/sqlite-db/src/rollover/overwrite.rs
+++ b/crates/sqlite-db/src/rollover/overwrite.rs
@@ -169,7 +169,7 @@ async fn insert_revoked_commit_transaction(
     revoked: RevokedCommit,
 ) -> Result<()> {
     let revoked_tx_script_pubkey = revoked.script_pubkey.to_hex();
-    let revocation_sk_theirs = models::SecretKey::from(revoked.revocation_sk_theirs);
+    let revocation_sk_theirs = revoked.revocation_sk_theirs.map(models::SecretKey::from);
     let revocation_sk_ours = revoked.revocation_sk_ours.map(models::SecretKey::from);
     let publication_pk_theirs = models::PublicKey::from(revoked.publication_pk_theirs);
     let encsig_ours = models::AdaptorSignature::from(revoked.encsig_ours);

--- a/crates/xtra-libp2p-rollover/src/current/maker.rs
+++ b/crates/xtra-libp2p-rollover/src/current/maker.rs
@@ -350,7 +350,7 @@ where
 
                 let revocation_sk_theirs = msg2.revocation_sk;
                 let revoked_commits = base_dlc_params
-                    .revoke_base_commit_tx(revocation_sk_theirs)
+                    .revoke_base_commit_tx(Some(revocation_sk_theirs))
                     .context("Taker sent invalid revocation sk")?;
 
                 let dlc = Dlc {

--- a/crates/xtra-libp2p-rollover/src/deprecated/maker.rs
+++ b/crates/xtra-libp2p-rollover/src/deprecated/maker.rs
@@ -350,7 +350,7 @@ where
 
                 let revocation_sk_theirs = msg2.revocation_sk;
                 let revoked_commits = base_dlc_params
-                    .revoke_base_commit_tx(revocation_sk_theirs)
+                    .revoke_base_commit_tx(Some(revocation_sk_theirs))
                     .context("Taker sent invalid revocation sk")?;
 
                 let dlc = Dlc {

--- a/crates/xtra-libp2p-rollover/src/deprecated/taker.rs
+++ b/crates/xtra-libp2p-rollover/src/deprecated/taker.rs
@@ -3,10 +3,13 @@ use crate::deprecated::protocol::*;
 use anyhow::Context;
 use anyhow::Result;
 use async_trait::async_trait;
+use asynchronous_codec::Framed;
+use asynchronous_codec::JsonCodec;
 use bdk::bitcoin::Txid;
 use bdk_ext::keypair;
 use futures::SinkExt;
 use futures::StreamExt;
+use maia_core::secp256k1_zkp::SecretKey;
 use maia_core::secp256k1_zkp::XOnlyPublicKey;
 use model::libp2p::PeerId;
 use model::olivia::BitMexPriceEventId;
@@ -300,24 +303,21 @@ where
                                 .await
                                 .context("Failed to send Msg2")?;
 
-                            let msg2 = framed
-                                .next()
-                                .timeout(ROLLOVER_MSG_TIMEOUT, next_rollover_span)
-                                .await
-                                .with_context(|| {
-                                    format!(
-                                        "Expected Msg2 within {} seconds",
-                                        ROLLOVER_MSG_TIMEOUT.as_secs()
-                                    )
-                                })?
-                                .context("Empty stream instead of Msg2")?
-                                .context("Unable to decode listener Msg2")?
-                                .into_rollover_msg()?
-                                .try_into_msg2()?;
+                            let base_dlc_params =
+                                dlc.base_dlc_params_from_latest(complete_fee_before_rollover);
 
-                            let revocation_sk_theirs = msg2.revocation_sk;
-                            let revoked_commits = dlc
-                                .base_dlc_params_from_latest(complete_fee_before_rollover)
+                            let revocation_sk_theirs =
+                                match receive_maker_revocation_key(&mut framed).await {
+                                    Ok(revocation_sk_theirs) => Some(revocation_sk_theirs),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                        "Finalising rollover without maker's revocation key: {e:#}"
+                                    );
+                                        None
+                                    }
+                                };
+
+                            let revoked_commits = base_dlc_params
                                 .revoke_base_commit_tx(revocation_sk_theirs)
                                 .context("Maker sent invalid revocation sk")?;
 
@@ -365,4 +365,27 @@ where
             },
         );
     }
+}
+
+async fn receive_maker_revocation_key(
+    framed: &mut Framed<Substream, JsonCodec<DialerMessage, ListenerMessage>>,
+) -> Result<SecretKey> {
+    let msg2 = framed
+        .next()
+        .timeout(ROLLOVER_MSG_TIMEOUT, || {
+            tracing::debug_span!("next rollover message")
+        })
+        .await
+        .with_context(|| {
+            format!(
+                "Expected Msg2 within {} seconds",
+                ROLLOVER_MSG_TIMEOUT.as_secs()
+            )
+        })?
+        .context("Empty stream instead of Msg2")?
+        .context("Unable to decode listener Msg2")?
+        .into_rollover_msg()?
+        .try_into_msg2()?;
+
+    Ok(msg2.revocation_sk)
 }


### PR DESCRIPTION
Fixes https://github.com/itchysats/itchysats/issues/3019.

This ensures that the taker can _always_ safely non-collaboratively settle the CFD.

Before these changes, the taker could fall behind in the state of the DLC if the maker failed to send their revocation sk in the last step of the rollover protocol. The taker would throw away everything exchanged during that instance of the rollover protocol. This would mean that the maker would know how to punish the publication of the commit transaction the taker considered current.

With these changes, the taker remembers the incomplete rollover details, updating the state of the DLC so that they can safely publish their latest commit transaction if they want to. The taker also notes that the maker did not share their revocation sk. This allows the taker to still insist on rolling over from the previous, yet-to-be-revoked-by-the-maker commit transaction, like they have been doing since the introduction of the rollover retry mechanism with patch https://github.com/itchysats/itchysats/commit/e0e643e44d9fa5f03422f4430ffc860d86ef2de6.

TODOs:

- [ ] Add a test.
- [ ] Mention it in the changelog.