### PR TITLE
chore: Relax dependency constraints in `bitmex_stream`

### DIFF
--- a/crates/bitmex-stream/Cargo.toml
+++ b/crates/bitmex-stream/Cargo.toml
@@ -10,7 +10,7 @@ description = "A stable and simple connection to BitMex's websocket API."
 anyhow = "1"
 async-stream = "0.3"
 futures = "0.3"
-hex = "0.4.3"
+hex = "0.4"
 ring = "0.16"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -18,7 +18,7 @@ tokio = { version = "1", features = ["macros", "time", "tracing"] }
 tokio-extras = { path = "../tokio-extras" }
 tokio-tungstenite = { version = "0.15", features = ["rustls-tls"] }
 tracing = "0.1"
-url = "2.3.1"
+url = "2.3"
 
 [dev-dependencies]
 anyhow = "1"


### PR DESCRIPTION
Specifying exact patch releases is unnecessary, and it just makes it harder to
reuse this library in other projects.