### PR TITLE
Log `Failed to fetch attestation` as error

### DIFF
--- a/crates/daemon/src/oracle.rs
+++ b/crates/daemon/src/oracle.rs
@@ -262,8 +262,16 @@ impl Actor {
 
                     Ok(())
                 },
-                |e| async move {
-                    tracing::debug!("Failed to fetch attestation: {:#}", e);
+                move |e| async move {
+                    let now = OffsetDateTime::now_utc();
+
+                    // If the event is more than 10 minutes in the past we expect an attestation to
+                    // be available and log an error if we can't fetch it
+                    if now > event_id.timestamp() + Duration::minutes(10) {
+                        tracing::error!("Failed to fetch attestation for {event_id}: {e:#}");
+                    } else {
+                        tracing::debug!("Failed to fetch attestation for {event_id}: {e:#}");
+                    }
                 },
             )
         }


### PR DESCRIPTION
We only log it as error if the event timestamp is `10` minutes in the past to avoid false negative error reports when the oracle is slow to report the attestation.

The `event_id` is added to the log statement for more context.

---

I propose to merge this into `master` and then cherrypick this commit on a patch release on top of `0.7.0` to get it into production. Is there anything else we would like to see in a patch release?
I remember we wanted to release https://github.com/itchysats/itchysats/pull/3244 ?