### PR TITLE
Revert "Self-implemented batching for `script_get_history`"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,6 @@ dependencies = [
  "tokio-extras",
  "tokio-util",
  "tracing",
- "tracing-subscriber",
  "uuid 1.1.2",
  "x25519-dalek",
  "xtra",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -60,4 +60,3 @@ xtras = { path = "../xtras" }
 [dev-dependencies]
 serde_test = "1"
 time = { version = "0.3.15", features = ["std"] }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
This reverts commit c020c985

fixes https://github.com/itchysats/itchysats/issues/3208

---

If we revert this our testnet setup should be stable again, at the moment testnet is basically broken because we fail to sync due to #3208  and it remains unclear why that happens.

We don't want to invest more time into this "fix" for now, because the memory problem was eventually "overcome" in a different way.

Note: I kept the metric to measuring how long the monitoring sync takes because it might be useful in the future.

Consequences: 

Closed https://github.com/itchysats/itchysats/pull/3222 because we don't know about side effects and we don't have to change this for now. If you think we should still merge https://github.com/itchysats/itchysats/pull/3222 please re-open. 

