### PR TITLE
Remove dependencies from bitmex stream lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitmex-stream"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,6 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-extras",
  "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",

--- a/crates/bitmex-stream/Cargo.toml
+++ b/crates/bitmex-stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitmex-stream"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A stable and simple connection to BitMex's websocket API."
 

--- a/crates/bitmex-stream/Cargo.toml
+++ b/crates/bitmex-stream/Cargo.toml
@@ -17,7 +17,6 @@ serde_json = "1"
 tokio = { version = "1", features = ["macros", "time", "tracing"] }
 tokio-tungstenite = { version = "0.15", features = ["rustls-tls"] }
 tracing = "0.1"
-url = "2.3.1"
 
 [dev-dependencies]
 anyhow = "1"

--- a/crates/bitmex-stream/Cargo.toml
+++ b/crates/bitmex-stream/Cargo.toml
@@ -15,7 +15,6 @@ ring = "0.16"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "time", "tracing"] }
-tokio-extras = { path = "../tokio-extras" }
 tokio-tungstenite = { version = "0.15", features = ["rustls-tls"] }
 tracing = "0.1"
 url = "2.3.1"

--- a/crates/bitmex-stream/src/lib.rs
+++ b/crates/bitmex-stream/src/lib.rs
@@ -83,7 +83,7 @@ fn subscribe_impl<const N: usize>(
 
         loop {
             tokio::select! {
-                _ = tokio_extras::time::sleep_silent(Duration::from_secs(5)) => {
+                _ = sleep(Duration::from_secs(5)) => {
                     let span = tracing::trace_span!("Ping BitMex");
                     span.in_scope(|| tracing::trace!("No message from BitMex in the last 5 seconds, pinging"));
                     let _ = connection
@@ -124,6 +124,11 @@ fn subscribe_impl<const N: usize>(
     };
 
     stream.boxed()
+}
+
+pub async fn sleep(duration: Duration) {
+    #[allow(clippy::disallowed_methods)]
+    tokio::time::sleep(duration).await
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Adding the itchysats bitmex-stream as dependency to 10101 resulted into the known dependency conflict of the normalization-unicode between url and bip39. I adapted the bitmex stream lib and refactored the code to not being dependent on the url crate anymore. This allows us to use it together with bip39 in 10101.

We might not want to merged that PR, but rather keep it until BIP39 upgrades their dependencies and we don't need that change anymore.